### PR TITLE
feat: Manager Outcome Score (MOS) — ground truth for experiments

### DIFF
--- a/scripts/experiments/01-par-vs-rank.ts
+++ b/scripts/experiments/01-par-vs-rank.ts
@@ -25,10 +25,13 @@ import {
 } from "../../src/services/gradingCore";
 import {
   runExperiment,
+  db,
+  schema,
   describeArray,
   spearmanCorrelation,
   printTable,
 } from "./helpers";
+import { computeLeagueMOS } from "../../src/services/outcomeScore";
 
 runExperiment({
   name: "par-vs-rank",
@@ -50,6 +53,10 @@ runExperiment({
     const allV1Corrs: number[] = [];
     const allV2Corrs: number[] = [];
 
+    // Store per-family data for reuse in MOS correlation section
+    const familySeasonalData = new Map<string, Awaited<ReturnType<typeof computeSeasonalRanks>>>();
+    const familyMembers = new Map<string, { leagueId: string; season: string }[]>();
+
     for (const family of families) {
       ctx.log(`\n--- Family: ${family.name} ---`);
 
@@ -69,6 +76,10 @@ runExperiment({
         leagueSeasonMap,
         { isSuperFlex: false },
       );
+
+      // Cache for MOS correlation section below
+      familySeasonalData.set(family.id, seasonalData);
+      familyMembers.set(family.id, members.map((m) => ({ leagueId: m.leagueId, season: m.season })));
 
       // Build per-player PPG lookup from seasonalData (avoids redundant DB query)
       const playerSeasonPPG = new Map<string, number>(); // "playerId:season" -> PPG
@@ -187,12 +198,90 @@ runExperiment({
 
     ctx.log(`\nAverage correlation — v1 (rank): ${avgV1}, v2 (PAR): ${avgV2}`);
 
+    // MOS correlation: for each league, compute MOS and correlate with
+    // the average production score of rostered players under each method
+    ctx.log("\n--- MOS Correlation ---");
+    const mosCorrelations: Record<string, { v1: number; v2: number }> = {};
+
+    for (const family of families) {
+      const members = familyMembers.get(family.id) ?? [];
+      const cachedSeasonalData = familySeasonalData.get(family.id);
+      if (!cachedSeasonalData || members.length === 0) continue;
+
+      for (const member of members) {
+        const leagueMOS = await computeLeagueMOS(member.leagueId, undefined, db);
+        if (leagueMOS.length === 0) continue;
+
+        // Get production scores per roster under v1 and v2
+        const rosterV1 = new Map<number, number[]>();
+        const rosterV2 = new Map<number, number[]>();
+
+        const leagueScores = await ctx.db
+          .select()
+          .from(ctx.schema.playerScores)
+          .where(eq(ctx.schema.playerScores.leagueId, member.leagueId));
+
+        for (const ps of leagueScores) {
+          const position = cachedSeasonalData.positions.get(ps.playerId);
+          if (!position) continue;
+
+          const rankKey = `${member.season}:${position}`;
+          const rankMap = cachedSeasonalData.ranks.get(rankKey);
+          const rank = rankMap?.get(ps.playerId);
+          if (rank === undefined) continue;
+
+          const awMap = cachedSeasonalData.activeWeeks.get(member.season);
+          const activeWeekCount = awMap?.get(ps.playerId) ?? 0;
+
+          const v1Score = rankToProductionValue(rank, activeWeekCount, position);
+          const v2Score = playerSeasonalPAR(
+            ps.playerId,
+            parseInt(member.season, 10),
+            parseInt(member.season, 10),
+            cachedSeasonalData,
+          );
+
+          if (!rosterV1.has(ps.rosterId)) rosterV1.set(ps.rosterId, []);
+          if (!rosterV2.has(ps.rosterId)) rosterV2.set(ps.rosterId, []);
+          rosterV1.get(ps.rosterId)!.push(v1Score);
+          rosterV2.get(ps.rosterId)!.push(v2Score);
+        }
+
+        // Build arrays for correlation with MOS
+        const mosVals: number[] = [];
+        const v1Avgs: number[] = [];
+        const v2Avgs: number[] = [];
+
+        for (const mosEntry of leagueMOS) {
+          const v1Arr = rosterV1.get(mosEntry.rosterId);
+          const v2Arr = rosterV2.get(mosEntry.rosterId);
+          if (!v1Arr || !v2Arr || v1Arr.length === 0) continue;
+
+          mosVals.push(mosEntry.mos);
+          v1Avgs.push(v1Arr.reduce((a, b) => a + b, 0) / v1Arr.length);
+          v2Avgs.push(v2Arr.reduce((a, b) => a + b, 0) / v2Arr.length);
+        }
+
+        if (mosVals.length >= 4) {
+          const corrV1MOS = spearmanCorrelation(v1Avgs, mosVals);
+          const corrV2MOS = spearmanCorrelation(v2Avgs, mosVals);
+          const key = `${family.name}:${member.season}`;
+          mosCorrelations[key] = {
+            v1: Math.round(corrV1MOS * 1000) / 1000,
+            v2: Math.round(corrV2MOS * 1000) / 1000,
+          };
+          ctx.log(`  ${key}: v1=${corrV1MOS.toFixed(3)}, v2=${corrV2MOS.toFixed(3)}`);
+        }
+      }
+    }
+
     return {
       metrics: {
         perSeasonCorrelations,
         averageCorrelationV1: avgV1,
         averageCorrelationV2: avgV2,
         seasonsAnalyzed: allV1Corrs.length,
+        mosCorrelations,
       },
       rawData: Object.entries(allTableRows).flatMap(([family, rows]) =>
         rows.map((r) => ({

--- a/scripts/experiments/01-par-vs-rank.ts
+++ b/scripts/experiments/01-par-vs-rank.ts
@@ -262,15 +262,16 @@ runExperiment({
           v2Avgs.push(v2Arr.reduce((a, b) => a + b, 0) / v2Arr.length);
         }
 
-        if (mosVals.length >= 4) {
+        if (mosVals.length >= 8) {
           const corrV1MOS = spearmanCorrelation(v1Avgs, mosVals);
           const corrV2MOS = spearmanCorrelation(v2Avgs, mosVals);
           const key = `${family.name}:${member.season}`;
           mosCorrelations[key] = {
             v1: Math.round(corrV1MOS * 1000) / 1000,
             v2: Math.round(corrV2MOS * 1000) / 1000,
+            n: mosVals.length,
           };
-          ctx.log(`  ${key}: v1=${corrV1MOS.toFixed(3)}, v2=${corrV2MOS.toFixed(3)}`);
+          ctx.log(`  ${key} (n=${mosVals.length}): v1=${corrV1MOS.toFixed(3)}, v2=${corrV2MOS.toFixed(3)}`);
         }
       }
     }

--- a/scripts/experiments/03-production-layers.ts
+++ b/scripts/experiments/03-production-layers.ts
@@ -58,7 +58,7 @@ runExperiment({
       return { metrics: {}, rawData: [] };
     }
 
-    const allMetrics: Record<string, Record<string, { corrWinPct: number; corrFpts: number; corrMOS: number }>> = {};
+    const allMetrics: Record<string, Record<string, { corrWinPct: number; corrFpts: number; corrMOS: number | null }>> = {};
     const allRawRows: Record<string, unknown>[] = [];
 
     for (const family of families) {
@@ -192,6 +192,7 @@ runExperiment({
           const winPcts: number[] = [];
           const fpts: number[] = [];
           const mosVals: number[] = [];
+          const hasMOS = mosMap.size > 0;
 
           for (const roster of leagueRosters) {
             const prod = rosterProductions.get(roster.rosterId) ?? 0;
@@ -201,16 +202,16 @@ runExperiment({
             productions.push(prod);
             winPcts.push(winPct);
             fpts.push(roster.fpts ?? 0);
-            mosVals.push(mosMap.get(roster.rosterId) ?? 0);
+            if (hasMOS) mosVals.push(mosMap.get(roster.rosterId) ?? 0);
           }
 
           const corrWin = spearmanCorrelation(productions, winPcts);
           const corrFpts = spearmanCorrelation(productions, fpts);
-          const corrMOS = spearmanCorrelation(productions, mosVals);
+          const corrMOS = hasMOS ? spearmanCorrelation(productions, mosVals) : null;
 
           const corrWinRounded = Math.round(corrWin * 1000) / 1000;
           const corrFptsRounded = Math.round(corrFpts * 1000) / 1000;
-          const corrMOSRounded = Math.round(corrMOS * 1000) / 1000;
+          const corrMOSRounded = hasMOS ? Math.round(corrMOS * 1000) / 1000 : null;
 
           allMetrics[seasonKey][config.name] = {
             corrWinPct: corrWinRounded,
@@ -223,7 +224,7 @@ runExperiment({
             leagueRosters.length,
             corrWin.toFixed(3),
             corrFpts.toFixed(3),
-            corrMOS.toFixed(3),
+            hasMOS ? corrMOS.toFixed(3) : "n/a",
           ]);
         }
 

--- a/scripts/experiments/03-production-layers.ts
+++ b/scripts/experiments/03-production-layers.ts
@@ -17,7 +17,8 @@
  * Usage: npx tsx scripts/experiments/03-production-layers.ts
  */
 
-import { runExperiment, schema, spearmanCorrelation, printTable } from "./helpers";
+import { runExperiment, db, schema, spearmanCorrelation, printTable } from "./helpers";
+import { computeLeagueMOS } from "../../src/services/outcomeScore";
 import { eq, inArray } from "drizzle-orm";
 import {
   pointsAboveReplacement,
@@ -57,7 +58,7 @@ runExperiment({
       return { metrics: {}, rawData: [] };
     }
 
-    const allMetrics: Record<string, Record<string, { corrWinPct: number; corrFpts: number }>> = {};
+    const allMetrics: Record<string, Record<string, { corrWinPct: number; corrFpts: number; corrMOS: number }>> = {};
     const allRawRows: Record<string, unknown>[] = [];
 
     for (const family of families) {
@@ -106,6 +107,10 @@ runExperiment({
         const playoffStart = playoffCfg?.playoffStart ?? null;
 
         ctx.log(`\n  Season ${season} (${leagueRosters.length} rosters):`);
+
+        // Compute MOS for this league
+        const leagueMOS = await computeLeagueMOS(leagueId, undefined, db);
+        const mosMap = new Map(leagueMOS.map((m) => [m.rosterId, m.mos]));
 
         const tableRows: (string | number)[][] = [];
         const seasonKey = `${family.name}:${season}`;
@@ -186,6 +191,7 @@ runExperiment({
           const productions: number[] = [];
           const winPcts: number[] = [];
           const fpts: number[] = [];
+          const mosVals: number[] = [];
 
           for (const roster of leagueRosters) {
             const prod = rosterProductions.get(roster.rosterId) ?? 0;
@@ -195,17 +201,21 @@ runExperiment({
             productions.push(prod);
             winPcts.push(winPct);
             fpts.push(roster.fpts ?? 0);
+            mosVals.push(mosMap.get(roster.rosterId) ?? 0);
           }
 
           const corrWin = spearmanCorrelation(productions, winPcts);
           const corrFpts = spearmanCorrelation(productions, fpts);
+          const corrMOS = spearmanCorrelation(productions, mosVals);
 
           const corrWinRounded = Math.round(corrWin * 1000) / 1000;
           const corrFptsRounded = Math.round(corrFpts * 1000) / 1000;
+          const corrMOSRounded = Math.round(corrMOS * 1000) / 1000;
 
           allMetrics[seasonKey][config.name] = {
             corrWinPct: corrWinRounded,
             corrFpts: corrFptsRounded,
+            corrMOS: corrMOSRounded,
           };
 
           tableRows.push([
@@ -213,11 +223,12 @@ runExperiment({
             leagueRosters.length,
             corrWin.toFixed(3),
             corrFpts.toFixed(3),
+            corrMOS.toFixed(3),
           ]);
         }
 
         printTable(
-          ["Config", "Rosters", "Corr(prod,winPct)", "Corr(prod,fpts)"],
+          ["Config", "Rosters", "Corr(prod,winPct)", "Corr(prod,fpts)", "Corr(prod,MOS)"],
           tableRows,
         );
 
@@ -230,6 +241,7 @@ runExperiment({
             rosters: row[1],
             corrWinPct: row[2],
             corrFpts: row[3],
+            corrMOS: row[4],
           });
         }
       }

--- a/scripts/experiments/05-mos-weights.ts
+++ b/scripts/experiments/05-mos-weights.ts
@@ -33,8 +33,8 @@ import {
 } from "../../src/services/outcomeScore";
 
 const WEIGHT_VECTORS: (MOSWeights & { name: string })[] = [
-  { name: "baseline",       winPct: 0.40, starter: 0.30, playoff: 0.20, champ: 0.10 },
-  { name: "starter-heavy",  winPct: 0.30, starter: 0.40, playoff: 0.20, champ: 0.10 },
+  { name: "baseline",       winPct: 0.30, starter: 0.40, playoff: 0.20, champ: 0.10 },
+  { name: "wins-heavy",     winPct: 0.40, starter: 0.30, playoff: 0.20, champ: 0.10 },
   { name: "wins-dominant",  winPct: 0.50, starter: 0.25, playoff: 0.15, champ: 0.10 },
   { name: "playoff-heavy",  winPct: 0.30, starter: 0.20, playoff: 0.35, champ: 0.15 },
   { name: "equal",          winPct: 0.25, starter: 0.25, playoff: 0.25, champ: 0.25 },

--- a/scripts/experiments/05-mos-weights.ts
+++ b/scripts/experiments/05-mos-weights.ts
@@ -1,0 +1,227 @@
+/**
+ * Experiment 5: MOS Weight Sensitivity
+ *
+ * Hypothesis: The baseline weights (40/30/20/10) produce MOS distributions
+ * with the best discrimination (entropy) and cross-season stability
+ * (correlation of manager MOS across consecutive seasons).
+ *
+ * Method:
+ *   For each weight vector, compute MOS for all rosters across all family
+ *   league seasons. Measure:
+ *     1. Shannon entropy of MOS distribution (higher = better discrimination)
+ *     2. Spearman correlation of owner MOS between consecutive seasons
+ *        (higher = more stable signal, not noise)
+ *     3. Descriptive stats (min, max, mean, stddev)
+ *
+ * Usage: npx tsx scripts/experiments/05-mos-weights.ts
+ */
+
+import { eq } from "drizzle-orm";
+import {
+  runExperiment,
+  db,
+  schema,
+  describeArray,
+  spearmanCorrelation,
+  shannonEntropy,
+  printTable,
+} from "./helpers";
+import {
+  computeLeagueMOS,
+  type MOSWeights,
+  type ManagerOutcomeScore,
+} from "../../src/services/outcomeScore";
+
+const WEIGHT_VECTORS: (MOSWeights & { name: string })[] = [
+  { name: "baseline",       winPct: 0.40, starter: 0.30, playoff: 0.20, champ: 0.10 },
+  { name: "starter-heavy",  winPct: 0.30, starter: 0.40, playoff: 0.20, champ: 0.10 },
+  { name: "wins-dominant",  winPct: 0.50, starter: 0.25, playoff: 0.15, champ: 0.10 },
+  { name: "playoff-heavy",  winPct: 0.30, starter: 0.20, playoff: 0.35, champ: 0.15 },
+  { name: "equal",          winPct: 0.25, starter: 0.25, playoff: 0.25, champ: 0.25 },
+];
+
+/**
+ * Discretize MOS values into bins for entropy calculation.
+ * Uses 10 equal-width bins from 0 to 1.
+ */
+function discretizeMOS(scores: number[]): string[] {
+  return scores.map((s) => {
+    const bin = Math.min(Math.floor(s * 10), 9);
+    return `${(bin / 10).toFixed(1)}-${((bin + 1) / 10).toFixed(1)}`;
+  });
+}
+
+/**
+ * Compute cross-season stability: for owners who appear in consecutive seasons,
+ * correlate their MOS scores.
+ */
+function crossSeasonCorrelation(
+  scores: ManagerOutcomeScore[],
+  familyMembers: { leagueId: string; season: string }[],
+  rosterOwners: Map<string, string>, // "leagueId:rosterId" -> ownerId
+): number {
+  // Group scores by season
+  const bySeason = new Map<string, ManagerOutcomeScore[]>();
+  for (const s of scores) {
+    const arr = bySeason.get(s.season) ?? [];
+    arr.push(s);
+    bySeason.set(s.season, arr);
+  }
+
+  const seasons = [...bySeason.keys()].sort();
+  if (seasons.length < 2) return 0;
+
+  const prevScores: number[] = [];
+  const nextScores: number[] = [];
+
+  for (let i = 0; i < seasons.length - 1; i++) {
+    const prev = bySeason.get(seasons[i]) ?? [];
+    const next = bySeason.get(seasons[i + 1]) ?? [];
+
+    // Build owner -> MOS maps for each season
+    const prevOwnerMOS = new Map<string, number>();
+    for (const s of prev) {
+      const owner = rosterOwners.get(`${s.leagueId}:${s.rosterId}`);
+      if (owner) prevOwnerMOS.set(owner, s.mos);
+    }
+
+    const nextOwnerMOS = new Map<string, number>();
+    for (const s of next) {
+      const owner = rosterOwners.get(`${s.leagueId}:${s.rosterId}`);
+      if (owner) nextOwnerMOS.set(owner, s.mos);
+    }
+
+    // Find overlapping owners
+    for (const [owner, prevMos] of prevOwnerMOS) {
+      const nextMos = nextOwnerMOS.get(owner);
+      if (nextMos !== undefined) {
+        prevScores.push(prevMos);
+        nextScores.push(nextMos);
+      }
+    }
+  }
+
+  if (prevScores.length < 3) return 0;
+  return spearmanCorrelation(prevScores, nextScores);
+}
+
+runExperiment({
+  name: "mos-weight-sensitivity",
+  hypothesis:
+    "The baseline weights (40/30/20/10) produce MOS distributions with the best discrimination (entropy) and cross-season stability",
+  config: {
+    weightVectors: WEIGHT_VECTORS.map((w) => ({
+      name: w.name,
+      weights: { winPct: w.winPct, starter: w.starter, playoff: w.playoff, champ: w.champ },
+    })),
+  },
+  run: async (ctx) => {
+    const families = await ctx.db.select().from(ctx.schema.leagueFamilies);
+    if (families.length === 0) {
+      ctx.log("No league families found.");
+      return { metrics: {}, rawData: [] };
+    }
+
+    // Load all roster owners for cross-season correlation
+    const allRosters = await ctx.db.select({
+      leagueId: schema.rosters.leagueId,
+      rosterId: schema.rosters.rosterId,
+      ownerId: schema.rosters.ownerId,
+    }).from(schema.rosters);
+
+    const rosterOwners = new Map<string, string>();
+    for (const r of allRosters) {
+      if (r.ownerId) {
+        rosterOwners.set(`${r.leagueId}:${r.rosterId}`, r.ownerId);
+      }
+    }
+
+    // Pre-load all family members (doesn't change across weight vectors)
+    const allFamilyMembers: { leagueId: string; season: string }[] = [];
+    const leagueIds: string[] = [];
+    for (const family of families) {
+      const members = await ctx.db
+        .select()
+        .from(ctx.schema.leagueFamilyMembers)
+        .where(eq(ctx.schema.leagueFamilyMembers.familyId, family.id));
+
+      for (const m of members) {
+        allFamilyMembers.push({ leagueId: m.leagueId, season: m.season });
+        leagueIds.push(m.leagueId);
+      }
+    }
+
+    const perVectorMetrics: Record<string, {
+      entropy: number;
+      crossSeasonCorr: number;
+      stats: ReturnType<typeof describeArray>;
+    }> = {};
+
+    const tableRows: (string | number)[][] = [];
+
+    for (const weightVector of WEIGHT_VECTORS) {
+      ctx.log(`\n--- Weight vector: ${weightVector.name} ---`);
+      ctx.log(`  winPct=${weightVector.winPct} starter=${weightVector.starter} playoff=${weightVector.playoff} champ=${weightVector.champ}`);
+
+      const allScores: ManagerOutcomeScore[] = [];
+
+      for (const lid of leagueIds) {
+        const leagueMOS = await computeLeagueMOS(lid, weightVector, db);
+        allScores.push(...leagueMOS);
+      }
+
+      if (allScores.length === 0) {
+        ctx.log("  No scores computed.");
+        continue;
+      }
+
+      const mosValues = allScores.map((s) => s.mos);
+      const stats = describeArray(mosValues);
+      const entropy = shannonEntropy(discretizeMOS(mosValues));
+      const crossCorr = crossSeasonCorrelation(
+        allScores,
+        allFamilyMembers,
+        rosterOwners,
+      );
+
+      ctx.log(`  Rosters: ${allScores.length}`);
+      ctx.log(`  Entropy: ${entropy.toFixed(3)}`);
+      ctx.log(`  Cross-season corr: ${crossCorr.toFixed(3)}`);
+      ctx.log(`  Mean: ${stats.mean.toFixed(3)}, StdDev: ${stats.stddev.toFixed(3)}`);
+
+      perVectorMetrics[weightVector.name] = { entropy, crossSeasonCorr: crossCorr, stats };
+      tableRows.push([
+        weightVector.name,
+        allScores.length,
+        entropy.toFixed(3),
+        crossCorr.toFixed(3),
+        stats.mean,
+        stats.stddev,
+        stats.min,
+        stats.max,
+      ]);
+    }
+
+    if (tableRows.length > 0) {
+      ctx.log("\n--- Summary ---");
+      printTable(
+        ["Weights", "Rosters", "Entropy", "CrossCorr", "Mean", "StdDev", "Min", "Max"],
+        tableRows,
+      );
+    }
+
+    return {
+      metrics: perVectorMetrics,
+      rawData: tableRows.map((r) => ({
+        name: r[0],
+        rosters: r[1],
+        entropy: r[2],
+        crossSeasonCorr: r[3],
+        mean: r[4],
+        stddev: r[5],
+        min: r[6],
+        max: r[7],
+      })),
+    };
+  },
+});

--- a/scripts/experiments/05-mos-weights.ts
+++ b/scripts/experiments/05-mos-weights.ts
@@ -57,7 +57,6 @@ function discretizeMOS(scores: number[]): string[] {
  */
 function crossSeasonCorrelation(
   scores: ManagerOutcomeScore[],
-  familyMembers: { leagueId: string; season: string }[],
   rosterOwners: Map<string, string>, // "leagueId:rosterId" -> ownerId
 ): number {
   // Group scores by season
@@ -136,9 +135,8 @@ runExperiment({
       }
     }
 
-    // Pre-load all family members (doesn't change across weight vectors)
-    const allFamilyMembers: { leagueId: string; season: string }[] = [];
-    const leagueIds: string[] = [];
+    // Collect unique league IDs across all families
+    const leagueIdSet = new Set<string>();
     for (const family of families) {
       const members = await ctx.db
         .select()
@@ -146,10 +144,10 @@ runExperiment({
         .where(eq(ctx.schema.leagueFamilyMembers.familyId, family.id));
 
       for (const m of members) {
-        allFamilyMembers.push({ leagueId: m.leagueId, season: m.season });
-        leagueIds.push(m.leagueId);
+        leagueIdSet.add(m.leagueId);
       }
     }
+    const leagueIds = [...leagueIdSet];
 
     const perVectorMetrics: Record<string, {
       entropy: number;
@@ -180,7 +178,6 @@ runExperiment({
       const entropy = shannonEntropy(discretizeMOS(mosValues));
       const crossCorr = crossSeasonCorrelation(
         allScores,
-        allFamilyMembers,
         rosterOwners,
       );
 

--- a/src/services/outcomeScore.ts
+++ b/src/services/outcomeScore.ts
@@ -1,0 +1,295 @@
+/**
+ * Manager Outcome Score (MOS)
+ *
+ * A 0-to-1 composite metric measuring how well a manager's season went.
+ * Used as ground truth for experiment validation — better grading algorithms
+ * should produce grades that correlate more strongly with MOS.
+ *
+ * Components (default weights):
+ *   40% win percentage — most data-rich, least luck-dependent
+ *   30% starter contribution — total starter points vs league best
+ *   20% playoff advancement — rounds won / total playoff rounds
+ *   10% championship result — champion, runner-up, semifinal loss
+ */
+
+import { getDb, schema } from "@/db";
+import { eq } from "drizzle-orm";
+import type { SleeperBracketMatchup } from "@/lib/sleeper";
+import { extractBracketRosterIds } from "./gradingCore";
+
+// ============================================================
+// Types
+// ============================================================
+
+export interface MOSWeights {
+  winPct: number;
+  starter: number;
+  playoff: number;
+  champ: number;
+}
+
+export const DEFAULT_WEIGHTS: MOSWeights = {
+  winPct: 0.4,
+  starter: 0.3,
+  playoff: 0.2,
+  champ: 0.1,
+};
+
+export interface ManagerOutcomeScore {
+  rosterId: number;
+  leagueId: string;
+  season: string;
+  mos: number;
+  components: {
+    winPct: number;
+    starterScore: number;
+    playoffScore: number;
+    champScore: number;
+  };
+}
+
+export interface PlayoffResult {
+  rosterId: number;
+  roundsWon: number;
+  totalRounds: number;
+  /** 1 = champion, 2 = runner-up, 3-4 = semifinal loss, etc. */
+  placement: number | null;
+}
+
+// ============================================================
+// Bracket parsing
+// ============================================================
+
+/**
+ * Parse a Sleeper winners bracket to determine playoff results per roster.
+ *
+ * The bracket is an array of matchups with round (r), winner (w), loser (l),
+ * and optional placement (p) fields. We walk the bracket to count rounds won
+ * per roster and determine final placement.
+ */
+export function parsePlayoffResults(
+  bracket: SleeperBracketMatchup[],
+  numPlayoffTeams: number,
+): PlayoffResult[] {
+  if (!bracket || bracket.length === 0) return [];
+
+  const totalRounds = Math.ceil(Math.log2(Math.max(2, numPlayoffTeams)));
+
+  const rosterIds = extractBracketRosterIds(bracket);
+
+  // Count rounds won per roster
+  const roundsWon = new Map<number, number>();
+  for (const id of rosterIds) {
+    roundsWon.set(id, 0);
+  }
+
+  for (const m of bracket) {
+    if (m.w !== null && m.w !== undefined) {
+      roundsWon.set(m.w, (roundsWon.get(m.w) ?? 0) + 1);
+    }
+  }
+
+  // Determine placement from bracket data
+  // Sleeper sometimes provides `p` field, otherwise derive from bracket structure
+  const placements = new Map<number, number>();
+
+  // Check for explicit placement fields first
+  for (const m of bracket) {
+    if (m.p !== undefined && m.p !== null) {
+      if (m.w !== null && m.w !== undefined) {
+        // Winner of a placement match gets placement p
+        placements.set(m.w, m.p);
+      }
+      if (m.l !== null && m.l !== undefined) {
+        // Loser of a placement match gets p+1
+        placements.set(m.l, m.p + 1);
+      }
+    }
+  }
+
+  // If no explicit placements, derive from bracket structure
+  if (placements.size === 0) {
+    // Find the final round (highest r value)
+    const maxRound = Math.max(...bracket.map((m) => m.r));
+    const finalMatch = bracket.find((m) => m.r === maxRound);
+
+    if (finalMatch) {
+      if (finalMatch.w !== null && finalMatch.w !== undefined) {
+        placements.set(finalMatch.w, 1); // champion
+      }
+      if (finalMatch.l !== null && finalMatch.l !== undefined) {
+        placements.set(finalMatch.l, 2); // runner-up
+      }
+    }
+
+    // Semifinal losers (lost in round before final)
+    const semiFinalMatches = bracket.filter((m) => m.r === maxRound - 1);
+    for (const m of semiFinalMatches) {
+      if (m.l !== null && m.l !== undefined && !placements.has(m.l)) {
+        placements.set(m.l, 3); // semifinal loss (3rd-4th)
+      }
+    }
+  }
+
+  return Array.from(rosterIds).map((id) => ({
+    rosterId: id,
+    roundsWon: roundsWon.get(id) ?? 0,
+    totalRounds,
+    placement: placements.get(id) ?? null,
+  }));
+}
+
+/**
+ * Convert a playoff placement to a championship score (0-1).
+ */
+function champScoreFromPlacement(placement: number | null): number {
+  if (placement === null) return 0;
+  if (placement === 1) return 1.0; // champion
+  if (placement === 2) return 0.5; // runner-up
+  if (placement <= 4) return 0.25; // semifinal loss
+  return 0;
+}
+
+// ============================================================
+// MOS computation
+// ============================================================
+
+/**
+ * Compute MOS for all rosters in a single league.
+ */
+export async function computeLeagueMOS(
+  leagueId: string,
+  weights: MOSWeights = DEFAULT_WEIGHTS,
+  dbOverride?: ReturnType<typeof getDb>,
+): Promise<ManagerOutcomeScore[]> {
+  const db = dbOverride ?? getDb();
+
+  // Load league metadata
+  const [league] = await db
+    .select({
+      id: schema.leagues.id,
+      season: schema.leagues.season,
+      settings: schema.leagues.settings,
+      winnersBracket: schema.leagues.winnersBracket,
+    })
+    .from(schema.leagues)
+    .where(eq(schema.leagues.id, leagueId));
+
+  if (!league) return [];
+
+  // Load rosters
+  const rosters = await db
+    .select({
+      rosterId: schema.rosters.rosterId,
+      wins: schema.rosters.wins,
+      losses: schema.rosters.losses,
+      ties: schema.rosters.ties,
+    })
+    .from(schema.rosters)
+    .where(eq(schema.rosters.leagueId, leagueId));
+
+  if (rosters.length === 0) return [];
+
+  // Load matchups to compute starter point totals
+  const matchups = await db
+    .select({
+      rosterId: schema.matchups.rosterId,
+      starterPoints: schema.matchups.starterPoints,
+    })
+    .from(schema.matchups)
+    .where(eq(schema.matchups.leagueId, leagueId));
+
+  // Sum starter points per roster
+  const starterTotals = new Map<number, number>();
+  for (const m of matchups) {
+    const pts = m.starterPoints as number[] | null;
+    if (!pts) continue;
+    const weekTotal = pts.reduce((sum, p) => sum + (p ?? 0), 0);
+    starterTotals.set(
+      m.rosterId,
+      (starterTotals.get(m.rosterId) ?? 0) + weekTotal,
+    );
+  }
+
+  const maxStarterTotal = Math.max(...starterTotals.values(), 1);
+
+  // Parse playoff results
+  const settings = league.settings as Record<string, unknown> | null;
+  const numPlayoffTeams = (settings?.playoff_teams as number) ?? 6;
+  const bracket = league.winnersBracket as SleeperBracketMatchup[] | null;
+
+  const playoffResults = bracket && bracket.length > 0
+    ? parsePlayoffResults(bracket, numPlayoffTeams)
+    : [];
+
+  const playoffMap = new Map(playoffResults.map((r) => [r.rosterId, r]));
+
+  // Check if playoff/champ data is available
+  const hasPlayoffData = playoffResults.length > 0;
+
+  // Normalize weights if playoff data is missing
+  let effectiveWeights = weights;
+  if (!hasPlayoffData) {
+    // Redistribute playoff + champ weight to winPct and starter
+    const redistributed = weights.playoff + weights.champ;
+    const remaining = weights.winPct + weights.starter;
+    effectiveWeights = {
+      winPct: weights.winPct + (redistributed * weights.winPct) / remaining,
+      starter: weights.starter + (redistributed * weights.starter) / remaining,
+      playoff: 0,
+      champ: 0,
+    };
+  }
+
+  return rosters.map((roster) => {
+    const totalGames =
+      (roster.wins ?? 0) + (roster.losses ?? 0) + (roster.ties ?? 0);
+    const winPct =
+      totalGames > 0
+        ? ((roster.wins ?? 0) + (roster.ties ?? 0) * 0.5) / totalGames
+        : 0;
+
+    const starterScore =
+      (starterTotals.get(roster.rosterId) ?? 0) / maxStarterTotal;
+
+    const pr = playoffMap.get(roster.rosterId);
+    const playoffScore = pr ? pr.roundsWon / pr.totalRounds : 0;
+    const champScore = pr ? champScoreFromPlacement(pr.placement) : 0;
+
+    const mos =
+      effectiveWeights.winPct * winPct +
+      effectiveWeights.starter * starterScore +
+      effectiveWeights.playoff * playoffScore +
+      effectiveWeights.champ * champScore;
+
+    return {
+      rosterId: roster.rosterId,
+      leagueId,
+      season: league.season,
+      mos,
+      components: { winPct, starterScore, playoffScore, champScore },
+    };
+  });
+}
+
+/**
+ * Compute MOS for all leagues in a family (cross-season).
+ */
+export async function computeFamilyMOS(
+  familyId: string,
+  weights: MOSWeights = DEFAULT_WEIGHTS,
+  dbOverride?: ReturnType<typeof getDb>,
+): Promise<ManagerOutcomeScore[]> {
+  const db = dbOverride ?? getDb();
+
+  const members = await db
+    .select({ leagueId: schema.leagueFamilyMembers.leagueId })
+    .from(schema.leagueFamilyMembers)
+    .where(eq(schema.leagueFamilyMembers.familyId, familyId));
+
+  const allResults = await Promise.all(
+    members.map((member) => computeLeagueMOS(member.leagueId, weights, db)),
+  );
+
+  return allResults.flat();
+}

--- a/src/services/outcomeScore.ts
+++ b/src/services/outcomeScore.ts
@@ -88,15 +88,39 @@ export function parsePlayoffResults(
   }
 
   for (const m of bracket) {
+    // Skip consolation/placement matches (3rd place, 5th place, etc.)
+    // These don't represent advancement in the championship bracket.
+    // Championship match (p=1) and runner-up (p=2 via loss) still count.
+    const isConsolation = m.p !== undefined && m.p !== null && m.p >= 3;
+    if (isConsolation) continue;
+
     if (m.w !== null && m.w !== undefined) {
-      // Winner advanced past this round
       const current = roundsAdvanced.get(m.w) ?? 0;
       roundsAdvanced.set(m.w, Math.max(current, m.r));
     }
     if (m.l !== null && m.l !== undefined) {
-      // Loser advanced past rounds before this one
       const current = roundsAdvanced.get(m.l) ?? 0;
       roundsAdvanced.set(m.l, Math.max(current, m.r - 1));
+    }
+  }
+
+  // Credit bye teams for advancing past the round(s) they skipped.
+  // Detect as rosters whose first main-bracket appearance is round 2+.
+  const firstAppearance = new Map<number, number>();
+  for (const m of bracket) {
+    const isConsolation = m.p !== undefined && m.p !== null && m.p >= 3;
+    if (isConsolation) continue;
+    for (const id of [m.t1, m.t2, m.w, m.l]) {
+      if (typeof id === "number") {
+        const current = firstAppearance.get(id) ?? Infinity;
+        firstAppearance.set(id, Math.min(current, m.r));
+      }
+    }
+  }
+  for (const [id, firstRound] of firstAppearance) {
+    if (firstRound > 1) {
+      const current = roundsAdvanced.get(id) ?? 0;
+      roundsAdvanced.set(id, Math.max(current, firstRound - 1));
     }
   }
 

--- a/src/services/outcomeScore.ts
+++ b/src/services/outcomeScore.ts
@@ -6,8 +6,8 @@
  * should produce grades that correlate more strongly with MOS.
  *
  * Components (default weights):
- *   40% win percentage — most data-rich, least luck-dependent
- *   30% starter contribution — total starter points vs league best
+ *   40% starter contribution — purest signal of roster-building quality
+ *   30% win percentage — data-rich but influenced by matchup scheduling luck
  *   20% playoff advancement — rounds won / total playoff rounds
  *   10% championship result — champion, runner-up, semifinal loss
  */
@@ -29,8 +29,8 @@ export interface MOSWeights {
 }
 
 export const DEFAULT_WEIGHTS: MOSWeights = {
-  winPct: 0.4,
-  starter: 0.3,
+  winPct: 0.3,
+  starter: 0.4,
   playoff: 0.2,
   champ: 0.1,
 };

--- a/src/services/outcomeScore.ts
+++ b/src/services/outcomeScore.ts
@@ -77,15 +77,26 @@ export function parsePlayoffResults(
 
   const rosterIds = extractBracketRosterIds(bracket);
 
-  // Count rounds won per roster
-  const roundsWon = new Map<number, number>();
+  // Track the highest round each roster advanced past.
+  // A winner of round R advanced past R (they move to R+1).
+  // A loser of round R was eliminated at R (advanced past R-1 rounds).
+  // This correctly handles byes — a team with a bye in round 1
+  // that wins in round 2 advanced past 2 rounds, same as totalRounds-1.
+  const roundsAdvanced = new Map<number, number>();
   for (const id of rosterIds) {
-    roundsWon.set(id, 0);
+    roundsAdvanced.set(id, 0);
   }
 
   for (const m of bracket) {
     if (m.w !== null && m.w !== undefined) {
-      roundsWon.set(m.w, (roundsWon.get(m.w) ?? 0) + 1);
+      // Winner advanced past this round
+      const current = roundsAdvanced.get(m.w) ?? 0;
+      roundsAdvanced.set(m.w, Math.max(current, m.r));
+    }
+    if (m.l !== null && m.l !== undefined) {
+      // Loser advanced past rounds before this one
+      const current = roundsAdvanced.get(m.l) ?? 0;
+      roundsAdvanced.set(m.l, Math.max(current, m.r - 1));
     }
   }
 
@@ -133,7 +144,7 @@ export function parsePlayoffResults(
 
   return Array.from(rosterIds).map((id) => ({
     rosterId: id,
-    roundsWon: roundsWon.get(id) ?? 0,
+    roundsWon: roundsAdvanced.get(id) ?? 0,
     totalRounds,
     placement: placements.get(id) ?? null,
   }));

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -356,7 +356,7 @@ export async function syncLeague(
   if (playoffStart && maxWeek >= playoffStart) {
     try {
       const bracket = await Sleeper.getWinnersBracket(leagueId);
-      if (bracket?.length > 0) {
+      if (bracket?.length > 0 && bracket.some((m) => m.w !== null)) {
         await db.update(schema.leagues)
           .set({ winnersBracket: bracket })
           .where(eq(schema.leagues.id, leagueId));


### PR DESCRIPTION
## Summary

- **MOS** is a 0-to-1 composite metric measuring season outcomes per roster, used as ground truth for experiment validation
- Components: 40% starter contribution, 30% win%, 20% playoff advancement, 10% championship
- Includes Sleeper bracket parsing with correct bye handling and consolation match filtering
- Experiments 01 (PAR vs rank) and 03 (production layers) now correlate against MOS alongside existing metrics
- New experiment 05 tests weight sensitivity across 5 vectors measuring discrimination (entropy) and cross-season stability

## Changes

- `src/services/outcomeScore.ts` — MOS computation, bracket parsing, bye handling
- `scripts/experiments/05-mos-weights.ts` — weight sensitivity experiment
- `scripts/experiments/01-par-vs-rank.ts` — MOS correlation added
- `scripts/experiments/03-production-layers.ts` — MOS correlation added
- `src/services/sync.ts` — guard against storing incomplete bracket data

## Test plan

- [x] Build passes (`npm run build`)
- [x] Bracket parsing verified with synthetic 6-team bracket and all 5 real seasons
- [x] Consolation matches (3rd/5th place) excluded from advancement scoring
- [x] Bye teams correctly credited for skipped rounds
- [x] MOS scores in [0,1] range across 72 rosters, components sum correctly
- [x] Weight sensitivity experiment ran successfully (recorded to DB)
- [x] No-bracket fallback: weight renormalization works for pre-draft seasons
- [x] `seasonalData` scope bug fixed — per-family caching prevents stale data

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)