### PR TITLE
PR 3.3 - Player Weekly Log API

### DIFF
--- a/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
+++ b/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
@@ -1,0 +1,350 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb, schema } from "@/db";
+import { eq, and, inArray, sql } from "drizzle-orm";
+
+/**
+ * GET /api/leagues/[familyId]/player/[playerId]/weekly-log
+ *
+ * Returns week-by-week data for a player across all seasons in a league family:
+ * - Which manager rostered them
+ * - Started or benched in fantasy
+ * - Lineup slot (WR, FLEX, SUPER_FLEX, etc.)
+ * - NFL roster status (ACT, RES, INA, etc.)
+ * - Fantasy points scored
+ *
+ * Query params:
+ *   ?season=2025          — filter to specific season
+ *   ?rosterId=3           — filter to specific roster/manager
+ *   ?starterOnly=true     — only show weeks where player was started
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { familyId: string; playerId: string } }
+) {
+  const db = getDb();
+  const { familyId, playerId } = params;
+  const searchParams = req.nextUrl.searchParams;
+  const seasonFilter = searchParams.get("season");
+  const rosterIdFilter = searchParams.get("rosterId");
+  const starterOnly = searchParams.get("starterOnly") === "true";
+
+  // --- Resolve family → league IDs ---
+  const isUuid =
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+      familyId
+    );
+
+  let resolvedFamilyId: string | null = null;
+  if (isUuid) {
+    const family = await db
+      .select()
+      .from(schema.leagueFamilies)
+      .where(eq(schema.leagueFamilies.id, familyId))
+      .limit(1);
+    if (family.length > 0) resolvedFamilyId = family[0].id;
+  }
+  if (!resolvedFamilyId) {
+    const family = await db
+      .select()
+      .from(schema.leagueFamilies)
+      .where(eq(schema.leagueFamilies.rootLeagueId, familyId))
+      .limit(1);
+    if (family.length > 0) resolvedFamilyId = family[0].id;
+  }
+  if (!resolvedFamilyId) {
+    return NextResponse.json({ error: "Not found" }, { status: 404 });
+  }
+
+  // Get all family members (leagueId + season)
+  const members = await db
+    .select()
+    .from(schema.leagueFamilyMembers)
+    .where(eq(schema.leagueFamilyMembers.familyId, resolvedFamilyId));
+
+  let filteredMembers = members;
+  if (seasonFilter) {
+    filteredMembers = members.filter((m) => m.season === seasonFilter);
+  }
+
+  const leagueIds = filteredMembers.map((m) => m.leagueId);
+  if (leagueIds.length === 0) {
+    return NextResponse.json({ weeks: [], player: null, managers: [] });
+  }
+
+  // Map leagueId → season
+  const leagueSeasonMap = new Map(
+    filteredMembers.map((m) => [m.leagueId, m.season])
+  );
+
+  // --- Load player info ---
+  const playerRows = await db
+    .select()
+    .from(schema.players)
+    .where(eq(schema.players.id, playerId))
+    .limit(1);
+
+  const player = playerRows.length > 0
+    ? {
+        id: playerRows[0].id,
+        name: playerRows[0].name,
+        position: playerRows[0].position,
+        team: playerRows[0].team,
+        gsisId: playerRows[0].gsisId,
+      }
+    : null;
+
+  // --- Load player_scores across all leagues ---
+  const scoreConditions = [
+    inArray(schema.playerScores.leagueId, leagueIds),
+    eq(schema.playerScores.playerId, playerId),
+  ];
+  if (rosterIdFilter) {
+    scoreConditions.push(
+      eq(schema.playerScores.rosterId, parseInt(rosterIdFilter, 10))
+    );
+  }
+  if (starterOnly) {
+    scoreConditions.push(eq(schema.playerScores.isStarter, true));
+  }
+
+  const scores = await db
+    .select()
+    .from(schema.playerScores)
+    .where(and(...scoreConditions))
+    .orderBy(
+      sql`${schema.playerScores.leagueId}`,
+      sql`${schema.playerScores.week}`
+    );
+
+  // --- Load roster_positions for each league (for slot derivation) ---
+  const leagueRows = await db
+    .select({
+      id: schema.leagues.id,
+      rosterPositions: schema.leagues.rosterPositions,
+    })
+    .from(schema.leagues)
+    .where(inArray(schema.leagues.id, leagueIds));
+
+  const leagueRosterPositions = new Map<string, string[]>(
+    leagueRows.map((l) => [l.id, (l.rosterPositions as string[]) || []])
+  );
+
+  // --- Load matchups for slot derivation ---
+  // We need the starters array for each (leagueId, week, rosterId)
+  // Build a set of keys we need
+  const matchupKeys = new Set(
+    scores.map((s) => `${s.leagueId}|${s.week}|${s.rosterId}`)
+  );
+
+  const matchupRows = await db
+    .select({
+      leagueId: schema.matchups.leagueId,
+      week: schema.matchups.week,
+      rosterId: schema.matchups.rosterId,
+      starters: schema.matchups.starters,
+    })
+    .from(schema.matchups)
+    .where(inArray(schema.matchups.leagueId, leagueIds));
+
+  // Index matchups by key
+  const matchupMap = new Map<string, string[]>();
+  for (const m of matchupRows) {
+    const key = `${m.leagueId}|${m.week}|${m.rosterId}`;
+    if (matchupKeys.has(key)) {
+      matchupMap.set(key, (m.starters as string[]) || []);
+    }
+  }
+
+  // --- Load roster → owner mapping + user display names ---
+  const rosterRows = await db
+    .select()
+    .from(schema.rosters)
+    .where(inArray(schema.rosters.leagueId, leagueIds));
+
+  const userRows = await db
+    .select()
+    .from(schema.leagueUsers)
+    .where(inArray(schema.leagueUsers.leagueId, leagueIds));
+
+  // leagueId → userId → displayName
+  const userNameMap = new Map<string, string>();
+  for (const u of userRows) {
+    userNameMap.set(`${u.leagueId}|${u.userId}`, u.displayName || u.userId);
+  }
+
+  // leagueId → rosterId → { ownerId, displayName }
+  const rosterOwnerMap = new Map<string, { ownerId: string; displayName: string }>();
+  for (const r of rosterRows) {
+    if (r.ownerId) {
+      const displayName =
+        userNameMap.get(`${r.leagueId}|${r.ownerId}`) || r.ownerId;
+      rosterOwnerMap.set(`${r.leagueId}|${r.rosterId}`, {
+        ownerId: r.ownerId,
+        displayName,
+      });
+    }
+  }
+
+  // --- Load NFL roster status (if player has gsisId) ---
+  const nflStatusMap = new Map<string, { status: string; statusAbbr: string | null; team: string | null }>();
+  if (player?.gsisId) {
+    const nflRows = await db
+      .select()
+      .from(schema.nflWeeklyRosterStatus)
+      .where(eq(schema.nflWeeklyRosterStatus.gsisId, player.gsisId));
+
+    for (const row of nflRows) {
+      nflStatusMap.set(`${row.season}|${row.week}`, {
+        status: row.status,
+        statusAbbr: row.statusAbbr,
+        team: row.team,
+      });
+    }
+  }
+
+  // --- Build bye week map from nfl_schedule ---
+  // For each (season, team), find weeks where team has no game
+  const relevantSeasons = [...new Set(members.map((m) => parseInt(m.season, 10)))].filter((n) => !isNaN(n));
+  const byeWeekMap = new Map<string, Set<number>>(); // "season|team" → bye week numbers
+
+  if (relevantSeasons.length > 0) {
+    const scheduleRows = await db
+      .select()
+      .from(schema.nflSchedule)
+      .where(inArray(schema.nflSchedule.season, relevantSeasons));
+
+    // Group schedule by season
+    const schedBySeason = new Map<number, typeof scheduleRows>();
+    for (const row of scheduleRows) {
+      const arr = schedBySeason.get(row.season) || [];
+      arr.push(row);
+      schedBySeason.set(row.season, arr);
+    }
+
+    for (const season of relevantSeasons) {
+      const games = schedBySeason.get(season) || [];
+      if (games.length === 0) continue;
+
+      // All weeks in this season's schedule
+      const allWeeks = new Set(games.map((g) => g.week));
+      // Teams playing each week
+      const teamWeeks = new Map<string, Set<number>>();
+      for (const g of games) {
+        if (!teamWeeks.has(g.homeTeam)) teamWeeks.set(g.homeTeam, new Set());
+        if (!teamWeeks.has(g.awayTeam)) teamWeeks.set(g.awayTeam, new Set());
+        teamWeeks.get(g.homeTeam)!.add(g.week);
+        teamWeeks.get(g.awayTeam)!.add(g.week);
+      }
+
+      for (const [team, weeks] of teamWeeks) {
+        const byes = new Set<number>();
+        for (const week of allWeeks) {
+          if (!weeks.has(week)) byes.add(week);
+        }
+        if (byes.size > 0) {
+          byeWeekMap.set(`${season}|${team}`, byes);
+        }
+      }
+    }
+  }
+
+  // --- Assemble weekly log ---
+  const weeks = scores.map((s) => {
+    const season = leagueSeasonMap.get(s.leagueId) || "";
+    const seasonNum = parseInt(season, 10);
+
+    // Lineup slot derivation
+    const matchupKey = `${s.leagueId}|${s.week}|${s.rosterId}`;
+    const starters = matchupMap.get(matchupKey) || [];
+    const rosterPositions = leagueRosterPositions.get(s.leagueId) || [];
+    let lineupSlot: string | null = null;
+    if (s.isStarter) {
+      const starterIdx = starters.indexOf(playerId);
+      if (starterIdx >= 0 && starterIdx < rosterPositions.length) {
+        lineupSlot = rosterPositions[starterIdx];
+      }
+    }
+
+    // Manager info
+    const ownerKey = `${s.leagueId}|${s.rosterId}`;
+    const owner = rosterOwnerMap.get(ownerKey);
+
+    // NFL status
+    const nflKey = `${seasonNum}|${s.week}`;
+    const nflStatus = nflStatusMap.get(nflKey);
+
+    // Bye week detection: use team from roster status for this week,
+    // or infer from nearest adjacent week (handles traded players + bye weeks where no roster row exists)
+    let isByeWeek = false;
+    if (player?.gsisId && !nflStatus) {
+      // No roster status row — could be bye week or missing data
+      // Infer team from nearest adjacent week's roster status
+      let inferredTeam: string | null = null;
+      for (let delta = 1; delta <= 18; delta++) {
+        const before = nflStatusMap.get(`${seasonNum}|${s.week - delta}`);
+        if (before?.team) { inferredTeam = before.team; break; }
+        const after = nflStatusMap.get(`${seasonNum}|${s.week + delta}`);
+        if (after?.team) { inferredTeam = after.team; break; }
+      }
+      if (inferredTeam) {
+        const teamByes = byeWeekMap.get(`${seasonNum}|${inferredTeam}`);
+        if (teamByes?.has(s.week)) isByeWeek = true;
+      }
+    } else if (nflStatus?.team) {
+      // Has roster status — check if this week is a bye for that team
+      // (shouldn't happen since bye = no roster row, but defensive)
+      const teamByes = byeWeekMap.get(`${seasonNum}|${nflStatus.team}`);
+      if (teamByes?.has(s.week)) isByeWeek = true;
+    } else if (!player?.gsisId && player?.team) {
+      // Fallback: no gsis_id at all — use player's current team from Sleeper
+      // Won't handle mid-season trades, but better than no bye detection
+      const teamByes = byeWeekMap.get(`${seasonNum}|${player.team}`);
+      if (teamByes?.has(s.week)) isByeWeek = true;
+    }
+
+    return {
+      season,
+      week: s.week,
+      leagueId: s.leagueId,
+      manager: owner
+        ? { userId: owner.ownerId, displayName: owner.displayName, rosterId: s.rosterId }
+        : null,
+      fantasyStatus: s.isStarter ? "starter" : "bench",
+      lineupSlot,
+      points: s.points || 0,
+      nflStatus: nflStatus?.status || null,
+      nflStatusAbbr: nflStatus?.statusAbbr || null,
+      isByeWeek,
+    };
+  });
+
+  // Sort by season desc, week asc
+  weeks.sort((a, b) => {
+    const seasonDiff = parseInt(b.season, 10) - parseInt(a.season, 10);
+    if (seasonDiff !== 0) return seasonDiff;
+    return a.week - b.week;
+  });
+
+  // --- Build unique managers list for filter UI ---
+  const managersMap = new Map<string, { userId: string; displayName: string }>();
+  for (const w of weeks) {
+    if (w.manager && !managersMap.has(w.manager.userId)) {
+      managersMap.set(w.manager.userId, {
+        userId: w.manager.userId,
+        displayName: w.manager.displayName,
+      });
+    }
+  }
+
+  // --- Build available seasons for filter UI ---
+  const availableSeasons = [
+    ...new Set(members.map((m) => m.season)),
+  ].sort((a, b) => parseInt(b, 10) - parseInt(a, 10));
+
+  return NextResponse.json({
+    player,
+    weeks,
+    managers: Array.from(managersMap.values()),
+    availableSeasons,
+  });
+}


### PR DESCRIPTION
## Summary
- Adds comprehensive weekly log API endpoint (`/api/leagues/[familyId]/player/[playerId]/weekly-log`)
- Provides week-by-week player data across all seasons in a league family
- Includes intelligent bye week detection using NFL schedule data

## Features
- **Manager tracking**: Shows which manager rostered the player each week
- **Fantasy status**: Indicates if player was started or benched
- **Lineup slots**: Shows specific lineup slot (WR, FLEX, SUPER_FLEX, etc.)
- **NFL status**: Displays NFL roster status (ACT, RES, INA, etc.)
- **Points**: Fantasy points scored per week
- **Bye week detection**: 
  - Derives bye weeks from `nfl_schedule` table
  - Handles players with no roster status row during bye weeks
  - Supports mid-season team trades by inferring team from adjacent weeks
  - Fallback to Sleeper team data when `gsis_id` is unavailable

## Query Parameters
- `season` - Filter to specific season
- `rosterId` - Filter to specific roster/manager
- `starterOnly` - Show only weeks where player was started

## Dependencies
- **Depends on PR 3.1 (NFL infrastructure)** for:
  - `nfl_schedule` table (bye week detection)
  - `nfl_weekly_roster_status` table (NFL status)
- Will have compilation warnings until PR 3.1 is merged

## Database Tables Used
- `league_families`, `league_family_members`
- `players`, `player_scores`
- `leagues`, `rosters`, `league_users`, `matchups`
- `nfl_schedule` (from PR 3.1)
- `nfl_weekly_roster_status` (from PR 3.1)

## Part of PR #3 Split
This is part of splitting up the large PR #3 into smaller, focused PRs for easier review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)