### PR TITLE
feat: Manager Page — radar chart, grade card, season history

### DIFF
--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -154,14 +154,14 @@ export default function ManagerPage() {
                       </td>
                       {Object.keys(PILLAR_LABELS).map((key) => {
                         const metric = row[key] as
-                          | { value: number; grade: string }
+                          | { value: number; grade: string; percentile: number }
                           | undefined;
                         return (
                           <td key={key} className="px-4 py-3 text-center">
                             {metric ? (
                               <div className="flex items-center justify-center gap-2">
                                 <span className="font-mono text-sm">
-                                  {metric.value}
+                                  {Math.round(metric.percentile)}
                                 </span>
                                 <GradeBadge grade={metric.grade} size="xs" />
                               </div>

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -1,0 +1,236 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useParams } from "next/navigation";
+import Link from "next/link";
+import { GradeBadge } from "@/components/GradeBadge";
+import { ManagerRadarChart } from "@/components/ManagerRadarChart";
+import { ManagerGradeCard } from "@/components/ManagerGradeCard";
+import { PILLAR_LABELS } from "@/lib/pillars";
+
+interface SeasonRow {
+  season: string;
+  [metric: string]: unknown;
+}
+
+interface Transaction {
+  id: string;
+  type: string;
+  season: string;
+  week: number;
+  adds: Array<{ id: string; name: string; position: string | null; team: string | null }>;
+  drops: Array<{ id: string; name: string; position: string | null; team: string | null }>;
+  grade: string | null;
+  score: number | null;
+  createdAt: number | null;
+}
+
+interface ManagerData {
+  manager: {
+    userId: string;
+    displayName: string;
+    teamName: string | null;
+    avatar: string | null;
+  };
+  overallScore: { value: number; grade: string; percentile: number } | null;
+  pillarScores: Record<string, { value: number; grade: string; percentile: number } | null>;
+  seasonHistory: SeasonRow[];
+  recentTransactions: Transaction[];
+  seasons: Array<{ leagueId: string; season: string }>;
+}
+
+export default function ManagerPage() {
+  const params = useParams();
+  const familyId = params.familyId as string;
+  const userId = params.userId as string;
+
+  const [data, setData] = useState<ManagerData | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    async function loadData() {
+      setLoading(true);
+      try {
+        const res = await fetch(`/api/leagues/${familyId}/manager/${userId}`);
+        if (res.ok) {
+          setData(await res.json());
+        }
+      } catch (err) {
+        console.error("Failed to load manager data:", err);
+      } finally {
+        setLoading(false);
+      }
+    }
+    loadData();
+  }, [familyId, userId]);
+
+  if (loading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-pulse text-muted-foreground">
+          Loading manager...
+        </div>
+      </div>
+    );
+  }
+
+  if (!data) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <p className="text-muted-foreground">Manager not found</p>
+      </div>
+    );
+  }
+
+  const { manager, overallScore, pillarScores, seasonHistory, recentTransactions } = data;
+
+  return (
+    <div>
+      {/* Sub-header */}
+      <div className="border-b">
+        <div className="container mx-auto px-6 py-3 flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Link
+              href={`/league/${familyId}`}
+              className="text-sm text-muted-foreground hover:text-primary transition-colors"
+            >
+              &larr; League
+            </Link>
+            <span className="text-muted-foreground">/</span>
+            <h1 className="text-lg font-semibold">
+              {manager.teamName || manager.displayName}
+            </h1>
+            {manager.teamName && manager.displayName !== manager.teamName && (
+              <span className="text-sm text-muted-foreground">
+                {manager.displayName}
+              </span>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <main className="container mx-auto px-6 py-8 space-y-8">
+        {/* Top section: Grade card + Radar chart */}
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+          <ManagerGradeCard
+            overallScore={overallScore}
+            pillarScores={pillarScores}
+          />
+          <div className="border rounded-lg p-4">
+            <h2 className="text-sm font-medium text-muted-foreground mb-2">
+              Manager DNA
+            </h2>
+            <ManagerRadarChart pillarScores={pillarScores} />
+          </div>
+        </div>
+
+        {/* Season History */}
+        {seasonHistory.length > 0 && (
+          <section>
+            <h2 className="text-lg font-semibold mb-4">Season History</h2>
+            <div className="border rounded-lg overflow-hidden">
+              <table className="w-full">
+                <thead className="bg-muted/50">
+                  <tr className="text-left text-sm">
+                    <th className="px-4 py-3 font-medium">Season</th>
+                    {Object.values(PILLAR_LABELS).map((label) => (
+                      <th
+                        key={label}
+                        className="px-4 py-3 font-medium text-center"
+                      >
+                        {label}
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {seasonHistory.map((row) => (
+                    <tr
+                      key={row.season}
+                      className="border-t hover:bg-muted/30 transition-colors"
+                    >
+                      <td className="px-4 py-3 font-mono text-sm">
+                        {row.season}
+                      </td>
+                      {Object.keys(PILLAR_LABELS).map((key) => {
+                        const metric = row[key] as
+                          | { value: number; grade: string }
+                          | undefined;
+                        return (
+                          <td key={key} className="px-4 py-3 text-center">
+                            {metric ? (
+                              <div className="flex items-center justify-center gap-2">
+                                <span className="font-mono text-sm">
+                                  {metric.value}
+                                </span>
+                                <GradeBadge grade={metric.grade} size="xs" />
+                              </div>
+                            ) : (
+                              <span className="text-xs text-muted-foreground">
+                                --
+                              </span>
+                            )}
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </section>
+        )}
+
+        {/* Recent Transactions */}
+        {recentTransactions.length > 0 && (
+          <section>
+            <h2 className="text-lg font-semibold mb-4">
+              Recent Transactions
+            </h2>
+            <div className="space-y-3">
+              {recentTransactions.map((tx) => (
+                <div
+                  key={tx.id}
+                  className="border rounded-lg px-4 py-3 flex items-start justify-between gap-4"
+                >
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2 mb-1">
+                      <span
+                        className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+                          tx.type === "trade"
+                            ? "bg-purple-500/15 text-purple-400"
+                            : "bg-amber-500/15 text-amber-400"
+                        }`}
+                      >
+                        {tx.type === "free_agent" ? "FA" : tx.type}
+                      </span>
+                      <span className="text-xs text-muted-foreground">
+                        {tx.season} W{tx.week}
+                      </span>
+                    </div>
+                    <div className="text-sm">
+                      {tx.adds.length > 0 && (
+                        <span className="text-emerald-400">
+                          +{tx.adds.map((p) => p.name).join(", ")}
+                        </span>
+                      )}
+                      {tx.adds.length > 0 && tx.drops.length > 0 && (
+                        <span className="text-muted-foreground mx-1">/</span>
+                      )}
+                      {tx.drops.length > 0 && (
+                        <span className="text-red-400">
+                          -{tx.drops.map((p) => p.name).join(", ")}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                  {tx.grade && <GradeBadge grade={tx.grade} size="xs" />}
+                </div>
+              ))}
+            </div>
+          </section>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -161,7 +161,7 @@ export default function ManagerPage() {
                             {metric ? (
                               <div className="flex items-center justify-center gap-2">
                                 <span className="font-mono text-sm">
-                                  {Math.round(metric.percentile)}
+                                  {Math.round(metric.percentile)}%
                                 </span>
                                 <GradeBadge grade={metric.grade} size="xs" />
                               </div>

--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -1,0 +1,296 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getDb, schema } from "@/db";
+import { eq, and, inArray, desc } from "drizzle-orm";
+import { resolveFamily } from "@/lib/familyResolution";
+
+export async function GET(
+  req: NextRequest,
+  { params }: { params: Promise<{ familyId: string; userId: string }> },
+) {
+  try {
+    const { familyId: rawFamilyId, userId } = await params;
+    const db = getDb();
+
+    // Resolve familyId (supports both UUID and rootLeagueId)
+    const familyId = await resolveFamily(rawFamilyId);
+    if (!familyId) {
+      return NextResponse.json(
+        { error: "League family not found" },
+        { status: 404 },
+      );
+    }
+
+    const members = await db
+      .select()
+      .from(schema.leagueFamilyMembers)
+      .where(eq(schema.leagueFamilyMembers.familyId, familyId));
+
+    if (members.length === 0) {
+      return NextResponse.json(
+        { error: "League family not found" },
+        { status: 404 },
+      );
+    }
+
+    const leagueIds = members.map((m) => m.leagueId);
+
+    // Load user info, metrics, transactions, and rosters in parallel
+    const [users, allMetrics, recentTx, rosters] = await Promise.all([
+      db
+        .select()
+        .from(schema.leagueUsers)
+        .where(
+          and(
+            inArray(schema.leagueUsers.leagueId, leagueIds),
+            eq(schema.leagueUsers.userId, userId),
+          ),
+        ),
+      db
+        .select()
+        .from(schema.managerMetrics)
+        .where(eq(schema.managerMetrics.managerId, userId)),
+      db
+        .select({
+          id: schema.transactions.id,
+          type: schema.transactions.type,
+          leagueId: schema.transactions.leagueId,
+          week: schema.transactions.week,
+          adds: schema.transactions.adds,
+          drops: schema.transactions.drops,
+          createdAt: schema.transactions.createdAt,
+        })
+        .from(schema.transactions)
+        .where(
+          and(
+            inArray(schema.transactions.leagueId, leagueIds),
+            inArray(schema.transactions.type, [
+              "trade",
+              "waiver",
+              "free_agent",
+            ]),
+          ),
+        )
+        .orderBy(desc(schema.transactions.createdAt))
+        .limit(200),
+      db
+        .select({
+          leagueId: schema.rosters.leagueId,
+          rosterId: schema.rosters.rosterId,
+        })
+        .from(schema.rosters)
+        .where(
+          and(
+            inArray(schema.rosters.leagueId, leagueIds),
+            eq(schema.rosters.ownerId, userId),
+          ),
+        ),
+    ]);
+
+    const user = users[0];
+    if (!user) {
+      return NextResponse.json(
+        { error: "Manager not found" },
+        { status: 404 },
+      );
+    }
+
+    const managerRosterIds = new Set(
+      rosters.map((r) => `${r.leagueId}:${r.rosterId}`),
+    );
+
+    // Filter transactions to those involving this manager
+    const managerTx = recentTx.filter((tx) => {
+      const adds = (tx.adds || {}) as Record<string, number>;
+      const drops = (tx.drops || {}) as Record<string, number>;
+      for (const rid of Object.values(adds)) {
+        if (managerRosterIds.has(`${tx.leagueId}:${rid}`)) return true;
+      }
+      for (const rid of Object.values(drops)) {
+        if (managerRosterIds.has(`${tx.leagueId}:${rid}`)) return true;
+      }
+      return false;
+    }).slice(0, 10);
+
+    // Parse metrics into structured response
+    const pillarTypes = [
+      "trade_score",
+      "draft_score",
+      "waiver_score",
+      "lineup_score",
+    ];
+
+    // All-time pillar scores
+    const pillarScores: Record<
+      string,
+      { value: number; grade: string; percentile: number } | null
+    > = {};
+    for (const pillar of pillarTypes) {
+      const m = allMetrics.find(
+        (r) => r.metric === pillar && r.scope === "all_time",
+      );
+      if (m) {
+        const meta = m.meta as Record<string, unknown> | null;
+        pillarScores[pillar] = {
+          value: m.value,
+          grade: (meta?.grade as string) ?? "",
+          percentile: m.percentile ?? 0,
+        };
+      } else {
+        pillarScores[pillar] = null;
+      }
+    }
+
+    // Overall score
+    const overallMetric = allMetrics.find(
+      (r) => r.metric === "overall_score" && r.scope === "all_time",
+    );
+    const overallMeta = overallMetric?.meta as Record<string, unknown> | null;
+    const overallScore = overallMetric
+      ? {
+          value: overallMetric.value,
+          grade: (overallMeta?.grade as string) ?? "",
+          percentile: overallMetric.percentile ?? 0,
+        }
+      : null;
+
+    // Season history — group season-scoped metrics by season
+    const leagueToSeason = new Map(
+      members.map((m) => [m.leagueId, m.season]),
+    );
+    const seasonMetrics = allMetrics.filter((r) =>
+      r.scope.startsWith("season:"),
+    );
+
+    const seasonMap = new Map<
+      string,
+      Record<string, { value: number; grade: string }>
+    >();
+    for (const m of seasonMetrics) {
+      const season = m.scope.replace("season:", "");
+      if (!seasonMap.has(season)) seasonMap.set(season, {});
+      const meta = m.meta as Record<string, unknown> | null;
+      seasonMap.get(season)![m.metric] = {
+        value: m.value,
+        grade: (meta?.grade as string) ?? "",
+      };
+    }
+
+    const seasonHistory = Array.from(seasonMap.entries())
+      .map(([season, metrics]) => ({ season, ...metrics }))
+      .sort((a, b) => b.season.localeCompare(a.season));
+
+    // Load player names for transaction display
+    const playerIds = new Set<string>();
+    for (const tx of managerTx) {
+      const adds = (tx.adds || {}) as Record<string, number>;
+      const drops = (tx.drops || {}) as Record<string, number>;
+      for (const pid of Object.keys(adds)) playerIds.add(pid);
+      for (const pid of Object.keys(drops)) playerIds.add(pid);
+    }
+
+    const players =
+      playerIds.size > 0
+        ? await db
+            .select({
+              id: schema.players.id,
+              firstName: schema.players.firstName,
+              lastName: schema.players.lastName,
+              position: schema.players.position,
+              team: schema.players.team,
+            })
+            .from(schema.players)
+            .where(inArray(schema.players.id, [...playerIds]))
+        : [];
+
+    const playerMap = new Map(
+      players.map((p) => [
+        p.id,
+        {
+          id: p.id,
+          name: [p.firstName, p.lastName].filter(Boolean).join(" ") || p.id,
+          position: p.position,
+          team: p.team,
+        },
+      ]),
+    );
+
+    // Load trade + waiver grades for these transactions
+    const txIds = managerTx.map((tx) => tx.id);
+    const [tradeGrades, waiverGrades] =
+      txIds.length > 0
+        ? await Promise.all([
+            db
+              .select({
+                transactionId: schema.tradeGrades.transactionId,
+                rosterId: schema.tradeGrades.rosterId,
+                grade: schema.tradeGrades.grade,
+                blendedScore: schema.tradeGrades.blendedScore,
+              })
+              .from(schema.tradeGrades)
+              .where(inArray(schema.tradeGrades.transactionId, txIds)),
+            db
+              .select({
+                transactionId: schema.waiverGrades.transactionId,
+                rosterId: schema.waiverGrades.rosterId,
+                grade: schema.waiverGrades.grade,
+                blendedScore: schema.waiverGrades.blendedScore,
+              })
+              .from(schema.waiverGrades)
+              .where(inArray(schema.waiverGrades.transactionId, txIds)),
+          ])
+        : [[], []];
+
+    const txLeagueMap = new Map(managerTx.map((t) => [t.id, t.leagueId]));
+    const gradeMap = new Map<string, { grade: string; score: number }>();
+    for (const g of [...tradeGrades, ...waiverGrades]) {
+      const txLeagueId = txLeagueMap.get(g.transactionId);
+      if (txLeagueId && managerRosterIds.has(`${txLeagueId}:${g.rosterId}`)) {
+        gradeMap.set(g.transactionId, {
+          grade: g.grade ?? "",
+          score: g.blendedScore ?? 0,
+        });
+      }
+    }
+
+    const enrichedTx = managerTx.map((tx) => {
+      const adds = (tx.adds || {}) as Record<string, number>;
+      const drops = (tx.drops || {}) as Record<string, number>;
+      const season = leagueToSeason.get(tx.leagueId) ?? "";
+      const txGrade = gradeMap.get(tx.id);
+
+      return {
+        id: tx.id,
+        type: tx.type,
+        season,
+        week: tx.week,
+        adds: Object.keys(adds).map((pid) => playerMap.get(pid) ?? { id: pid, name: pid, position: null, team: null }),
+        drops: Object.keys(drops).map((pid) => playerMap.get(pid) ?? { id: pid, name: pid, position: null, team: null }),
+        grade: txGrade?.grade ?? null,
+        score: txGrade?.score ?? null,
+        createdAt: tx.createdAt,
+      };
+    });
+
+    return NextResponse.json({
+      manager: {
+        userId: user.userId,
+        displayName: user.displayName,
+        teamName: user.teamName,
+        avatar: user.avatar,
+      },
+      overallScore,
+      pillarScores,
+      seasonHistory,
+      recentTransactions: enrichedTx,
+      seasons: members
+        .map((m) => ({ leagueId: m.leagueId, season: m.season }))
+        .sort((a, b) => b.season.localeCompare(a.season)),
+    });
+  } catch (err) {
+    console.error("[manager API] Error:", err);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getDb, schema } from "@/db";
 import { eq, and, inArray, desc } from "drizzle-orm";
 import { resolveFamily } from "@/lib/familyResolution";
+import { percentileToGrade } from "@/services/gradingCore";
 
 export async function GET(
   req: NextRequest,
@@ -48,7 +49,7 @@ export async function GET(
       db
         .select()
         .from(schema.managerMetrics)
-        .where(eq(schema.managerMetrics.managerId, userId)),
+        .where(inArray(schema.managerMetrics.leagueId, leagueIds)),
       db
         .select({
           id: schema.transactions.id,
@@ -111,7 +112,7 @@ export async function GET(
       return false;
     }).slice(0, 10);
 
-    // Parse metrics into structured response
+    // Parse metrics — compute global percentiles across all managers
     const pillarTypes = [
       "trade_score",
       "draft_score",
@@ -119,21 +120,40 @@ export async function GET(
       "lineup_score",
     ];
 
-    // All-time pillar scores
+    // Build global score distributions per metric+scope for percentile ranking
+    const globalScores = new Map<string, number[]>(); // "metric:scope" -> sorted values
+    for (const m of allMetrics) {
+      const key = `${m.metric}:${m.scope}`;
+      if (!globalScores.has(key)) globalScores.set(key, []);
+      globalScores.get(key)!.push(m.value);
+    }
+    for (const arr of globalScores.values()) arr.sort((a, b) => a - b);
+
+    function globalPercentile(metric: string, scope: string, value: number): number {
+      const sorted = globalScores.get(`${metric}:${scope}`);
+      if (!sorted || sorted.length <= 1) return 50;
+      const rank = sorted.filter((v) => v < value).length;
+      return Math.round((rank / (sorted.length - 1)) * 1000) / 10;
+    }
+
+    // Filter to this manager's metrics
+    const myMetrics = allMetrics.filter((r) => r.managerId === userId);
+
+    // All-time pillar scores with global percentile grades
     const pillarScores: Record<
       string,
       { value: number; grade: string; percentile: number } | null
     > = {};
     for (const pillar of pillarTypes) {
-      const m = allMetrics.find(
+      const m = myMetrics.find(
         (r) => r.metric === pillar && r.scope === "all_time",
       );
       if (m) {
-        const meta = m.meta as Record<string, unknown> | null;
+        const pctl = globalPercentile(pillar, "all_time", m.value);
         pillarScores[pillar] = {
           value: m.value,
-          grade: (meta?.grade as string) ?? "",
-          percentile: m.percentile ?? 0,
+          grade: percentileToGrade(pctl),
+          percentile: pctl,
         };
       } else {
         pillarScores[pillar] = null;
@@ -141,15 +161,20 @@ export async function GET(
     }
 
     // Overall score
-    const overallMetric = allMetrics.find(
+    const overallMetric = myMetrics.find(
       (r) => r.metric === "overall_score" && r.scope === "all_time",
     );
-    const overallMeta = overallMetric?.meta as Record<string, unknown> | null;
     const overallScore = overallMetric
       ? {
           value: overallMetric.value,
-          grade: (overallMeta?.grade as string) ?? "",
-          percentile: overallMetric.percentile ?? 0,
+          grade: percentileToGrade(
+            globalPercentile("overall_score", "all_time", overallMetric.value),
+          ),
+          percentile: globalPercentile(
+            "overall_score",
+            "all_time",
+            overallMetric.value,
+          ),
         }
       : null;
 
@@ -157,7 +182,7 @@ export async function GET(
     const leagueToSeason = new Map(
       members.map((m) => [m.leagueId, m.season]),
     );
-    const seasonMetrics = allMetrics.filter((r) =>
+    const seasonMetrics = myMetrics.filter((r) =>
       r.scope.startsWith("season:"),
     );
 
@@ -168,11 +193,11 @@ export async function GET(
     for (const m of seasonMetrics) {
       const season = m.scope.replace("season:", "");
       if (!seasonMap.has(season)) seasonMap.set(season, {});
-      const meta = m.meta as Record<string, unknown> | null;
+      const pctl = globalPercentile(m.metric, m.scope, m.value);
       seasonMap.get(season)![m.metric] = {
         value: m.value,
-        grade: (meta?.grade as string) ?? "",
-        percentile: m.percentile ?? 0,
+        grade: percentileToGrade(pctl),
+        percentile: pctl,
       };
     }
 

--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -163,7 +163,7 @@ export async function GET(
 
     const seasonMap = new Map<
       string,
-      Record<string, { value: number; grade: string }>
+      Record<string, { value: number; grade: string; percentile: number }>
     >();
     for (const m of seasonMetrics) {
       const season = m.scope.replace("season:", "");
@@ -172,6 +172,7 @@ export async function GET(
       seasonMap.get(season)![m.metric] = {
         value: m.value,
         grade: (meta?.grade as string) ?? "",
+        percentile: m.percentile ?? 0,
       };
     }
 

--- a/src/components/ManagerGradeCard.tsx
+++ b/src/components/ManagerGradeCard.tsx
@@ -1,0 +1,63 @@
+import { GradeBadge } from "@/components/GradeBadge";
+import { PILLAR_LABELS } from "@/lib/pillars";
+
+interface ManagerGradeCardProps {
+  overallScore: {
+    value: number;
+    grade: string;
+    percentile: number;
+  } | null;
+  pillarScores: Record<
+    string,
+    { value: number; grade: string; percentile: number } | null
+  >;
+}
+
+export function ManagerGradeCard({
+  overallScore,
+  pillarScores,
+}: ManagerGradeCardProps) {
+  if (!overallScore) {
+    return (
+      <div className="border rounded-lg p-6 text-center text-muted-foreground text-sm">
+        No overall score yet — sync league data to generate grades
+      </div>
+    );
+  }
+
+  return (
+    <div className="border rounded-lg p-6">
+      <div className="flex items-center gap-4 mb-6">
+        <div className="text-5xl font-bold">{overallScore.value}</div>
+        <div>
+          <GradeBadge grade={overallScore.grade} size="sm" />
+          <div className="text-xs text-muted-foreground mt-1">
+            Top {Math.round(100 - overallScore.percentile)}%
+          </div>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 gap-3">
+        {Object.entries(PILLAR_LABELS).map(([key, label]) => {
+          const pillar = pillarScores[key];
+          return (
+            <div
+              key={key}
+              className="flex items-center justify-between border rounded px-3 py-2"
+            >
+              <span className="text-sm text-muted-foreground">{label}</span>
+              {pillar ? (
+                <div className="flex items-center gap-2">
+                  <span className="text-sm font-mono">{pillar.value}</span>
+                  <GradeBadge grade={pillar.grade} size="xs" />
+                </div>
+              ) : (
+                <span className="text-xs text-muted-foreground">--</span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ManagerGradeCard.tsx
+++ b/src/components/ManagerGradeCard.tsx
@@ -1,6 +1,12 @@
 import { GradeBadge } from "@/components/GradeBadge";
 import { PILLAR_LABELS } from "@/lib/pillars";
 
+function ordinal(n: number): string {
+  const s = ["th", "st", "nd", "rd"];
+  const v = n % 100;
+  return n + (s[(v - 20) % 10] || s[v] || s[0]);
+}
+
 interface ManagerGradeCardProps {
   overallScore: {
     value: number;
@@ -28,11 +34,11 @@ export function ManagerGradeCard({
   return (
     <div className="border rounded-lg p-6">
       <div className="flex items-center gap-4 mb-6">
-        <div className="text-5xl font-bold">{overallScore.value}</div>
+        <div className="text-5xl font-bold">{ordinal(Math.round(overallScore.percentile))}</div>
         <div>
           <GradeBadge grade={overallScore.grade} size="sm" />
           <div className="text-xs text-muted-foreground mt-1">
-            Top {Math.round(100 - overallScore.percentile)}%
+            Score: {overallScore.value}
           </div>
         </div>
       </div>
@@ -48,7 +54,7 @@ export function ManagerGradeCard({
               <span className="text-sm text-muted-foreground">{label}</span>
               {pillar ? (
                 <div className="flex items-center gap-2">
-                  <span className="text-sm font-mono">{pillar.value}</span>
+                  <span className="text-sm font-mono">{ordinal(Math.round(pillar.percentile))}</span>
                   <GradeBadge grade={pillar.grade} size="xs" />
                 </div>
               ) : (

--- a/src/components/ManagerRadarChart.tsx
+++ b/src/components/ManagerRadarChart.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import {
+  RadarChart,
+  PolarGrid,
+  PolarAngleAxis,
+  PolarRadiusAxis,
+  Radar,
+  ResponsiveContainer,
+} from "recharts";
+
+import { PILLAR_LABELS } from "@/lib/pillars";
+
+interface ManagerRadarChartProps {
+  pillarScores: Record<string, { value: number; grade: string; percentile: number } | null>;
+}
+
+export function ManagerRadarChart({ pillarScores }: ManagerRadarChartProps) {
+  const data = Object.entries(PILLAR_LABELS).map(([key, label]) => ({
+    pillar: label,
+    score: pillarScores[key]?.value ?? 0,
+    fullMark: 100,
+  }));
+
+  const hasData = data.some((d) => d.score > 0);
+  if (!hasData) {
+    return (
+      <div className="flex items-center justify-center h-64 text-muted-foreground text-sm">
+        No grading data yet
+      </div>
+    );
+  }
+
+  return (
+    <ResponsiveContainer width="100%" height={280}>
+      <RadarChart cx="50%" cy="50%" outerRadius="75%" data={data}>
+        <PolarGrid stroke="hsl(var(--border))" />
+        <PolarAngleAxis
+          dataKey="pillar"
+          tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 12 }}
+        />
+        <PolarRadiusAxis
+          angle={90}
+          domain={[0, 100]}
+          tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10 }}
+          tickCount={5}
+        />
+        <Radar
+          name="Score"
+          dataKey="score"
+          stroke="hsl(var(--primary))"
+          fill="hsl(var(--primary))"
+          fillOpacity={0.2}
+          strokeWidth={2}
+        />
+      </RadarChart>
+    </ResponsiveContainer>
+  );
+}

--- a/src/components/ManagerRadarChart.tsx
+++ b/src/components/ManagerRadarChart.tsx
@@ -18,7 +18,7 @@ interface ManagerRadarChartProps {
 export function ManagerRadarChart({ pillarScores }: ManagerRadarChartProps) {
   const data = Object.entries(PILLAR_LABELS).map(([key, label]) => ({
     pillar: label,
-    score: pillarScores[key]?.value ?? 0,
+    score: pillarScores[key]?.percentile ?? 0,
     fullMark: 100,
   }));
 

--- a/src/lib/pillars.ts
+++ b/src/lib/pillars.ts
@@ -1,0 +1,15 @@
+export const PILLAR_KEYS = [
+  "trade_score",
+  "draft_score",
+  "waiver_score",
+  "lineup_score",
+] as const;
+
+export type PillarKey = (typeof PILLAR_KEYS)[number];
+
+export const PILLAR_LABELS: Record<PillarKey, string> = {
+  trade_score: "Trading",
+  draft_score: "Drafting",
+  waiver_score: "Waivers",
+  lineup_score: "Lineups",
+};

--- a/src/services/gradingCore.ts
+++ b/src/services/gradingCore.ts
@@ -283,6 +283,22 @@ export function scoreToGrade(score: number, thresholds?: Record<string, number>)
   return "F";
 }
 
+/**
+ * Assign a letter grade based on global percentile rank.
+ * Used for manager-level display where grades should reflect
+ * standing across all managers in all leagues, not absolute score.
+ */
+export function percentileToGrade(percentile: number): string {
+  if (percentile >= 90) return "A+";
+  if (percentile >= 75) return "A";
+  if (percentile >= 60) return "B+";
+  if (percentile >= 45) return "B";
+  if (percentile >= 30) return "C";
+  if (percentile >= 15) return "D";
+  if (percentile >= 5) return "D-";
+  return "F";
+}
+
 /** Normalize a diff into a 0-100 score centered at 50 */
 export function normalizeScore(diff: number, scaling: number): number {
   return clamp(50 + clamp(diff / scaling, -1, 1) * 50, 0, 100);

--- a/src/services/managerGrades.ts
+++ b/src/services/managerGrades.ts
@@ -134,7 +134,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
   // 4. Compute weighted all_time score per (manager, metric)
   const managerAllTime = new Map<
     string,
-    Map<string, { score: number; seasons: number }>
+    Map<string, { score: number; percentile: number; seasons: number }>
   >();
 
   const metricScores = new Map<string, Array<{ managerId: string; score: number }>>();
@@ -162,6 +162,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     if (!managerAllTime.has(managerId)) managerAllTime.set(managerId, new Map());
     managerAllTime.get(managerId)!.set(metric, {
       score: allTimeScore,
+      percentile: 0, // filled after percentile computation
       seasons: entries.length,
     });
 
@@ -191,7 +192,20 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     });
   }
 
-  // Batch upsert all all_time metrics
+  // Delete stale all_time rows (prevents duplicates across different leagueIds)
+  const allManagerIds = [...managerAllTime.keys()];
+  if (allManagerIds.length > 0) {
+    await db
+      .delete(schema.managerMetrics)
+      .where(
+        and(
+          inArray(schema.managerMetrics.managerId, allManagerIds),
+          eq(schema.managerMetrics.scope, "all_time"),
+        ),
+      );
+  }
+
+  // Batch insert fresh all_time metrics
   await batchUpsertManagerMetrics(allTimeValues);
 
   // 5. Compute percentiles per metric and batch update
@@ -199,6 +213,10 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     const sorted = [...scores].sort((a, b) => a.score - b.score);
     for (const entry of sorted) {
       const percentile = computePercentile(entry, sorted);
+
+      // Store percentile in managerAllTime for overall_score computation
+      const mgrMetric = managerAllTime.get(entry.managerId)?.get(metric);
+      if (mgrMetric) mgrMetric.percentile = percentile;
 
       const groupKey = `${entry.managerId}::${metric}`;
       const entries = grouped.get(groupKey);
@@ -244,12 +262,13 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     const values = Array.from(metrics.entries());
     if (values.length === 0) continue;
 
-    // Weighted overall_score using pillarWeights from config
+    // Weighted overall_score from pillar percentiles (not raw scores)
+    // This ensures pillars on different scales contribute equally
     let weightedSum = 0;
     let totalWeight = 0;
     for (const [metric, data] of values) {
       const weight = pillarWeights[metric] ?? 1;
-      weightedSum += data.score * weight;
+      weightedSum += data.percentile * weight;
       totalWeight += weight;
     }
     const overallScore =

--- a/src/services/managerGrades.ts
+++ b/src/services/managerGrades.ts
@@ -193,6 +193,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
   }
 
   // Delete stale all_time rows (prevents duplicates across different leagueIds)
+  // Scoped to this family's leagueIds so other families are untouched
   const allManagerIds = [...managerAllTime.keys()];
   if (allManagerIds.length > 0) {
     await db
@@ -200,6 +201,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
       .where(
         and(
           inArray(schema.managerMetrics.managerId, allManagerIds),
+          inArray(schema.managerMetrics.leagueId, leagueIds),
           eq(schema.managerMetrics.scope, "all_time"),
         ),
       );


### PR DESCRIPTION
## Summary
New Manager Page at `/league/[familyId]/manager/[userId]` with full grading display, plus scoring fixes to make grades intuitive.

### Manager Page (new)
- **Grade card** — overall percentile, letter grade, per-pillar breakdown
- **Radar chart** — four-axis visualization (Trading, Drafting, Waivers, Lineups) using recharts
- **Season history table** — per-season percentile + grades across all pillars
- **Recent transactions** — last 10 trades/waivers with individual grades

### Scoring fixes
- **Percentile-based display** — radar chart and grade cards show global percentile rank instead of raw scores, making cross-pillar comparison meaningful
- **Global percentile grades** — letter grades derived from global percentile (top 10% = A+), not absolute score thresholds. Three excellent managers in the same league all get A's.
- **overall_score from percentiles** — composite score now averages pillar percentiles, not raw scores. Fixes the "91st percentile trader gets C overall" bug.
- **Deduplicate all_time rows** — deletes stale rows before reinserting during rollup. Fixes duplicate metrics caused by varying leagueIds across syncs.

### New files
- `src/app/api/leagues/[familyId]/manager/[userId]/route.ts` — API endpoint
- `src/app/(app)/league/[familyId]/manager/[userId]/page.tsx` — page component
- `src/components/ManagerRadarChart.tsx` — recharts radar chart
- `src/components/ManagerGradeCard.tsx` — grade + percentile display
- `src/lib/pillars.ts` — shared PILLAR_LABELS/PILLAR_KEYS constants

### Modified files
- `src/services/gradingCore.ts` — `percentileToGrade()` function
- `src/services/managerGrades.ts` — percentile-based overall_score + all_time dedup

## Test plan
- [ ] Navigate to league overview → click manager name → Manager Page loads
- [ ] Percentiles and grades align (high percentile = good grade)
- [ ] Radar chart reflects pillar strengths visually
- [ ] Season history shows per-season grades
- [ ] No duplicate all_time rows in manager_metrics
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)