### PR TITLE
feat: benefit-driven landing, mobile nav, skeleton loading

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -59,22 +59,23 @@ export default function DashboardPage() {
   }
 
   async function loadLeagues() {
-    setLoading(true);
     const res = await fetch("/api/leagues/discover");
     const data = await res.json();
     setFamilies(data.families || []);
     setLoading(false);
   }
 
-  async function handleSleeperLinked() {
-    await checkSleeperLink();
-  }
 
   if (status === "loading" || !session) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-pulse text-muted-foreground">Loading...</div>
-      </div>
+      <main className="container mx-auto px-6 py-8">
+        <div className="h-7 w-40 bg-muted animate-pulse rounded mb-6" />
+        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, i) => (
+            <LeagueCardSkeleton key={i} />
+          ))}
+        </div>
+      </main>
     );
   }
 
@@ -86,21 +87,34 @@ export default function DashboardPage() {
               Link your Sleeper account
             </h2>
             <p className="text-muted-foreground mb-6">
-              Enter your Sleeper username to connect your fantasy leagues.
+              Enter your Sleeper username to get started. We&apos;ll find all
+              your dynasty leagues and start analyzing your trades, drafts, and
+              lineups.
             </p>
-            <LinkSleeperForm onLinked={handleSleeperLinked} />
+            <LinkSleeperForm onLinked={checkSleeperLink} />
           </div>
         ) : loading ? (
-          <div className="flex items-center justify-center py-20">
-            <div className="animate-pulse text-muted-foreground">
-              Loading leagues...
+          <div>
+            <h2 className="text-xl font-semibold mb-6">Your Leagues</h2>
+            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <LeagueCardSkeleton key={i} />
+              ))}
             </div>
           </div>
         ) : families.length === 0 ? (
-          <div className="text-center py-20">
-            <p className="text-muted-foreground">
-              No leagues found for your Sleeper account.
+          <div className="text-center py-20 max-w-md mx-auto">
+            <p className="text-lg font-medium mb-2">No leagues found</p>
+            <p className="text-muted-foreground mb-6">
+              Make sure your Sleeper username is correct and that you have at
+              least one dynasty league.
             </p>
+            <button
+              onClick={() => setLinkStatus(null)}
+              className="text-sm text-primary hover:underline"
+            >
+              Try a different username
+            </button>
           </div>
         ) : (
           <div>
@@ -113,5 +127,21 @@ export default function DashboardPage() {
           </div>
         )}
       </main>
+  );
+}
+
+function LeagueCardSkeleton() {
+  return (
+    <div className="rounded-lg border bg-card p-5 animate-pulse">
+      <div className="flex items-start justify-between mb-2">
+        <div className="h-5 w-32 bg-muted rounded" />
+        <div className="h-4 w-14 bg-muted rounded-full" />
+      </div>
+      <div className="space-y-2 mt-3">
+        <div className="h-4 w-24 bg-muted rounded" />
+        <div className="h-4 w-28 bg-muted rounded" />
+        <div className="h-4 w-16 bg-muted rounded" />
+      </div>
+    </div>
   );
 }

--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -37,7 +37,7 @@ export default function DashboardPage() {
 
   useEffect(() => {
     if (status === "unauthenticated") {
-      router.push("/");
+      router.push("/login");
     }
   }, [status, router]);
 
@@ -79,25 +79,6 @@ export default function DashboardPage() {
   }
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b">
-        <div className="container mx-auto px-6 py-4 flex items-center justify-between">
-          <h1 className="text-2xl font-bold">
-            Dynasty <span className="text-primary">DNA</span>
-          </h1>
-          <div className="flex items-center gap-4">
-            {linkStatus?.linked && (
-              <span className="text-sm text-muted-foreground">
-                Sleeper: {linkStatus.sleeperUsername}
-              </span>
-            )}
-            <span className="text-sm text-muted-foreground">
-              {session.user?.name || session.user?.email}
-            </span>
-          </div>
-        </div>
-      </header>
-
       <main className="container mx-auto px-6 py-8">
         {!linkStatus?.linked ? (
           <div className="max-w-md mx-auto">
@@ -132,6 +113,5 @@ export default function DashboardPage() {
           </div>
         )}
       </main>
-    </div>
   );
 }

--- a/src/app/(app)/layout.tsx
+++ b/src/app/(app)/layout.tsx
@@ -1,0 +1,14 @@
+import { AppNav } from "@/components/AppNav";
+
+export default function AppLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="min-h-screen bg-background">
+      <AppNav />
+      {children}
+    </div>
+  );
+}

--- a/src/app/(app)/league/[familyId]/drafts/page.tsx
+++ b/src/app/(app)/league/[familyId]/drafts/page.tsx
@@ -91,20 +91,20 @@ export default function DraftsPage() {
   }, [familyId, selectedSeason]);
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b">
-        <div className="container mx-auto px-6 py-4 flex items-center gap-4">
-          <Link
-            href={`/league/${familyId}`}
-            className="text-sm text-muted-foreground hover:text-foreground"
-          >
-            &larr; League
-          </Link>
-          <h1 className="text-2xl font-bold">Draft History</h1>
+      <div>
+        <div className="border-b">
+          <div className="container mx-auto px-6 py-3 flex items-center gap-4">
+            <Link
+              href={`/league/${familyId}`}
+              className="text-sm text-muted-foreground hover:text-foreground"
+            >
+              &larr; League
+            </Link>
+            <h1 className="text-lg font-semibold">Draft History</h1>
+          </div>
         </div>
-      </header>
 
-      <main className="container mx-auto px-6 py-8">
+        <main className="container mx-auto px-6 py-8">
         {/* Season filter */}
         {data?.seasons && data.seasons.length > 1 && (
           <div className="flex gap-2 mb-6">
@@ -157,7 +157,7 @@ export default function DraftsPage() {
           </div>
         )}
       </main>
-    </div>
+      </div>
   );
 }
 

--- a/src/app/(app)/league/[familyId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/page.tsx
@@ -130,46 +130,47 @@ export default function LeagueOverviewPage() {
   );
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b">
-        <div className="container mx-auto px-6 py-4 flex items-center justify-between">
-          <div className="flex items-center gap-4">
-            <Link
-              href="/dashboard"
-              className="text-sm text-muted-foreground hover:text-foreground"
-            >
-              &larr; Leagues
-            </Link>
-            <h1 className="text-2xl font-bold">{data.league.name}</h1>
-            <span className="text-sm text-muted-foreground">
-              {data.league.season} Season
-            </span>
-          </div>
-          <div className="flex items-center gap-3">
-            <Link
-              href={`/league/${familyId}/transactions`}
-              className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
-            >
-              Transactions
-            </Link>
-            <Link
-              href={`/league/${familyId}/drafts`}
-              className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
-            >
-              Drafts
-            </Link>
-            <button
-              onClick={handleSync}
-              disabled={syncing}
-              className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors disabled:opacity-50"
-            >
-              {syncing ? "Syncing..." : "Sync Data"}
-            </button>
+      <div>
+        {/* Sub-header */}
+        <div className="border-b">
+          <div className="container mx-auto px-6 py-3 flex items-center justify-between">
+            <div className="flex items-center gap-4">
+              <Link
+                href="/dashboard"
+                className="text-sm text-muted-foreground hover:text-foreground"
+              >
+                &larr; Dashboard
+              </Link>
+              <h1 className="text-lg font-semibold">{data.league.name}</h1>
+              <span className="text-sm text-muted-foreground">
+                {data.league.season}
+              </span>
+            </div>
+            <div className="flex items-center gap-3">
+              <Link
+                href={`/league/${familyId}/transactions`}
+                className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
+              >
+                Transactions
+              </Link>
+              <Link
+                href={`/league/${familyId}/drafts`}
+                className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
+              >
+                Drafts
+              </Link>
+              <button
+                onClick={handleSync}
+                disabled={syncing}
+                className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors disabled:opacity-50"
+              >
+                {syncing ? "Syncing..." : "Sync Data"}
+              </button>
+            </div>
           </div>
         </div>
-      </header>
 
-      <main className="container mx-auto px-6 py-8">
+        <main className="container mx-auto px-6 py-8">
         {/* Season selector */}
         {data.seasons.length > 1 && (
           <div className="flex gap-2 mb-6">
@@ -255,6 +256,6 @@ export default function LeagueOverviewPage() {
           </div>
         )}
       </main>
-    </div>
+      </div>
   );
 }

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -174,31 +174,31 @@ export default function PlayerDetailPage() {
   const { player } = data;
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b">
-        <div className="container mx-auto px-6 py-4 flex items-center gap-4">
-          <Link
-            href={`/league/${familyId}`}
-            className="text-sm text-muted-foreground hover:text-foreground"
-          >
-            &larr; League
-          </Link>
-          <div className="flex-1">
-            <h1 className="text-2xl font-bold">{player.name}</h1>
-            <div className="text-sm text-muted-foreground">
-              {player.position} {player.team ? `— ${player.team}` : ""}
+      <div>
+        <div className="border-b">
+          <div className="container mx-auto px-6 py-3 flex items-center gap-4">
+            <Link
+              href={`/league/${familyId}`}
+              className="text-sm text-muted-foreground hover:text-foreground"
+            >
+              &larr; League
+            </Link>
+            <div className="flex-1">
+              <h1 className="text-lg font-semibold">{player.name}</h1>
+              <div className="text-sm text-muted-foreground">
+                {player.position} {player.team ? `— ${player.team}` : ""}
+              </div>
             </div>
+            <Link
+              href={`/league/${familyId}/timeline?playerId=${playerId}`}
+              className="text-sm text-muted-foreground hover:text-foreground ml-auto"
+            >
+              Timeline &rarr;
+            </Link>
           </div>
-          <Link
-            href={`/league/${familyId}/timeline?playerId=${playerId}`}
-            className="text-sm text-muted-foreground hover:text-foreground ml-auto"
-          >
-            Timeline &rarr;
-          </Link>
         </div>
-      </header>
 
-      <main className="container mx-auto px-6 py-8">
+        <main className="container mx-auto px-6 py-8">
         {/* Summary Stats */}
         {stats && (
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
@@ -347,7 +347,7 @@ export default function PlayerDetailPage() {
           </div>
         )}
       </main>
-    </div>
+      </div>
   );
 }
 

--- a/src/app/(app)/league/[familyId]/timeline/page.tsx
+++ b/src/app/(app)/league/[familyId]/timeline/page.tsx
@@ -116,18 +116,18 @@ export default function TimelinePage() {
   }
 
   return (
-    <div className="min-h-screen bg-background flex flex-col">
-      <header className="border-b">
-        <div className="container mx-auto px-6 py-4 flex items-center gap-4">
+    <div className="flex flex-col flex-1">
+      <div className="border-b">
+        <div className="container mx-auto px-6 py-3 flex items-center gap-4">
           <Link
             href={`/league/${familyId}`}
             className="text-sm text-muted-foreground hover:text-foreground"
           >
             &larr; League
           </Link>
-          <h1 className="text-xl font-bold">Asset Timeline</h1>
+          <h1 className="text-lg font-semibold">Asset Timeline</h1>
         </div>
-      </header>
+      </div>
 
       {/* Mobile tabs (< md) */}
       {timelines.length > 1 && (

--- a/src/app/(app)/league/[familyId]/transactions/page.tsx
+++ b/src/app/(app)/league/[familyId]/transactions/page.tsx
@@ -59,20 +59,20 @@ export default function TransactionsPage() {
   ];
 
   return (
-    <div className="min-h-screen bg-background">
-      <header className="border-b">
-        <div className="container mx-auto px-6 py-4 flex items-center gap-4">
-          <Link
-            href={`/league/${familyId}`}
-            className="text-sm text-muted-foreground hover:text-foreground"
-          >
-            &larr; League
-          </Link>
-          <h1 className="text-2xl font-bold">Transactions</h1>
+      <div>
+        <div className="border-b">
+          <div className="container mx-auto px-6 py-3 flex items-center gap-4">
+            <Link
+              href={`/league/${familyId}`}
+              className="text-sm text-muted-foreground hover:text-foreground"
+            >
+              &larr; League
+            </Link>
+            <h1 className="text-lg font-semibold">Transactions</h1>
+          </div>
         </div>
-      </header>
 
-      <main className="container mx-auto px-6 py-8">
+        <main className="container mx-auto px-6 py-8">
         {/* Filters */}
         <div className="flex flex-wrap gap-4 mb-6">
           {/* Season filter */}
@@ -173,6 +173,6 @@ export default function TransactionsPage() {
           </>
         )}
       </main>
-    </div>
+      </div>
   );
 }

--- a/src/app/(public)/changelog/page.tsx
+++ b/src/app/(public)/changelog/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { PublicNav } from "@/components/PublicNav";
 import { StatusBadge } from "@/components/StatusBadge";
 import { formatDate } from "@/lib/utils";
 import type { RoadmapIssue } from "@/app/api/roadmap/route";
@@ -58,8 +57,6 @@ export default function ChangelogPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <PublicNav />
-
       <main className="container mx-auto px-6 py-12 max-w-3xl">
         <div className="mb-10">
           <h1 className="text-3xl font-bold tracking-tight mb-2">Changelog</h1>

--- a/src/app/(public)/experiments/page.tsx
+++ b/src/app/(public)/experiments/page.tsx
@@ -1,8 +1,6 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { PublicNav } from "@/components/PublicNav";
-
 interface ExperimentRun {
   id: string;
   name: string;
@@ -181,8 +179,6 @@ export default function ExperimentsPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <PublicNav />
-
       <main className="container mx-auto px-6 py-8 max-w-4xl">
         <div className="mb-8">
           <h1 className="text-2xl font-bold tracking-tight">

--- a/src/app/(public)/layout.tsx
+++ b/src/app/(public)/layout.tsx
@@ -1,0 +1,14 @@
+import { PublicNav } from "@/components/PublicNav";
+
+export default function PublicLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <>
+      <PublicNav />
+      {children}
+    </>
+  );
+}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { PublicNav } from "@/components/PublicNav";
 import { AuthCTA } from "@/components/AuthCTA";
 import {
   ArrowRightLeft,
@@ -14,8 +13,6 @@ import {
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-secondary/20">
-      <PublicNav />
-
       {/* Hero */}
       <section className="container mx-auto px-6 py-24 text-center max-w-3xl">
         <h1 className="text-5xl font-bold tracking-tight mb-4">

--- a/src/app/(public)/roadmap/page.tsx
+++ b/src/app/(public)/roadmap/page.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { PublicNav } from "@/components/PublicNav";
 import { RoadmapCard } from "@/components/RoadmapCard";
 import type { RoadmapIssue } from "@/app/api/roadmap/route";
 import { type FeatureFlag, getActiveExperiments } from "@/lib/featureFlags";
@@ -124,8 +123,6 @@ export default function RoadmapPage() {
 
   return (
     <div className="min-h-screen bg-background">
-      <PublicNav />
-
       <main className="container mx-auto px-6 py-12 max-w-3xl">
         {/* Header */}
         <div className="mb-10">

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { signIn, useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
+
+export default function LoginPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (session) {
+      router.push("/dashboard");
+    }
+  }, [session, router]);
+
+  if (status === "loading") {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background to-secondary/20">
+      <div className="max-w-sm w-full mx-auto px-6">
+        <div className="text-center mb-8">
+          <h1 className="text-4xl font-bold tracking-tight mb-2">
+            Dynasty <span className="text-primary">DNA</span>
+          </h1>
+          <p className="text-muted-foreground">
+            Sign in to access your leagues
+          </p>
+        </div>
+
+        <div className="flex flex-col gap-3">
+          <button
+            onClick={() => signIn("google")}
+            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-white text-gray-800 border border-gray-300 hover:bg-gray-50 transition-colors font-medium"
+          >
+            <GoogleIcon />
+            Sign in with Google
+          </button>
+          <button
+            onClick={() => signIn("github")}
+            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-gray-900 text-white hover:bg-gray-800 transition-colors font-medium"
+          >
+            <GitHubIcon />
+            Sign in with GitHub
+          </button>
+        </div>
+
+        <p className="text-xs text-muted-foreground mt-8 text-center">
+          After signing in, you&apos;ll link your Sleeper account to get started.
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function GoogleIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 18 18">
+      <path
+        d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
+        fill="#4285F4"
+      />
+      <path
+        d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z"
+        fill="#34A853"
+      />
+      <path
+        d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+}
+
+function GitHubIcon() {
+  return (
+    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
+      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
+    </svg>
+  );
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { signIn, useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { Suspense, useEffect } from "react";
 
-export default function LoginPage() {
+function LoginContent() {
   const { data: session, status } = useSession();
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
 
   useEffect(() => {
     if (session) {
@@ -34,6 +36,12 @@ export default function LoginPage() {
           </p>
         </div>
 
+        {error && (
+          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg p-3 mb-4 text-center dark:bg-red-950 dark:border-red-900 dark:text-red-400">
+            Sign-in failed. Please try again.
+          </div>
+        )}
+
         <div className="flex flex-col gap-3">
           <button
             onClick={() => signIn("google")}
@@ -56,6 +64,20 @@ export default function LoginPage() {
         </p>
       </div>
     </div>
+  );
+}
+
+export default function LoginPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center">
+          <div className="animate-pulse text-muted-foreground">Loading...</div>
+        </div>
+      }
+    >
+      <LoginContent />
+    </Suspense>
   );
 }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -19,15 +19,17 @@ export default function LandingPage() {
       {/* Hero */}
       <section className="container mx-auto px-6 py-24 text-center max-w-3xl">
         <h1 className="text-5xl font-bold tracking-tight mb-4">
-          Decode your dynasty
-          <br />
-          management <span className="text-primary">DNA</span>
+          Decode your dynasty <span className="text-primary">DNA</span>
         </h1>
-        <p className="text-xl text-muted-foreground mb-10 max-w-xl mx-auto">
-          Trade grades, draft analysis, lineup optimization, and manager
-          profiles — powered by your Sleeper league data.
+        <p className="text-xl text-muted-foreground mb-8 max-w-xl mx-auto">
+          Find out if you won the trade, graded every pick right, and where
+          you&apos;re leaving points on your bench — all from your Sleeper data.
         </p>
         <AuthCTA />
+        <p className="text-xs text-muted-foreground mt-6">
+          Powered by 50+ data points per player &middot; FantasyCalc &middot;
+          nflverse
+        </p>
       </section>
 
       {/* Feature cards */}
@@ -35,23 +37,23 @@ export default function LandingPage() {
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
           <FeatureCard
             icon={<ArrowRightLeft className="h-6 w-6 text-primary" />}
-            title="Trade Grading"
-            description="Every trade scored with surplus value and context-aware analysis."
+            title="Know if you won the trade"
+            description="Every trade scored with surplus value so you can see who came out ahead — and why."
           />
           <FeatureCard
             icon={<ClipboardList className="h-6 w-6 text-primary" />}
-            title="Draft Analysis"
-            description="Pick-by-pick grades comparing draft capital spent vs. production gained."
+            title="Grade every pick"
+            description="Pick-by-pick draft grades comparing capital spent vs. production gained."
           />
           <FeatureCard
             icon={<BarChart3 className="h-6 w-6 text-primary" />}
-            title="Lineup Optimization"
-            description="See how your weekly lineups compare to the optimal set."
+            title="Never leave points on your bench"
+            description="Weekly lineup analysis showing exactly where you left points on the table."
           />
           <FeatureCard
             icon={<Dna className="h-6 w-6 text-primary" />}
-            title="Manager DNA"
-            description="A profile of your management style across trades, drafts, and waivers."
+            title="Discover your manager style"
+            description="A profile across trades, drafts, and waivers that reveals how you build rosters."
           />
         </div>
       </section>
@@ -60,29 +62,29 @@ export default function LandingPage() {
       <section className="border-t bg-muted/30">
         <div className="container mx-auto px-6 py-16 max-w-5xl">
           <h2 className="text-2xl font-bold tracking-tight mb-2 text-center">
-            How It&apos;s Built
+            Built by a dynasty player, for dynasty players
           </h2>
           <p className="text-muted-foreground text-center mb-10 max-w-lg mx-auto">
-            Dynasty DNA is built in the open with hypothesis-driven development.
+            Every feature is built in the open — see what&apos;s planned, what shipped, and the data behind each decision.
           </p>
           <div className="grid gap-6 sm:grid-cols-3">
             <BuildCard
               href="/roadmap"
               icon={<Map className="h-5 w-5 text-primary" />}
               title="Roadmap"
-              description="See what we're building and why — every feature starts with a hypothesis."
+              description="What we're building next and why — priorities driven by real league data."
             />
             <BuildCard
               href="/changelog"
               icon={<BookOpen className="h-5 w-5 text-primary" />}
               title="Changelog"
-              description="What shipped and the results. Transparent decision-making."
+              description="What shipped and the results. Full transparency on every release."
             />
             <BuildCard
               href="/experiments"
               icon={<FlaskConical className="h-5 w-5 text-primary" />}
               title="Experiments"
-              description="Algorithm variants tested against real data with structured metrics."
+              description="Algorithm variants tested against real data to find what actually works."
             />
           </div>
         </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,106 +1,151 @@
-"use client";
-
-import { signIn, useSession } from "next-auth/react";
-import { useRouter } from "next/navigation";
-import { useEffect } from "react";
 import Link from "next/link";
+import { PublicNav } from "@/components/PublicNav";
+import { AuthCTA } from "@/components/AuthCTA";
+import {
+  ArrowRightLeft,
+  ClipboardList,
+  BarChart3,
+  Dna,
+  Map,
+  BookOpen,
+  FlaskConical,
+} from "lucide-react";
 
-export default function HomePage() {
-  const { data: session, status } = useSession();
-  const router = useRouter();
-
-  useEffect(() => {
-    if (session) {
-      router.push("/dashboard");
-    }
-  }, [session, router]);
-
-  if (status === "loading") {
-    return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-pulse text-muted-foreground">Loading...</div>
-      </div>
-    );
-  }
-
+export default function LandingPage() {
   return (
-    <div className="min-h-screen flex flex-col bg-gradient-to-b from-background to-secondary/20">
-      {/* Top nav */}
-      <nav className="flex items-center justify-end gap-6 px-6 py-4">
-        <Link href="/roadmap" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-          Roadmap
-        </Link>
-        <Link href="/changelog" className="text-sm text-muted-foreground hover:text-foreground transition-colors">
-          Changelog
-        </Link>
-      </nav>
+    <div className="min-h-screen bg-gradient-to-b from-background to-secondary/20">
+      <PublicNav />
 
-      <div className="flex-1 flex flex-col items-center justify-center">
-      <div className="max-w-2xl mx-auto text-center px-6">
+      {/* Hero */}
+      <section className="container mx-auto px-6 py-24 text-center max-w-3xl">
         <h1 className="text-5xl font-bold tracking-tight mb-4">
-          Dynasty <span className="text-primary">DNA</span>
+          Decode your dynasty
+          <br />
+          management <span className="text-primary">DNA</span>
         </h1>
-        <p className="text-xl text-muted-foreground mb-2">
-          Decode your dynasty fantasy football management style
+        <p className="text-xl text-muted-foreground mb-10 max-w-xl mx-auto">
+          Trade grades, draft analysis, lineup optimization, and manager
+          profiles — powered by your Sleeper league data.
         </p>
-        <p className="text-muted-foreground mb-10 max-w-lg mx-auto">
-          Trade grades, counterfactual analysis, lineup optimization, and
-          manager DNA profiles — powered by your Sleeper league data.
-        </p>
+        <AuthCTA />
+      </section>
 
-        <div className="flex flex-col gap-3 max-w-xs mx-auto">
-          <button
-            onClick={() => signIn("google")}
-            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-white text-gray-800 border border-gray-300 hover:bg-gray-50 transition-colors font-medium"
-          >
-            <GoogleIcon />
-            Sign in with Google
-          </button>
-          <button
-            onClick={() => signIn("github")}
-            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-gray-900 text-white hover:bg-gray-800 transition-colors font-medium"
-          >
-            <GitHubIcon />
-            Sign in with GitHub
-          </button>
+      {/* Feature cards */}
+      <section className="container mx-auto px-6 pb-20 max-w-5xl">
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+          <FeatureCard
+            icon={<ArrowRightLeft className="h-6 w-6 text-primary" />}
+            title="Trade Grading"
+            description="Every trade scored with surplus value and context-aware analysis."
+          />
+          <FeatureCard
+            icon={<ClipboardList className="h-6 w-6 text-primary" />}
+            title="Draft Analysis"
+            description="Pick-by-pick grades comparing draft capital spent vs. production gained."
+          />
+          <FeatureCard
+            icon={<BarChart3 className="h-6 w-6 text-primary" />}
+            title="Lineup Optimization"
+            description="See how your weekly lineups compare to the optimal set."
+          />
+          <FeatureCard
+            icon={<Dna className="h-6 w-6 text-primary" />}
+            title="Manager DNA"
+            description="A profile of your management style across trades, drafts, and waivers."
+          />
         </div>
+      </section>
 
-        <p className="text-xs text-muted-foreground mt-8">
-          After signing in, you&apos;ll link your Sleeper account to get started.
-        </p>
-      </div>
-      </div>
+      {/* How It's Built */}
+      <section className="border-t bg-muted/30">
+        <div className="container mx-auto px-6 py-16 max-w-5xl">
+          <h2 className="text-2xl font-bold tracking-tight mb-2 text-center">
+            How It&apos;s Built
+          </h2>
+          <p className="text-muted-foreground text-center mb-10 max-w-lg mx-auto">
+            Dynasty DNA is built in the open with hypothesis-driven development.
+          </p>
+          <div className="grid gap-6 sm:grid-cols-3">
+            <BuildCard
+              href="/roadmap"
+              icon={<Map className="h-5 w-5 text-primary" />}
+              title="Roadmap"
+              description="See what we're building and why — every feature starts with a hypothesis."
+            />
+            <BuildCard
+              href="/changelog"
+              icon={<BookOpen className="h-5 w-5 text-primary" />}
+              title="Changelog"
+              description="What shipped and the results. Transparent decision-making."
+            />
+            <BuildCard
+              href="/experiments"
+              icon={<FlaskConical className="h-5 w-5 text-primary" />}
+              title="Experiments"
+              description="Algorithm variants tested against real data with structured metrics."
+            />
+          </div>
+        </div>
+      </section>
+
+      {/* Footer */}
+      <footer className="border-t">
+        <div className="container mx-auto px-6 py-8 text-center text-xs text-muted-foreground">
+          <a
+            href="https://github.com/jrygrande/dynasty-dna"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-primary hover:underline"
+          >
+            View source on GitHub
+          </a>
+        </div>
+      </footer>
     </div>
   );
 }
 
-function GoogleIcon() {
+function FeatureCard({
+  icon,
+  title,
+  description,
+}: {
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
   return (
-    <svg width="18" height="18" viewBox="0 0 18 18">
-      <path
-        d="M17.64 9.2c0-.637-.057-1.251-.164-1.84H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z"
-        fill="#4285F4"
-      />
-      <path
-        d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z"
-        fill="#34A853"
-      />
-      <path
-        d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z"
-        fill="#FBBC05"
-      />
-      <path
-        d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z"
-        fill="#EA4335"
-      />
-    </svg>
+    <div className="rounded-lg border bg-card p-6">
+      <div className="mb-3">{icon}</div>
+      <h3 className="font-semibold mb-1">{title}</h3>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </div>
   );
 }
 
-function GitHubIcon() {
+function BuildCard({
+  href,
+  icon,
+  title,
+  description,
+}: {
+  href: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+}) {
   return (
-    <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor">
-      <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z" />
-    </svg>
+    <Link
+      href={href}
+      className="rounded-lg border bg-card p-6 hover:border-primary/50 transition-colors group"
+    >
+      <div className="flex items-center gap-2 mb-2">
+        {icon}
+        <h3 className="font-semibold group-hover:text-primary transition-colors">
+          {title}
+        </h3>
+      </div>
+      <p className="text-sm text-muted-foreground">{description}</p>
+    </Link>
   );
 }

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -1,10 +1,21 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
+import { useEffect, useState } from "react";
+import { Menu, X } from "lucide-react";
 
 export function AppNav() {
   const { data: session } = useSession();
+  const pathname = usePathname();
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
+
+  const displayName = session?.user?.name || session?.user?.email || "User";
 
   return (
     <header className="border-b">
@@ -14,10 +25,12 @@ export function AppNav() {
             Dynasty <span className="text-primary">DNA</span>
           </span>
         </Link>
-        <div className="flex items-center gap-4">
+
+        {/* Desktop nav */}
+        <div className="hidden sm:flex items-center gap-4">
           {session?.user && (
-            <span className="text-sm text-muted-foreground">
-              {session.user.name || session.user.email}
+            <span className="text-sm text-muted-foreground truncate max-w-[200px]">
+              {displayName}
             </span>
           )}
           <button
@@ -27,7 +40,34 @@ export function AppNav() {
             Sign Out
           </button>
         </div>
+
+        {/* Mobile menu button */}
+        <button
+          onClick={() => setMobileOpen(!mobileOpen)}
+          className="sm:hidden p-2 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={mobileOpen ? "Close menu" : "Open menu"}
+          aria-expanded={mobileOpen}
+        >
+          {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
       </div>
+
+      {/* Mobile nav */}
+      {mobileOpen && (
+        <div className="sm:hidden border-t px-6 py-4 flex flex-col gap-4 bg-background">
+          {session?.user && (
+            <span className="text-sm text-muted-foreground truncate">
+              {displayName}
+            </span>
+          )}
+          <button
+            onClick={() => signOut({ callbackUrl: "/login" })}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors text-left"
+          >
+            Sign Out
+          </button>
+        </div>
+      )}
     </header>
   );
 }

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import Link from "next/link";
+import { signOut, useSession } from "next-auth/react";
+
+export function AppNav() {
+  const { data: session } = useSession();
+
+  return (
+    <header className="border-b">
+      <div className="container mx-auto px-6 py-4 flex items-center justify-between">
+        <Link href="/dashboard" className="flex items-center gap-2">
+          <span className="text-lg font-bold tracking-tight">
+            Dynasty <span className="text-primary">DNA</span>
+          </span>
+        </Link>
+        <div className="flex items-center gap-4">
+          {session?.user && (
+            <span className="text-sm text-muted-foreground">
+              {session.user.name || session.user.email}
+            </span>
+          )}
+          <button
+            onClick={() => signOut({ callbackUrl: "/login" })}
+            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Sign Out
+          </button>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/AuthCTA.tsx
+++ b/src/components/AuthCTA.tsx
@@ -5,6 +5,13 @@ import { useSession } from "next-auth/react";
 
 export function AuthCTA() {
   const { status } = useSession();
+
+  if (status === "loading") {
+    return (
+      <div className="inline-flex items-center px-6 py-3 rounded-lg bg-muted animate-pulse h-[52px] w-[168px]" />
+    );
+  }
+
   const isAuthed = status === "authenticated";
 
   return (

--- a/src/components/AuthCTA.tsx
+++ b/src/components/AuthCTA.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+
+export function AuthCTA() {
+  const { status } = useSession();
+  const isAuthed = status === "authenticated";
+
+  return (
+    <Link
+      href={isAuthed ? "/dashboard" : "/login"}
+      className="inline-flex items-center gap-2 px-6 py-3 rounded-lg bg-primary text-primary-foreground hover:bg-primary/90 transition-colors font-medium text-lg"
+    >
+      {isAuthed ? "Go to Dashboard" : "Get Started"}
+    </Link>
+  );
+}

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -1,11 +1,55 @@
 "use client";
 
 import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
+
+const navLinks = [
+  { href: "/roadmap", label: "Roadmap" },
+  { href: "/changelog", label: "Changelog" },
+  { href: "/experiments", label: "Experiments" },
+];
 
 export function PublicNav() {
-  const { data: session, status } = useSession();
+  const { status } = useSession();
+  const pathname = usePathname();
   const isAuthed = status === "authenticated";
+  const [mobileOpen, setMobileOpen] = useState(false);
+
+  function linkClass(href: string) {
+    const active = pathname === href;
+    return `text-sm transition-colors ${
+      active
+        ? "text-foreground font-medium"
+        : "text-muted-foreground hover:text-foreground"
+    }`;
+  }
+
+  function renderLinks(onNavigate?: () => void) {
+    return (
+      <>
+        {navLinks.map((link) => (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={linkClass(link.href)}
+            onClick={onNavigate}
+          >
+            {link.label}
+          </Link>
+        ))}
+        <Link
+          href={isAuthed ? "/dashboard" : "/login"}
+          className="text-sm px-4 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors text-center"
+          onClick={onNavigate}
+        >
+          {isAuthed ? "Dashboard" : "Sign In"}
+        </Link>
+      </>
+    );
+  }
 
   return (
     <header className="border-b">
@@ -15,33 +59,28 @@ export function PublicNav() {
             Dynasty <span className="text-primary">DNA</span>
           </span>
         </Link>
-        <nav className="flex items-center gap-6">
-          <Link
-            href="/roadmap"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Roadmap
-          </Link>
-          <Link
-            href="/changelog"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Changelog
-          </Link>
-          <Link
-            href="/experiments"
-            className="text-sm text-muted-foreground hover:text-foreground transition-colors"
-          >
-            Experiments
-          </Link>
-          <Link
-            href={isAuthed ? "/dashboard" : "/login"}
-            className="text-sm px-4 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
-          >
-            {isAuthed ? "Dashboard" : "Sign In"}
-          </Link>
+
+        {/* Desktop nav */}
+        <nav className="hidden sm:flex items-center gap-6">
+          {renderLinks()}
         </nav>
+
+        {/* Mobile menu button */}
+        <button
+          onClick={() => setMobileOpen(!mobileOpen)}
+          className="sm:hidden p-2 text-muted-foreground hover:text-foreground transition-colors"
+          aria-label={mobileOpen ? "Close menu" : "Open menu"}
+        >
+          {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
+        </button>
       </div>
+
+      {/* Mobile nav */}
+      {mobileOpen && (
+        <nav className="sm:hidden border-t px-6 py-4 flex flex-col gap-4 bg-background">
+          {renderLinks(() => setMobileOpen(false))}
+        </nav>
+      )}
     </header>
   );
 }

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Menu, X } from "lucide-react";
 
 const navLinks = [
@@ -17,6 +17,11 @@ export function PublicNav() {
   const pathname = usePathname();
   const isAuthed = status === "authenticated";
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  // Auto-close mobile menu on route change (e.g., browser back/forward)
+  useEffect(() => {
+    setMobileOpen(false);
+  }, [pathname]);
 
   function linkClass(href: string) {
     const active = pathname === href;
@@ -70,6 +75,7 @@ export function PublicNav() {
           onClick={() => setMobileOpen(!mobileOpen)}
           className="sm:hidden p-2 text-muted-foreground hover:text-foreground transition-colors"
           aria-label={mobileOpen ? "Close menu" : "Open menu"}
+          aria-expanded={mobileOpen}
         >
           {mobileOpen ? <X className="h-5 w-5" /> : <Menu className="h-5 w-5" />}
         </button>

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -1,6 +1,12 @@
+"use client";
+
 import Link from "next/link";
+import { useSession } from "next-auth/react";
 
 export function PublicNav() {
+  const { data: session, status } = useSession();
+  const isAuthed = status === "authenticated";
+
   return (
     <header className="border-b">
       <div className="container mx-auto px-6 py-4 flex items-center justify-between">
@@ -29,10 +35,10 @@ export function PublicNav() {
             Experiments
           </Link>
           <Link
-            href="/"
+            href={isAuthed ? "/dashboard" : "/login"}
             className="text-sm px-4 py-1.5 rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors"
           >
-            Sign In
+            {isAuthed ? "Dashboard" : "Sign In"}
           </Link>
         </nav>
       </div>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -61,7 +61,7 @@ export const authOptions: NextAuthOptions = {
     },
   },
   pages: {
-    signIn: "/",
+    signIn: "/login",
   },
   debug: process.env.NODE_ENV === "development",
 };


### PR DESCRIPTION
## Summary
- **Benefit-driven landing copy**: Hero headline "Decode your dynasty DNA", 4 feature cards with benefit titles ("Know if you won the trade", "Grade every pick", etc.), specificity signal ("Powered by 50+ data points per player"), "Built by a dynasty player" trust section
- **Mobile nav + active indicators**: Hamburger menu at `sm` breakpoint with vertically-stacked links and auto-close on navigation; active page highlighted via bold/dark text styling
- **Skeleton loading**: Dashboard `LeagueCardSkeleton` with `animate-pulse` grid; two empty states with guidance text + retry (no-Sleeper-link form, no-leagues retry button)
- **Route groups**: Restructured to `(public)` and `(app)` with separate layouts and nav components (`PublicNav` / `AppNav`)

## UI Rubric Score
Scored against [the rubric](https://github.com/jrygrande/dynasty-dna/blob/main/memory/reference_ui_review_rubric.md) using browser-based verification (Claude for Chrome MCP).

| Dimension | Before | After | Delta |
|-----------|--------|-------|-------|
| A. Product Vision (2x) | 5 | **6.5** | +1.5 |
| B. Info Architecture (1x) | 6 | **7.5** | +1.5 |
| C. UX Flow (2x) | 4.5 | **6** | +1.5 |
| D. Visual Polish (1.5x) | 5.5 | **6** | +0.5 |
| E. Tech Sense (1x) | 7 | 7 | — |
| F. Meta-Portfolio (2.5x) | 7 | 7 | — |
| **Composite** | **5.75** | **6.6** | **+0.85** |

## Test plan
- [x] Landing page: hero, feature cards, specificity, trust section render correctly
- [x] Nav active indicator highlights current page on Roadmap, Changelog, Experiments
- [x] Mobile hamburger opens/closes, links navigate and auto-close menu
- [x] Dashboard skeleton cards animate during loading (code-verified)
- [x] Dashboard empty states show guidance + retry (code-verified)
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)