### PR TITLE
feat(design): Phase 1 — Claude-inspired design tokens + /design reference

### DIFF
--- a/public/design-preview/_card.css
+++ b/public/design-preview/_card.css
@@ -1,0 +1,34 @@
+/* Shared card styles for Dynasty DNA preview cards.
+   Each card is ~700×~(varies)px, no outer title/framing (rendered by host). */
+@import url('https://fonts.googleapis.com/css2?family=Source+Serif+4:opsz,wght@8..60,400;8..60,500&family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap');
+
+:root {
+  --cream-50:#FAF9F5; --cream-100:#F5F4EE; --cream-200:#EDEBE2; --cream-300:#DAD7CB;
+  --slate-900:#1F1E1B; --slate-800:#2B2A26; --slate-700:#3D3B35; --slate-500:#6B6A62; --slate-400:#8F8E85; --slate-300:#B5B3A8;
+  --sage-50:#F1F4EF; --sage-100:#E2E8DD; --sage-200:#C6D1BE; --sage-300:#A8B99C; --sage-400:#8AA07B; --sage-500:#6F8A60; --sage-600:#597048; --sage-700:#465938; --sage-800:#38462D; --sage-900:#2B3623;
+  --grade-a:#4F7A3E; --grade-b:#3B6EA5; --grade-c:#C69B3C; --grade-d:#C27237; --grade-f:#B2493F;
+  --font-serif:'Source Serif 4', Georgia, serif;
+  --font-sans:'Inter', system-ui, sans-serif;
+  --font-mono:'JetBrains Mono', monospace;
+}
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html, body {
+  background: var(--cream-50);
+  font-family: var(--font-sans);
+  color: var(--slate-900);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+.card {
+  padding: 24px 28px;
+  min-height: 100%;
+}
+.tabular { font-variant-numeric: tabular-nums; }
+.label {
+  font-size: 10.5px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--slate-500);
+  font-weight: 500;
+}

--- a/public/design-preview/assets/favicon.svg
+++ b/public/design-preview/assets/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" width="32" height="32">
+  <rect width="32" height="32" rx="6" fill="#FAF9F5"></rect>
+  <g fill="none" stroke="#6F8A60" stroke-width="2" stroke-linecap="round">
+    <path d="M8 6 C 24 12, 8 20, 24 26"></path>
+    <path d="M24 6 C 8 12, 24 20, 8 26"></path>
+  </g>
+</svg>

--- a/public/design-preview/assets/logo.svg
+++ b/public/design-preview/assets/logo.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  
+  <g fill="none" stroke="#6F8A60" stroke-width="3" stroke-linecap="round">
+    <path d="M16 10 C 48 22, 16 42, 48 54"></path>
+    <path d="M48 10 C 16 22, 48 42, 16 54"></path>
+    <path d="M22 16 L 42 16" opacity="0.55"></path>
+    <path d="M18 26 L 46 26" opacity="0.55"></path>
+    <path d="M18 38 L 46 38" opacity="0.55"></path>
+    <path d="M22 48 L 42 48" opacity="0.55"></path>
+  </g>
+</svg>

--- a/public/design-preview/assets/wordmark.svg
+++ b/public/design-preview/assets/wordmark.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 64" width="320" height="64">
+  <g fill="none" stroke="#6F8A60" stroke-width="3" stroke-linecap="round">
+    <path d="M10 10 C 42 22, 10 42, 42 54"></path>
+    <path d="M42 10 C 10 22, 42 42, 10 54"></path>
+    <path d="M16 16 L 36 16" opacity="0.55"></path>
+    <path d="M12 26 L 40 26" opacity="0.55"></path>
+    <path d="M12 38 L 40 38" opacity="0.55"></path>
+    <path d="M16 48 L 36 48" opacity="0.55"></path>
+  </g>
+  <text x="62" y="42" font-family="&#39;Source Serif 4&#39;, Georgia, serif" font-size="28" font-weight="500" fill="#1F1E1B" letter-spacing="-0.5">
+    Dynasty <tspan fill="#6F8A60">DNA</tspan>
+  </text>
+</svg>

--- a/public/design-preview/brand_icons.html
+++ b/public/design-preview/brand_icons.html
@@ -1,0 +1,27 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 4px; letter-spacing:-0.01em; }
+  .sub { color: var(--slate-500); font-size: 12.5px; margin-bottom: 16px; }
+  .grid { display:grid; grid-template-columns: repeat(6, 1fr); gap: 16px; }
+  .ic { display:flex; flex-direction:column; align-items:center; gap: 6px; padding: 10px; border: 1px solid var(--cream-200); border-radius: 8px; background: #fff; }
+  .ic svg { width: 22px; height: 22px; color: var(--slate-700); }
+  .ic .n { font-family: var(--font-mono); font-size: 10px; color: var(--slate-500); }
+</style>
+<div class="title">Iconography · Lucide</div>
+<div class="sub">Single set. 1.5 stroke, rounded caps, no fills. 16/20/24px sizes. No emoji, no custom SVGs.</div>
+<div class="grid">
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3 4 7l4 4"/><path d="M4 7h16"/><path d="m16 21 4-4-4-4"/><path d="M20 17H4"/></svg><span class="n">ArrowRightLeft</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg><span class="n">ClipboardList</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 3v18h18"/><path d="M7 16V8"/><path d="M12 16V4"/><path d="M17 16v-6"/></svg><span class="n">BarChart3</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M2 15c6.667-6 13.333 0 20-6"/><path d="M9 22c1.798-1.998 2.518-3.995 2.807-5.993"/><path d="M15 2c-1.798 1.998-2.518 3.995-2.807 5.993"/><path d="M17 6h.01"/><path d="M17 18h.01"/><path d="M7 6h.01"/><path d="M7 18h.01"/></svg><span class="n">Dna</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M3 6l6-3 6 3 6-3v15l-6 3-6-3-6 3z"/><path d="M9 3v15"/><path d="M15 6v15"/></svg><span class="n">Map</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M4 19.5v-15A2.5 2.5 0 0 1 6.5 2H19v20H6.5a2.5 2.5 0 0 1 0-5H20"/></svg><span class="n">BookOpen</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M10 2v6l-3 8a3 3 0 0 0 3 4h4a3 3 0 0 0 3-4l-3-8V2"/><path d="M8 2h8"/></svg><span class="n">FlaskConical</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><line x1="4" y1="6" x2="20" y2="6"/><line x1="4" y1="12" x2="20" y2="12"/><line x1="4" y1="18" x2="20" y2="18"/></svg><span class="n">Menu</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M18 6 6 18"/><path d="m6 6 12 12"/></svg><span class="n">X</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="m9 18 6-6-6-6"/></svg><span class="n">ChevronRight</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="M12 8v4l3 2"/></svg><span class="n">Clock</span></div>
+  <div class="ic"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M12 2v20M2 12h20"/></svg><span class="n">Plus</span></div>
+</div>
+</div></body></html>

--- a/public/design-preview/brand_logo.html
+++ b/public/design-preview/brand_logo.html
@@ -1,0 +1,29 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 12px; letter-spacing:-0.01em; }
+  .sub { color: var(--slate-500); font-size: 12.5px; margin-bottom: 16px; }
+  .row { display:flex; gap: 18px; align-items:center; }
+  .mark { display:flex; align-items:center; gap: 12px; }
+  .mark svg { width: 40px; height: 40px; }
+  .mark .name { font-family: var(--font-serif); font-size: 22px; font-weight: 500; letter-spacing:-0.01em; color: var(--slate-900); }
+  .mark .name .dna { color: var(--sage-600); }
+  .lockup { background: var(--slate-900); padding: 16px 20px; border-radius: 10px; }
+  .lockup .name { color: var(--cream-50); }
+  .lockup .name .dna { color: var(--sage-300); }
+  .swatch { display:flex; gap: 8px; margin-top: 18px; }
+  .swatch div { width: 56px; height: 56px; border-radius: 6px; display:flex; align-items:flex-end; padding: 6px; font-family: var(--font-mono); font-size: 9.5px; color: var(--slate-700); }
+</style>
+<div class="title">Logo & wordmark</div>
+<div class="sub">DNA double-helix monogram. Sage on cream for most use; sage-300 on slate-900 for dark lockup.</div>
+<div class="row">
+  <div class="mark">
+    <svg viewBox="0 0 64 64"><g fill="none" stroke="#6F8A60" stroke-width="3" stroke-linecap="round"><path d="M16 10 C 48 22, 16 42, 48 54"/><path d="M48 10 C 16 22, 48 42, 16 54"/><path d="M22 16 L 42 16" opacity=".55"/><path d="M18 26 L 46 26" opacity=".55"/><path d="M18 38 L 46 38" opacity=".55"/><path d="M22 48 L 42 48" opacity=".55"/></g></svg>
+    <div class="name">Dynasty <span class="dna">DNA</span></div>
+  </div>
+  <div class="mark lockup">
+    <svg viewBox="0 0 64 64"><g fill="none" stroke="#A8B99C" stroke-width="3" stroke-linecap="round"><path d="M16 10 C 48 22, 16 42, 48 54"/><path d="M48 10 C 16 22, 48 42, 16 54"/><path d="M22 16 L 42 16" opacity=".55"/><path d="M18 26 L 46 26" opacity=".55"/><path d="M18 38 L 46 38" opacity=".55"/><path d="M22 48 L 42 48" opacity=".55"/></g></svg>
+    <div class="name">Dynasty <span class="dna">DNA</span></div>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/brand_voice.html
+++ b/public/design-preview/brand_voice.html
@@ -1,0 +1,28 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 12px; letter-spacing:-0.01em; }
+  .grid { display:grid; grid-template-columns: 2fr 3fr; gap:16px; }
+  .vp { border: 1px solid var(--cream-300); border-radius: 10px; padding: 14px; background:#fff; }
+  .vp h4 { font-family: var(--font-sans); font-size: 13px; font-weight: 600; margin-bottom:6px; color: var(--slate-800); }
+  .vp p { font-size: 12.5px; line-height: 1.55; color: var(--slate-500); }
+  .do { color: var(--sage-700); }
+  .dont { color: var(--grade-f); }
+  .quote { font-family: var(--font-serif); font-style: italic; font-size: 15px; color: var(--slate-700); line-height: 1.5; border-left: 2px solid var(--sage-400); padding-left: 12px; margin: 8px 0; }
+</style>
+<div class="title">Voice — direct, expert, never hype</div>
+<div class="grid">
+  <div class="vp">
+    <h4 class="do">✓ Say</h4>
+    <p class="quote">You left 37.4 points on your bench in Week 6.</p>
+    <p class="quote">Sync league data to generate grades.</p>
+    <p class="quote">Decode your dynasty DNA.</p>
+  </div>
+  <div class="vp">
+    <h4 class="dont">✗ Don't</h4>
+    <p class="quote" style="border-left-color:var(--grade-f)">You might have missed a few points last week 😬</p>
+    <p class="quote" style="border-left-color:var(--grade-f)">Let's get your league data synced up so we can start grading! 🚀</p>
+    <p class="quote" style="border-left-color:var(--grade-f)">Discover insights about your squad.</p>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/color_chart.html
+++ b/public/design-preview/color_chart.html
@@ -1,0 +1,20 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 20px; font-weight: 500; letter-spacing:-0.01em; }
+  .sub { color: var(--slate-500); font-size: 12.5px; margin-top: 4px; margin-bottom: 16px; }
+  .grid { display:grid; grid-template-columns: repeat(6, 1fr); gap: 10px; }
+  .sw { border-radius:10px; aspect-ratio: 1; border: 1px solid var(--cream-300); display:flex; align-items:flex-end; padding: 8px; }
+  .sw .name { font-family: var(--font-mono); font-size: 10px; color: #fff; }
+</style>
+<div class="title">Chart palette</div>
+<div class="sub">Six muted stops — sage leads, the rest support. Deliberately desaturated so brand stays dominant.</div>
+<div class="grid">
+  <div class="sw" style="background:#6F8A60"><div class="name">chart-1 · sage<br>#6F8A60</div></div>
+  <div class="sw" style="background:#3B6EA5"><div class="name">chart-2 · blue<br>#3B6EA5</div></div>
+  <div class="sw" style="background:#C27237"><div class="name">chart-3 · terra<br>#C27237</div></div>
+  <div class="sw" style="background:#8A6DAD"><div class="name">chart-4 · mauve<br>#8A6DAD</div></div>
+  <div class="sw" style="background:#C69B3C"><div class="name">chart-5 · ochre<br>#C69B3C</div></div>
+  <div class="sw" style="background:#5E8A8A"><div class="name">chart-6 · teal<br>#5E8A8A</div></div>
+</div>
+</div></body></html>

--- a/public/design-preview/color_grades.html
+++ b/public/design-preview/color_grades.html
@@ -1,0 +1,41 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 20px; font-weight: 500; letter-spacing:-0.01em; }
+  .sub { color: var(--slate-500); font-size: 12.5px; margin-top: 4px; margin-bottom: 18px; }
+  .grid { display:grid; grid-template-columns: repeat(5, 1fr); gap: 10px; }
+  .g { border-radius: 10px; padding: 14px; display:flex; flex-direction:column; gap:6px; border: 1px solid var(--cream-300); background: #fff; }
+  .badge { display:inline-block; padding: 3px 9px; border-radius:4px; font-size: 12px; font-weight: 700; border: 1px solid; align-self:flex-start; font-family: var(--font-sans); }
+  .hex { font-family: var(--font-mono); font-size: 10px; color: var(--slate-500); }
+  .use { font-size: 12px; color: var(--slate-700); }
+</style>
+<div class="title">Grade palette</div>
+<div class="sub">Five stops, earned not decorative. Used in <code style="font-family:var(--font-mono)">GradeBadge</code> and grade-specific chart segments only.</div>
+<div class="grid">
+  <div class="g">
+    <span class="badge" style="color:#4F7A3E;background:rgba(79,122,62,0.12);border-color:rgba(79,122,62,0.3)">A+</span>
+    <span class="hex">#4F7A3E</span>
+    <span class="use">grade-a · 90th+ pct</span>
+  </div>
+  <div class="g">
+    <span class="badge" style="color:#3B6EA5;background:rgba(59,110,165,0.12);border-color:rgba(59,110,165,0.3)">B+</span>
+    <span class="hex">#3B6EA5</span>
+    <span class="use">grade-b · 70–89</span>
+  </div>
+  <div class="g">
+    <span class="badge" style="color:#C69B3C;background:rgba(198,155,60,0.15);border-color:rgba(198,155,60,0.3)">C</span>
+    <span class="hex">#C69B3C</span>
+    <span class="use">grade-c · 40–69</span>
+  </div>
+  <div class="g">
+    <span class="badge" style="color:#C27237;background:rgba(194,114,55,0.15);border-color:rgba(194,114,55,0.3)">D</span>
+    <span class="hex">#C27237</span>
+    <span class="use">grade-d · 20–39</span>
+  </div>
+  <div class="g">
+    <span class="badge" style="color:#B2493F;background:rgba(178,73,63,0.12);border-color:rgba(178,73,63,0.3)">F</span>
+    <span class="hex">#B2493F</span>
+    <span class="use">grade-f · &lt;20</span>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/color_neutrals.html
+++ b/public/design-preview/color_neutrals.html
@@ -1,0 +1,25 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .row { display:grid; grid-template-columns: repeat(6, 1fr); gap: 10px; }
+  .sw { border-radius: 8px; aspect-ratio: 1.3; display:flex; align-items:flex-end; justify-content:flex-start; padding: 8px 10px; border: 1px solid var(--cream-300); }
+  .sw .name { font-family: var(--font-mono); font-size: 10px; letter-spacing: 0.02em; }
+  .title { font-family: var(--font-serif); font-size: 20px; font-weight: 500; margin-bottom: 4px; letter-spacing:-0.01em; }
+  .sub { color: var(--slate-500); font-size: 12.5px; margin-bottom: 16px; }
+  .hex { font-family: var(--font-mono); font-size: 10px; color: var(--slate-700); display:block; opacity:0.8; }
+</style>
+<div class="title">Cream & Slate</div>
+<div class="sub">Warm, low-glare neutrals. Cream is the canvas; slate is the ink.</div>
+<div class="row">
+  <div class="sw" style="background:#FAF9F5"><div><div class="name">cream-50</div><span class="hex">#FAF9F5</span></div></div>
+  <div class="sw" style="background:#F5F4EE"><div><div class="name">cream-100</div><span class="hex">#F5F4EE</span></div></div>
+  <div class="sw" style="background:#EDEBE2"><div><div class="name">cream-200</div><span class="hex">#EDEBE2</span></div></div>
+  <div class="sw" style="background:#DAD7CB"><div><div class="name">cream-300</div><span class="hex">#DAD7CB</span></div></div>
+  <div class="sw" style="background:#B5B3A8"><div><div class="name">slate-300</div><span class="hex">#B5B3A8</span></div></div>
+  <div class="sw" style="background:#8F8E85"><div><div class="name" style="color:#fff">slate-400</div><span class="hex" style="color:#fff">#8F8E85</span></div></div>
+  <div class="sw" style="background:#6B6A62"><div><div class="name" style="color:#fff">slate-500</div><span class="hex" style="color:#fff">#6B6A62</span></div></div>
+  <div class="sw" style="background:#3D3B35"><div><div class="name" style="color:#fff">slate-700</div><span class="hex" style="color:#fff">#3D3B35</span></div></div>
+  <div class="sw" style="background:#2B2A26"><div><div class="name" style="color:#fff">slate-800</div><span class="hex" style="color:#fff">#2B2A26</span></div></div>
+  <div class="sw" style="background:#1F1E1B"><div><div class="name" style="color:#fff">slate-900</div><span class="hex" style="color:#fff">#1F1E1B</span></div></div>
+</div>
+</div></body></html>

--- a/public/design-preview/color_sage.html
+++ b/public/design-preview/color_sage.html
@@ -1,0 +1,32 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .row { display:grid; grid-template-columns: repeat(9, 1fr); gap: 8px; margin-top: 14px; }
+  .sw { border-radius: 8px; aspect-ratio: 1; display:flex; align-items:flex-end; padding: 6px 8px; border: 1px solid rgba(0,0,0,0.06); }
+  .sw .name { font-family: var(--font-mono); font-size: 9.5px; }
+  .title { font-family: var(--font-serif); font-size: 20px; font-weight: 500; letter-spacing:-0.01em; }
+  .sub { color: var(--slate-500); font-size: 12.5px; margin-top: 4px; }
+  .hero { display:flex; align-items:baseline; gap:16px; padding: 20px 22px; border-radius: 10px; background: var(--sage-500); color: #fff; margin-top: 14px; }
+  .hero .big { font-family: var(--font-mono); font-size: 22px; }
+  .hero .role { font-family: var(--font-sans); font-size: 13px; opacity: 0.9; }
+  .hero .use { margin-left:auto; font-size: 12px; opacity: 0.9; font-family: var(--font-sans); }
+</style>
+<div class="title">Sage — brand accent</div>
+<div class="sub"><code style="font-family:var(--font-mono)">sage-500</code> replaces Claude's orange. The only hue allowed as a brand signal.</div>
+<div class="hero">
+  <div class="big">#6F8A60</div>
+  <div class="role">sage-500 · --primary</div>
+  <div class="use">links · primary buttons · radar fill · "DNA" in wordmark</div>
+</div>
+<div class="row">
+  <div class="sw" style="background:#F1F4EF"><div class="name">50</div></div>
+  <div class="sw" style="background:#E2E8DD"><div class="name">100</div></div>
+  <div class="sw" style="background:#C6D1BE"><div class="name">200</div></div>
+  <div class="sw" style="background:#A8B99C"><div class="name">300</div></div>
+  <div class="sw" style="background:#8AA07B"><div class="name" style="color:#fff">400</div></div>
+  <div class="sw" style="background:#6F8A60"><div class="name" style="color:#fff">500</div></div>
+  <div class="sw" style="background:#597048"><div class="name" style="color:#fff">600</div></div>
+  <div class="sw" style="background:#465938"><div class="name" style="color:#fff">700</div></div>
+  <div class="sw" style="background:#2B3623"><div class="name" style="color:#fff">900</div></div>
+</div>
+</div></body></html>

--- a/public/design-preview/components_badges.html
+++ b/public/design-preview/components_badges.html
@@ -1,0 +1,33 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 14px; letter-spacing:-0.01em; }
+  .row { display:flex; flex-wrap:wrap; gap:10px; align-items:center; margin-bottom: 14px; }
+  .badge { display:inline-flex; align-items:center; padding: 3px 10px; border-radius: 4px; font-size: 12px; font-weight: 700; border: 1px solid; font-family: var(--font-sans); }
+  .pill { display:inline-flex; align-items:center; padding: 3px 10px; border-radius: 9999px; font-size: 11.5px; font-weight: 500; }
+  .label { font-size: 10.5px; letter-spacing: 0.08em; text-transform: uppercase; color: var(--slate-500); font-weight: 500; margin-bottom: 6px; }
+</style>
+<div class="title">Grade badges</div>
+<div class="row">
+  <span class="badge" style="color:#4F7A3E;background:rgba(79,122,62,0.12);border-color:rgba(79,122,62,0.3)">A+</span>
+  <span class="badge" style="color:#4F7A3E;background:rgba(79,122,62,0.10);border-color:rgba(79,122,62,0.25)">A</span>
+  <span class="badge" style="color:#3B6EA5;background:rgba(59,110,165,0.10);border-color:rgba(59,110,165,0.25)">B+</span>
+  <span class="badge" style="color:#3B6EA5;background:rgba(59,110,165,0.08);border-color:rgba(59,110,165,0.2)">B</span>
+  <span class="badge" style="color:#C69B3C;background:rgba(198,155,60,0.12);border-color:rgba(198,155,60,0.28)">C</span>
+  <span class="badge" style="color:#C27237;background:rgba(194,114,55,0.12);border-color:rgba(194,114,55,0.28)">D</span>
+  <span class="badge" style="color:#B2493F;background:rgba(178,73,63,0.12);border-color:rgba(178,73,63,0.28)">F</span>
+</div>
+<div class="label">Status pills</div>
+<div class="row">
+  <span class="pill" style="color:#4F7A3E;background:rgba(79,122,62,0.15)">Shipped</span>
+  <span class="pill" style="color:#3B6EA5;background:rgba(59,110,165,0.15)">In progress</span>
+  <span class="pill" style="color:#C69B3C;background:rgba(198,155,60,0.18)">Planned</span>
+  <span class="pill" style="color:#8A6DAD;background:rgba(138,109,173,0.15)">Exploring</span>
+</div>
+<div class="label">League tags</div>
+<div class="row">
+  <span class="pill" style="color:var(--sage-700);background:var(--sage-100)">Dynasty</span>
+  <span class="pill" style="color:var(--slate-700);background:var(--cream-200)">Redraft</span>
+  <span class="pill" style="color:var(--slate-700);background:var(--cream-200); text-transform:capitalize;">In season</span>
+</div>
+</div></body></html>

--- a/public/design-preview/components_buttons.html
+++ b/public/design-preview/components_buttons.html
@@ -1,0 +1,33 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .btns { display:flex; flex-wrap:wrap; gap:10px; align-items:center; }
+  .btn { padding: 9px 16px; border-radius: 6px; font-family: var(--font-sans); font-weight: 500; font-size: 14px; border: 1px solid transparent; cursor:pointer; transition: all 180ms cubic-bezier(.16,1,.3,1); }
+  .btn.primary { background: var(--sage-500); color: #fff; }
+  .btn.primary:hover { background: var(--sage-600); }
+  .btn.secondary { background: var(--cream-100); color: var(--slate-900); border-color: var(--cream-300); }
+  .btn.secondary:hover { background: var(--cream-200); }
+  .btn.ghost { background: transparent; color: var(--slate-700); }
+  .btn.ghost:hover { color: var(--slate-900); background: var(--cream-100); }
+  .btn.danger { background: transparent; color: var(--grade-f); border-color: rgba(178,73,63,0.3); }
+  .btn.disabled { opacity: 0.5; pointer-events: none; }
+  .btn.lg { padding: 12px 22px; font-size: 16px; border-radius: 8px; }
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 14px; letter-spacing:-0.01em; }
+  .label { margin-top: 14px; margin-bottom: 8px; }
+</style>
+<div class="title">Buttons</div>
+<div class="btns">
+  <button class="btn primary lg">Get started</button>
+  <button class="btn primary">Sync data</button>
+  <button class="btn secondary">Transactions</button>
+  <button class="btn secondary">Drafts</button>
+  <button class="btn ghost">Sign out</button>
+  <button class="btn primary disabled">Verifying…</button>
+</div>
+<div class="label">SIZES</div>
+<div class="btns">
+  <button class="btn primary lg">Large · marketing</button>
+  <button class="btn primary">Default</button>
+  <button class="btn secondary" style="padding:6px 12px; font-size:13px;">Small</button>
+</div>
+</div></body></html>

--- a/public/design-preview/components_cards.html
+++ b/public/design-preview/components_cards.html
@@ -1,0 +1,26 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .grid { display:grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .c { background: #fff; border: 1px solid var(--cream-300); border-radius: 10px; padding: 20px; transition: border-color 180ms; }
+  .c.hover { border-color: var(--sage-300); }
+  .c h3 { font-family: var(--font-sans); font-weight: 600; font-size: 15px; margin-bottom: 4px; color: var(--slate-900); }
+  .c p { font-size: 13px; color: var(--slate-500); line-height: 1.5; }
+  .icon { width: 24px; height: 24px; color: var(--sage-600); margin-bottom: 10px; }
+  .tag { display:inline-block; margin-top: 10px; font-size: 10px; font-family: var(--font-mono); color: var(--slate-400); letter-spacing: 0.06em; }
+</style>
+<div class="grid">
+  <div class="c">
+    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><path d="M8 3 4 7l4 4"/><path d="M4 7h16"/><path d="m16 21 4-4-4-4"/><path d="M20 17H4"/></svg>
+    <h3>Know if you won the trade</h3>
+    <p>Every trade scored with surplus value so you can see who came out ahead.</p>
+    <span class="tag">DEFAULT · border bg-card</span>
+  </div>
+  <div class="c hover">
+    <svg class="icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"><rect x="8" y="2" width="8" height="4" rx="1"/><path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"/></svg>
+    <h3>Grade every pick</h3>
+    <p>Pick-by-pick draft grades comparing capital spent vs. production gained.</p>
+    <span class="tag">HOVER · border-sage-300</span>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/components_grade_card.html
+++ b/public/design-preview/components_grade_card.html
@@ -1,0 +1,32 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 12px; letter-spacing:-0.01em; }
+  .grid { display:grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+  .hero { display:flex; align-items:center; gap: 16px; }
+  .big { font-family: var(--font-serif); font-size: 48px; font-weight: 500; letter-spacing: -0.02em; color: var(--slate-900); line-height: 1; }
+  .badge { display:inline-flex; padding: 3px 10px; border-radius: 4px; font-size: 12px; font-weight: 700; border: 1px solid; }
+  .score { font-family: var(--font-mono); font-size: 11px; color: var(--slate-500); margin-top: 4px; }
+  .panel { border: 1px solid var(--cream-300); border-radius: 10px; padding: 16px 18px; background: #fff; }
+  .pillars { display:grid; grid-template-columns: 1fr 1fr; gap: 8px; margin-top: 12px; }
+  .pillar { display:flex; align-items:center; justify-content:space-between; padding: 7px 10px; border: 1px solid var(--cream-200); border-radius: 6px; }
+  .pillar .lbl { font-size: 12.5px; color: var(--slate-500); }
+  .pillar .val { display:flex; align-items:center; gap: 6px; font-family: var(--font-mono); font-size: 12.5px; color: var(--slate-800); }
+</style>
+<div class="title">Manager grade card</div>
+<div class="panel">
+  <div class="hero">
+    <div class="big">63rd</div>
+    <div>
+      <span class="badge" style="color:#3B6EA5;background:rgba(59,110,165,0.1);border-color:rgba(59,110,165,0.25)">B</span>
+      <div class="score">Score: 72.4</div>
+    </div>
+  </div>
+  <div class="pillars">
+    <div class="pillar"><span class="lbl">Drafts</span><span class="val">78th <span class="badge" style="padding:1px 7px;font-size:10px;color:#4F7A3E;background:rgba(79,122,62,0.1);border-color:rgba(79,122,62,0.25)">A</span></span></div>
+    <div class="pillar"><span class="lbl">Trades</span><span class="val">54th <span class="badge" style="padding:1px 7px;font-size:10px;color:#3B6EA5;background:rgba(59,110,165,0.08);border-color:rgba(59,110,165,0.2)">B</span></span></div>
+    <div class="pillar"><span class="lbl">Lineups</span><span class="val">71st <span class="badge" style="padding:1px 7px;font-size:10px;color:#3B6EA5;background:rgba(59,110,165,0.1);border-color:rgba(59,110,165,0.25)">B+</span></span></div>
+    <div class="pillar"><span class="lbl">Waivers</span><span class="val">42nd <span class="badge" style="padding:1px 7px;font-size:10px;color:#C69B3C;background:rgba(198,155,60,0.12);border-color:rgba(198,155,60,0.28)">C</span></span></div>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/components_inputs.html
+++ b/public/design-preview/components_inputs.html
@@ -1,0 +1,39 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 14px; letter-spacing:-0.01em; }
+  .field { margin-bottom: 14px; }
+  label { display:block; font-size: 13px; font-weight: 500; color: var(--slate-800); margin-bottom: 6px; }
+  input { width: 100%; padding: 9px 12px; border: 1px solid var(--cream-300); border-radius: 6px; background: #fff; font-family: var(--font-sans); font-size: 14px; color: var(--slate-900); outline: none; transition: all 180ms; }
+  input:focus { border-color: var(--sage-500); box-shadow: 0 0 0 3px rgba(111,138,96,0.18); }
+  input::placeholder { color: var(--slate-400); }
+  .help { font-size: 12px; color: var(--slate-500); margin-top: 6px; }
+  .err { font-size: 12.5px; color: var(--grade-f); margin-top: 6px; }
+  .row { display:grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+</style>
+<div class="row">
+  <div>
+    <div class="field">
+      <label>Sleeper username</label>
+      <input value="jrygrande" />
+      <div class="help">We'll find all your dynasty leagues.</div>
+    </div>
+    <div class="field">
+      <label>Season</label>
+      <input placeholder="e.g. 2025" />
+    </div>
+  </div>
+  <div>
+    <div class="field">
+      <label>Sleeper username</label>
+      <input style="border-color: var(--sage-500); box-shadow: 0 0 0 3px rgba(111,138,96,0.18)" value="jrygrande|" />
+      <div class="help">FOCUS · sage ring</div>
+    </div>
+    <div class="field">
+      <label>Sleeper username</label>
+      <input style="border-color: rgba(178,73,63,0.5); box-shadow: 0 0 0 3px rgba(178,73,63,0.1)" value="notauser" />
+      <div class="err">User not found on Sleeper.</div>
+    </div>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/components_nav.html
+++ b/public/design-preview/components_nav.html
@@ -1,0 +1,41 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card" style="padding:0;">
+<style>
+  .nav { display:flex; align-items:center; justify-content:space-between; padding: 16px 24px; border-bottom: 1px solid var(--cream-300); background: var(--cream-50); }
+  .brand { font-family: var(--font-sans); font-weight: 700; font-size: 17px; letter-spacing: -0.01em; color: var(--slate-900); }
+  .brand .dna { color: var(--sage-600); }
+  .links { display:flex; align-items:center; gap: 24px; }
+  .links a { text-decoration: none; color: var(--slate-500); font-size: 14px; }
+  .links a.active { color: var(--slate-900); font-weight: 500; }
+  .cta { padding: 7px 14px; border-radius: 6px; background: var(--sage-500); color: #fff; font-size: 13.5px; font-weight: 500; }
+
+  .subnav { display:flex; align-items:center; justify-content:space-between; padding: 12px 24px; border-bottom: 1px solid var(--cream-300); background: var(--cream-50); }
+  .bc { display:flex; align-items:center; gap: 14px; }
+  .bc .back { color: var(--slate-500); font-size: 13px; text-decoration: none; }
+  .bc h1 { font-family: var(--font-sans); font-weight: 600; font-size: 16px; color: var(--slate-900); }
+  .bc .season { color: var(--slate-500); font-size: 13px; font-family: var(--font-mono); }
+  .actions { display:flex; gap: 8px; }
+  .btn { padding: 6px 12px; border-radius: 6px; font-size: 13px; border: 1px solid var(--cream-300); background: #fff; color: var(--slate-800); }
+</style>
+<div class="nav">
+  <div class="brand">Dynasty <span class="dna">DNA</span></div>
+  <div class="links">
+    <a href="#">Roadmap</a>
+    <a href="#" class="active">Changelog</a>
+    <a href="#">Experiments</a>
+    <a href="#" class="cta">Sign in</a>
+  </div>
+</div>
+<div class="subnav">
+  <div class="bc">
+    <a href="#" class="back">← Dashboard</a>
+    <h1>The Commissioner's League</h1>
+    <span class="season">2025</span>
+  </div>
+  <div class="actions">
+    <button class="btn">Transactions</button>
+    <button class="btn">Drafts</button>
+    <button class="btn">Sync data</button>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/components_table.html
+++ b/public/design-preview/components_table.html
@@ -1,0 +1,24 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 12px; letter-spacing:-0.01em; }
+  table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; border: 1px solid var(--cream-300); border-radius: 10px; overflow: hidden; }
+  th { text-align: left; font-size: 11.5px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--slate-500); font-weight: 500; padding: 10px 14px; background: rgba(237,235,226,0.5); }
+  th.r, td.r { text-align: right; }
+  td { padding: 11px 14px; border-top: 1px solid var(--cream-200); font-family: var(--font-mono); font-size: 13px; color: var(--slate-700); }
+  tr:hover td { background: rgba(237,235,226,0.35); }
+  td.name { font-family: var(--font-sans); color: var(--slate-900); font-weight: 500; }
+  td.pos { color: var(--slate-500); font-size: 12px; }
+  .num { color: var(--slate-500); font-size: 12px; }
+</style>
+<div class="title">Standings table</div>
+<table>
+  <thead><tr><th>#</th><th>Manager</th><th class="r">W</th><th class="r">L</th><th class="r">PF</th><th class="r">PA</th></tr></thead>
+  <tbody>
+    <tr><td class="num">1</td><td class="name">jrygrande <span class="pos">(Grande Dynasty)</span></td><td class="r">9</td><td class="r">2</td><td class="r">1,482.3</td><td class="r">1,301.7</td></tr>
+    <tr><td class="num">2</td><td class="name">ksommers <span class="pos">(Tush Push Club)</span></td><td class="r">8</td><td class="r">3</td><td class="r">1,417.8</td><td class="r">1,340.2</td></tr>
+    <tr><td class="num">3</td><td class="name">mweiss <span class="pos">(Bench Warmers)</span></td><td class="r">7</td><td class="r">4</td><td class="r">1,393.6</td><td class="r">1,388.1</td></tr>
+    <tr><td class="num">4</td><td class="name">dgarcia</td><td class="r">6</td><td class="r">5</td><td class="r">1,302.0</td><td class="r">1,320.4</td></tr>
+  </tbody>
+</table>
+</div></body></html>

--- a/public/design-preview/spacing_elevation.html
+++ b/public/design-preview/spacing_elevation.html
@@ -1,0 +1,31 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 12px; letter-spacing:-0.01em; }
+  .sub { color: var(--slate-500); font-size: 12px; margin-bottom: 20px; }
+  .grid { display:grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
+  .card-ex { background: #fff; padding: 18px; min-height: 90px; display:flex; flex-direction:column; justify-content:flex-end; }
+  .lbl { font-family: var(--font-mono); font-size: 10.5px; color: var(--slate-500); }
+  .rule { font-family: var(--font-sans); font-size: 11px; color: var(--slate-700); margin-top: 2px; }
+</style>
+<div class="title">Elevation — borders before shadows</div>
+<div class="sub">Dynasty DNA defaults to hairlines. Shadows appear only on floating surfaces (menus, modals, toasts).</div>
+<div class="grid">
+  <div class="card-ex" style="border: 1px solid var(--cream-300); border-radius: 8px;">
+    <div class="lbl">shadow-none</div>
+    <div class="rule">default card</div>
+  </div>
+  <div class="card-ex" style="border: 1px solid var(--cream-300); border-radius: 8px; box-shadow: 0 1px 2px rgba(31,30,27,0.04);">
+    <div class="lbl">shadow-xs</div>
+    <div class="rule">subtle lift</div>
+  </div>
+  <div class="card-ex" style="border: 1px solid var(--cream-300); border-radius: 8px; box-shadow: 0 4px 12px rgba(31,30,27,0.06), 0 2px 4px rgba(31,30,27,0.04);">
+    <div class="lbl">shadow-md</div>
+    <div class="rule">popover / menu</div>
+  </div>
+  <div class="card-ex" style="border: 1px solid var(--cream-300); border-radius: 8px; box-shadow: 0 12px 32px rgba(31,30,27,0.08), 0 4px 8px rgba(31,30,27,0.04);">
+    <div class="lbl">shadow-lg</div>
+    <div class="rule">modal / dialog</div>
+  </div>
+</div>
+</div></body></html>

--- a/public/design-preview/spacing_tokens.html
+++ b/public/design-preview/spacing_tokens.html
@@ -1,0 +1,29 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 14px; letter-spacing:-0.01em; }
+  .row { display:grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+  .tok { border: 1px solid var(--cream-300); border-radius: 8px; padding: 10px; background:#fff; text-align: center; }
+  .box { background: var(--sage-500); margin: 0 auto; border-radius: 3px; }
+  .name { font-family: var(--font-mono); font-size: 10.5px; color: var(--slate-500); margin-top: 6px; }
+  .val { font-family: var(--font-mono); font-size: 11px; color: var(--slate-900); font-weight: 600; }
+  .radius { display:flex; gap: 14px; align-items:flex-end; margin-top: 20px; }
+  .r { background: var(--sage-100); border: 1px solid var(--sage-300); width: 64px; height: 64px; display:flex; flex-direction:column; justify-content:flex-end; padding: 6px; }
+</style>
+<div class="title">Spacing scale · 4px base</div>
+<div class="row">
+  <div class="tok"><div class="box" style="width:4px;height:4px"></div><div class="val">4</div><div class="name">space-1</div></div>
+  <div class="tok"><div class="box" style="width:8px;height:8px"></div><div class="val">8</div><div class="name">space-2</div></div>
+  <div class="tok"><div class="box" style="width:16px;height:16px"></div><div class="val">16</div><div class="name">space-4</div></div>
+  <div class="tok"><div class="box" style="width:24px;height:24px"></div><div class="val">24</div><div class="name">space-6</div></div>
+  <div class="tok"><div class="box" style="width:48px;height:48px"></div><div class="val">48</div><div class="name">space-12</div></div>
+</div>
+<div class="title" style="margin-top:22px;">Corner radii</div>
+<div class="radius">
+  <div class="r" style="border-radius:4px"><span class="val">4</span><span class="name">sm</span></div>
+  <div class="r" style="border-radius:6px"><span class="val">6</span><span class="name">md · buttons</span></div>
+  <div class="r" style="border-radius:8px"><span class="val">8</span><span class="name">lg · cards</span></div>
+  <div class="r" style="border-radius:12px"><span class="val">12</span><span class="name">xl</span></div>
+  <div class="r" style="border-radius:9999px; width:96px"><span class="val">full</span><span class="name">pill · tabs</span></div>
+</div>
+</div></body></html>

--- a/public/design-preview/type_body.html
+++ b/public/design-preview/type_body.html
@@ -1,0 +1,16 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .row { display:flex; align-items:baseline; gap: 16px; padding: 10px 0; border-bottom: 1px solid var(--cream-200); }
+  .row:last-child { border:none; }
+  .meta { margin-left:auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--slate-500); letter-spacing:0.04em; flex-shrink: 0; }
+  .lead { font-family: var(--font-sans); font-size: 18px; line-height: 1.55; color: var(--slate-500); max-width: 440px; }
+  .body { font-family: var(--font-sans); font-size: 15px; line-height: 1.55; color: var(--slate-700); max-width: 440px; }
+  .small { font-family: var(--font-sans); font-size: 13px; color: var(--slate-500); }
+  .caption { font-family: var(--font-sans); font-size: 11px; letter-spacing:0.06em; text-transform:uppercase; color: var(--slate-500); font-weight: 500; }
+</style>
+<div class="row"><div class="lead">Find out if you won the trade, graded every pick right, and where you're leaving points on your bench.</div><span class="meta">LEAD · 18 / 1.55</span></div>
+<div class="row"><div class="body">Dynasty leagues reward discipline over multiple seasons. This page shows where your process compares to reality.</div><span class="meta">BODY · 15 / 1.55</span></div>
+<div class="row"><div class="small">Powered by FantasyCalc · nflverse · Sleeper API</div><span class="meta">SMALL · 13</span></div>
+<div class="row"><div class="caption">Week 6 · Lineup efficiency</div><span class="meta">CAPTION · 11 / 600</span></div>
+</div></body></html>

--- a/public/design-preview/type_display.html
+++ b/public/design-preview/type_display.html
@@ -1,0 +1,10 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .d1 { font-family: var(--font-serif); font-weight: 400; font-size: 52px; line-height:1.02; letter-spacing:-0.028em; color: var(--slate-900); }
+  .d1 .accent { color: var(--sage-600); }
+  .meta { font-family: var(--font-mono); font-size: 10.5px; color: var(--slate-500); margin-top: 14px; letter-spacing: 0.05em; }
+</style>
+<div class="d1">Decode your dynasty <span class="accent">DNA</span>.</div>
+<div class="meta">SOURCE SERIF 4 · 52 / 54 · -0.028em · 400</div>
+</div></body></html>

--- a/public/design-preview/type_headings.html
+++ b/public/design-preview/type_headings.html
@@ -1,0 +1,17 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  .row { display:flex; align-items:baseline; gap: 16px; padding: 10px 0; border-bottom: 1px solid var(--cream-200); }
+  .row:last-child { border:none; }
+  .sample { color: var(--slate-900); }
+  .meta { margin-left:auto; font-family: var(--font-mono); font-size: 10.5px; color: var(--slate-500); letter-spacing:0.04em; }
+  h1s { font-family: var(--font-serif); font-weight: 500; font-size: 32px; line-height:1.1; letter-spacing: -0.02em; }
+  h2s { font-family: var(--font-serif); font-weight: 500; font-size: 24px; line-height:1.15; letter-spacing: -0.02em; }
+  h3s { font-family: var(--font-sans); font-weight: 600; font-size: 20px; letter-spacing: -0.01em; }
+  h4s { font-family: var(--font-sans); font-weight: 600; font-size: 16px; }
+</style>
+<div class="row"><h1s class="sample">Know if you won the trade</h1s><span class="meta">H1 · SERIF 32 / 500</span></div>
+<div class="row"><h2s class="sample">Your leagues</h2s><span class="meta">H2 · SERIF 24 / 500</span></div>
+<div class="row"><h3s class="sample">Lineup Efficiency</h3s><span class="meta">H3 · INTER 20 / 600</span></div>
+<div class="row"><h4s class="sample">Week 6 breakdown</h4s><span class="meta">H4 · INTER 16 / 600</span></div>
+</div></body></html>

--- a/public/design-preview/type_mono.html
+++ b/public/design-preview/type_mono.html
@@ -1,0 +1,22 @@
+<!doctype html><html><head><meta charset="utf-8"><link rel="stylesheet" href="_card.css"></head>
+<body><div class="card">
+<style>
+  table { width: 100%; border-collapse: collapse; font-variant-numeric: tabular-nums; }
+  th { text-align: left; font-size: 11px; letter-spacing: 0.06em; text-transform: uppercase; color: var(--slate-500); font-weight: 500; padding: 6px 10px; background: rgba(237,235,226,0.5); }
+  th.r, td.r { text-align: right; }
+  td { padding: 8px 10px; border-top: 1px solid var(--cream-200); font-family: var(--font-mono); font-size: 13px; color: var(--slate-700); }
+  td.name { font-family: var(--font-sans); color: var(--slate-900); font-weight: 500; }
+  .title { font-family: var(--font-serif); font-size: 18px; font-weight: 500; margin-bottom: 10px; letter-spacing:-0.01em; }
+  .meta { font-family: var(--font-mono); font-size: 10px; color: var(--slate-500); margin-top: 10px; letter-spacing: 0.05em; }
+</style>
+<div class="title">Tabular numerals</div>
+<table>
+  <thead><tr><th>Manager</th><th class="r">Eff</th><th class="r">Pts Left</th><th class="r">Perfect</th><th class="r">Pct</th></tr></thead>
+  <tbody>
+    <tr><td class="name">jrygrande</td><td class="r">92.4%</td><td class="r">37.4</td><td class="r">3</td><td class="r">87th</td></tr>
+    <tr><td class="name">ksommers</td><td class="r">88.1%</td><td class="r">54.2</td><td class="r">2</td><td class="r">71st</td></tr>
+    <tr><td class="name">mweiss</td><td class="r">79.3%</td><td class="r">102.7</td><td class="r">0</td><td class="r">33rd</td></tr>
+  </tbody>
+</table>
+<div class="meta">JETBRAINS MONO · TABULAR FIGURES · ONE DECIMAL</div>
+</div></body></html>

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -1,0 +1,128 @@
+import type { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Design system — Dynasty DNA",
+  description:
+    "Token and component specimens for the Dynasty DNA brand: colors, type, spacing, components.",
+};
+
+type Card = {
+  file: string;
+  title: string;
+  height?: number;
+};
+
+type Group = {
+  label: string;
+  cards: Card[];
+};
+
+const DEFAULT_CARD_HEIGHT = 340;
+
+const GROUPS: Group[] = [
+  {
+    label: "Colors",
+    cards: [
+      { file: "color_sage.html", title: "Sage — brand accent" },
+      { file: "color_neutrals.html", title: "Cream + slate neutrals" },
+      { file: "color_grades.html", title: "Grade palette (A–F)" },
+      { file: "color_chart.html", title: "Chart palette" },
+    ],
+  },
+  {
+    label: "Type",
+    cards: [
+      { file: "type_display.html", title: "Display — Source Serif 4", height: 360 },
+      { file: "type_headings.html", title: "Headings", height: 360 },
+      { file: "type_body.html", title: "Body & prose" },
+      { file: "type_mono.html", title: "Mono — JetBrains Mono" },
+    ],
+  },
+  {
+    label: "Spacing & elevation",
+    cards: [
+      { file: "spacing_tokens.html", title: "Spacing scale" },
+      { file: "spacing_elevation.html", title: "Elevation & radius" },
+    ],
+  },
+  {
+    label: "Components",
+    cards: [
+      { file: "components_buttons.html", title: "Buttons" },
+      { file: "components_badges.html", title: "Badges" },
+      { file: "components_inputs.html", title: "Inputs" },
+      { file: "components_cards.html", title: "Cards" },
+      { file: "components_table.html", title: "Tables", height: 360 },
+      { file: "components_nav.html", title: "Navigation" },
+      { file: "components_grade_card.html", title: "Grade card", height: 380 },
+    ],
+  },
+  {
+    label: "Brand",
+    cards: [
+      { file: "brand_logo.html", title: "Logo & wordmark", height: 280 },
+      { file: "brand_icons.html", title: "Iconography — Lucide" },
+      { file: "brand_voice.html", title: "Voice & tone", height: 380 },
+    ],
+  },
+];
+
+export default function DesignSystemPage() {
+  return (
+    <main className="min-h-screen bg-background text-foreground">
+      <header className="border-b border-border">
+        <div className="container mx-auto px-6 py-10 max-w-5xl">
+          <p className="text-xs uppercase tracking-wider text-muted-foreground mb-3">
+            Design system · v1
+          </p>
+          <h1 className="font-serif text-4xl font-medium tracking-tight">
+            Dynasty <span className="text-primary">DNA</span>
+          </h1>
+          <p className="mt-3 text-muted-foreground max-w-2xl">
+            Claude-inspired warmth, sage accent, editorial serif display.
+            Specimens below are rendered from the handoff bundle so we can
+            eyeball tokens + components as we roll the redesign into real
+            screens.
+          </p>
+        </div>
+      </header>
+
+      <div className="container mx-auto px-6 py-12 max-w-5xl space-y-16">
+        {GROUPS.map((group) => (
+          <section key={group.label}>
+            <h2 className="text-xs uppercase tracking-wider text-muted-foreground mb-6">
+              {group.label}
+            </h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+              {group.cards.map((card) => (
+                <figure
+                  key={card.file}
+                  className="rounded-lg border border-border bg-card overflow-hidden"
+                >
+                  <iframe
+                    src={`/design-preview/${card.file}`}
+                    title={card.title}
+                    className="block w-full border-0"
+                    style={{ height: card.height ?? DEFAULT_CARD_HEIGHT }}
+                    loading="lazy"
+                  />
+                  <figcaption className="px-5 py-3 border-t border-border flex items-center justify-between text-sm">
+                    <span className="font-medium">{card.title}</span>
+                    <a
+                      href={`/design-preview/${card.file}`}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="text-muted-foreground hover:text-primary text-xs font-mono"
+                    >
+                      open ↗
+                    </a>
+                  </figcaption>
+                </figure>
+              ))}
+            </div>
+          </section>
+        ))}
+      </div>
+    </main>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -4,48 +4,101 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
-    --foreground: 222.2 84% 4.9%;
+    /* ------------------------------------------------------------
+       Dynasty DNA — Claude-inspired: cream canvas, warm slate ink,
+       sage accent. All tokens in HSL-triplet form for shadcn/Tailwind.
+       ------------------------------------------------------------ */
+
+    /* shadcn semantic tokens */
+    --background: 48 28% 97%;          /* cream-50 #FAF9F5 */
+    --foreground: 40 7% 11%;           /* slate-900 #1F1E1B */
     --card: 0 0% 100%;
-    --card-foreground: 222.2 84% 4.9%;
+    --card-foreground: 40 7% 11%;
     --popover: 0 0% 100%;
-    --popover-foreground: 222.2 84% 4.9%;
-    --primary: 221.2 83.2% 53.3%;
-    --primary-foreground: 210 40% 98%;
-    --secondary: 210 40% 96.1%;
-    --secondary-foreground: 222.2 47.4% 11.2%;
-    --muted: 210 40% 96.1%;
-    --muted-foreground: 215.4 16.3% 46.9%;
-    --accent: 210 40% 96.1%;
-    --accent-foreground: 222.2 47.4% 11.2%;
-    --destructive: 0 84.2% 60.2%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 214.3 31.8% 91.4%;
-    --input: 214.3 31.8% 91.4%;
-    --ring: 221.2 83.2% 53.3%;
+    --popover-foreground: 40 7% 11%;
+    --primary: 95 18% 46%;             /* sage-500 #6F8A60 */
+    --primary-foreground: 48 28% 97%;
+    --secondary: 47 19% 92%;           /* cream-100 */
+    --secondary-foreground: 40 7% 17%;
+    --muted: 47 19% 92%;
+    --muted-foreground: 40 4% 40%;
+    --accent: 95 18% 88%;              /* sage-100 */
+    --accent-foreground: 95 28% 22%;
+    --destructive: 5 47% 47%;          /* muted red */
+    --destructive-foreground: 48 28% 97%;
+    --border: 44 14% 82%;              /* cream-300 */
+    --input: 44 14% 82%;
+    --ring: 95 18% 46%;
     --radius: 0.5rem;
+
+    /* Raw scale tokens (hex — for charts, badges, marketing) */
+    --cream-50:  #FAF9F5;
+    --cream-100: #F5F4EE;
+    --cream-200: #EDEBE2;
+    --cream-300: #DAD7CB;
+
+    --slate-900: #1F1E1B;
+    --slate-800: #2B2A26;
+    --slate-700: #3D3B35;
+    --slate-500: #6B6A62;
+    --slate-400: #8F8E85;
+    --slate-300: #B5B3A8;
+
+    --sage-50:  #F1F4EF;
+    --sage-100: #E2E8DD;
+    --sage-200: #C6D1BE;
+    --sage-300: #A8B99C;
+    --sage-400: #8AA07B;
+    --sage-500: #6F8A60;
+    --sage-600: #597048;
+    --sage-700: #465938;
+    --sage-800: #38462D;
+    --sage-900: #2B3623;
+
+    --grade-a: #4F7A3E;  /* deeper sage */
+    --grade-b: #3B6EA5;  /* dusty blue */
+    --grade-c: #C69B3C;  /* warm ochre */
+    --grade-d: #C27237;  /* terracotta */
+    --grade-f: #B2493F;  /* muted red */
+
+    --chart-1: var(--sage-500);
+    --chart-2: #3B6EA5;
+    --chart-3: #C27237;
+    --chart-4: #8A6DAD;
+    --chart-5: #C69B3C;
+    --chart-6: #5E8A8A;
+
+    /* Soft warm-shadowed elevation — never blue-tinted */
+    --shadow-xs: 0 1px 2px rgba(31, 30, 27, 0.04);
+    --shadow-sm: 0 1px 3px rgba(31, 30, 27, 0.06), 0 1px 2px rgba(31, 30, 27, 0.04);
+    --shadow-md: 0 4px 12px rgba(31, 30, 27, 0.06), 0 2px 4px rgba(31, 30, 27, 0.04);
+    --shadow-lg: 0 12px 32px rgba(31, 30, 27, 0.08), 0 4px 8px rgba(31, 30, 27, 0.04);
   }
 
   .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-    --primary: 217.2 91.2% 59.8%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 224.3 76.3% 48%;
+    /* Dark mode is not currently wired anywhere in the app. The brand
+       direction is light-first (cream canvas), so this block exists only
+       to keep shadcn primitives rendering if someone toggles .dark.
+       Revisit with design when we actually ship a dark theme. */
+    --background: 40 7% 11%;
+    --foreground: 48 28% 97%;
+    --card: 40 7% 13%;
+    --card-foreground: 48 28% 97%;
+    --popover: 40 7% 13%;
+    --popover-foreground: 48 28% 97%;
+    --primary: 95 18% 52%;
+    --primary-foreground: 40 7% 11%;
+    --secondary: 40 7% 17%;
+    --secondary-foreground: 48 28% 97%;
+    --muted: 40 7% 17%;
+    --muted-foreground: 40 7% 65%;
+    --accent: 95 18% 22%;
+    --accent-foreground: 48 28% 97%;
+    --destructive: 5 47% 47%;
+    --destructive-foreground: 48 28% 97%;
+    --border: 40 7% 22%;
+    --input: 40 7% 22%;
+    --ring: 95 18% 52%;
   }
 }
 
@@ -54,6 +107,13 @@
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground font-sans;
+    font-feature-settings: "cv11", "ss01";
+  }
+  /* Every number in this product is tabular — fantasy stats, grades,
+     percentiles, timestamps. Apply globally to mono by default; authors
+     can also use Tailwind's `tabular-nums` utility anywhere. */
+  code, kbd, pre, samp, .font-mono {
+    font-variant-numeric: tabular-nums;
   }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,9 +1,25 @@
 import type { Metadata } from "next";
-import { Inter } from "next/font/google";
+import { Inter, Source_Serif_4, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 import { Providers } from "@/components/Providers";
 
-const inter = Inter({ subsets: ["latin"] });
+const inter = Inter({
+  subsets: ["latin"],
+  variable: "--font-sans",
+  display: "swap",
+});
+
+const sourceSerif = Source_Serif_4({
+  subsets: ["latin"],
+  variable: "--font-serif",
+  display: "swap",
+});
+
+const jetBrainsMono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono",
+  display: "swap",
+});
 
 export const metadata: Metadata = {
   title: "Dynasty DNA",
@@ -17,8 +33,11 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html lang="en">
-      <body className={inter.className}>
+    <html
+      lang="en"
+      className={`${inter.variable} ${sourceSerif.variable} ${jetBrainsMono.variable}`}
+    >
+      <body>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -16,6 +16,11 @@ export default {
       },
     },
     extend: {
+      fontFamily: {
+        sans: ["var(--font-sans)", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "sans-serif"],
+        serif: ["var(--font-serif)", "Georgia", "serif"],
+        mono: ["var(--font-mono)", "SF Mono", "Menlo", "Consolas", "monospace"],
+      },
       colors: {
         border: "hsl(var(--border))",
         input: "hsl(var(--input))",
@@ -50,11 +55,58 @@ export default {
           DEFAULT: "hsl(var(--card))",
           foreground: "hsl(var(--card-foreground))",
         },
+        cream: {
+          50: "var(--cream-50)",
+          100: "var(--cream-100)",
+          200: "var(--cream-200)",
+          300: "var(--cream-300)",
+        },
+        slate: {
+          300: "var(--slate-300)",
+          400: "var(--slate-400)",
+          500: "var(--slate-500)",
+          700: "var(--slate-700)",
+          800: "var(--slate-800)",
+          900: "var(--slate-900)",
+        },
+        sage: {
+          50: "var(--sage-50)",
+          100: "var(--sage-100)",
+          200: "var(--sage-200)",
+          300: "var(--sage-300)",
+          400: "var(--sage-400)",
+          500: "var(--sage-500)",
+          600: "var(--sage-600)",
+          700: "var(--sage-700)",
+          800: "var(--sage-800)",
+          900: "var(--sage-900)",
+        },
+        grade: {
+          a: "var(--grade-a)",
+          b: "var(--grade-b)",
+          c: "var(--grade-c)",
+          d: "var(--grade-d)",
+          f: "var(--grade-f)",
+        },
+        chart: {
+          1: "var(--chart-1)",
+          2: "var(--chart-2)",
+          3: "var(--chart-3)",
+          4: "var(--chart-4)",
+          5: "var(--chart-5)",
+          6: "var(--chart-6)",
+        },
       },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",
         sm: "calc(var(--radius) - 4px)",
+      },
+      boxShadow: {
+        xs: "var(--shadow-xs)",
+        sm: "var(--shadow-sm)",
+        md: "var(--shadow-md)",
+        lg: "var(--shadow-lg)",
       },
       keyframes: {
         "accordion-down": {
@@ -74,4 +126,3 @@ export default {
   },
   plugins: [require("tailwindcss-animate")],
 } satisfies Config;
-


### PR DESCRIPTION
## Summary

Phase 1 of the 6-phase [design-system rollout](https://github.com/jrygrande/dynasty-dna/issues/50). Lands the token + font foundation and a reference `/design` route. No page-level rewrites yet — those come in Phases 3–5.

- Replaces the default shadcn blue/gray palette with sage/cream/slate (Claude-inspired). Shadcn primitives + all existing `text-primary` / `bg-primary` usages re-skin for free — landing page `/` already looks transformed.
- Wires Source Serif 4 + JetBrains Mono alongside Inter via `next/font`, exposed as CSS variables `--font-sans/serif/mono`.
- Adds `sage-*`, `cream-*`, `slate-*`, `grade-a..f`, `chart-1..6` color scales to Tailwind — ready for Phase 3's shared-primitive rewrites.
- Copies 20 HTML preview cards from the Claude Design handoff bundle into `public/design-preview/`; `/design` route renders them as an iframe grid grouped by category (colors, type, spacing, components, brand).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (`/design` prerenders statically, 137 B)
- [x] Preview: `/` landing page renders with cream canvas, sage "DNA" accent, sage Get Started button
- [x] Preview: `/design` renders all 20 specimen cards in 5 groups; H1 uses Source Serif 4
- [x] Preview: computed styles verified — body bg `rgb(249,249,245)` (cream-50), `text-foreground` `rgb(30,29,26)` (slate-900), `--primary` = sage HSL, `--chart-1` aliases `--sage-500`
- [x] `/simplify` review pass (inlined `--chart-1` alias, dropped unused `ease-out-soft`, defaulted `/design` card height, consolidated `font-sans` into global body rule, removed overlap with Tailwind's `tabular-nums` utility)

Closes: part of #50 (Phase 1 only; phases 2–6 follow in subsequent PRs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)