### PR TITLE
feat(design): Phase 3 — port shared badge + chart primitives to tokens

### DIFF
--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -18,6 +18,9 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
+import { GradeBadge } from "@/components/GradeBadge";
+import { StatusBadge } from "@/components/StatusBadge";
+import { TypeBadge } from "@/components/TransactionCard";
 
 export const metadata: Metadata = {
   title: "Design system — Dynasty DNA",
@@ -163,6 +166,53 @@ export default function DesignSystemPage() {
                 <p className="text-xs text-muted-foreground">
                   Separator above renders as a single hairline.
                 </p>
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Grade badges</CardTitle>
+                <CardDescription>
+                  Earned colors: A sage → B dusty blue → C ochre → D
+                  terracotta → F muted red.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                {["A+", "A", "B+", "B", "C", "D", "D-", "F"].map((g) => (
+                  <GradeBadge key={g} grade={g} />
+                ))}
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Status pills</CardTitle>
+                <CardDescription>
+                  Shipped / in progress / planned / exploring. Used on
+                  roadmap + experiments.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                <StatusBadge status="shipped" />
+                <StatusBadge status="in-progress" />
+                <StatusBadge status="planned" />
+                <StatusBadge status="exploring" />
+              </CardContent>
+            </Card>
+
+            <Card>
+              <CardHeader>
+                <CardTitle>Transaction type pills</CardTitle>
+                <CardDescription>
+                  Trade / waiver / free agent / commissioner. Match the
+                  grade palette so the type signal sits beside grades.
+                </CardDescription>
+              </CardHeader>
+              <CardContent className="flex flex-wrap gap-2">
+                <TypeBadge type="trade" />
+                <TypeBadge type="waiver" />
+                <TypeBadge type="free_agent" />
+                <TypeBadge type="commissioner" />
               </CardContent>
             </Card>
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -55,18 +55,20 @@
     --sage-800: #38462D;
     --sage-900: #2B3623;
 
-    --grade-a: #4F7A3E;  /* deeper sage */
-    --grade-b: #3B6EA5;  /* dusty blue */
-    --grade-c: #C69B3C;  /* warm ochre */
-    --grade-d: #C27237;  /* terracotta */
-    --grade-f: #B2493F;  /* muted red */
+    /* Grade + chart tokens stored as RGB triplets so Tailwind's
+       `<alpha-value>` substitution works (e.g. `bg-grade-a/12`). */
+    --grade-a:  79 122  62;  /* #4F7A3E  deeper sage */
+    --grade-b:  59 110 165;  /* #3B6EA5  dusty blue */
+    --grade-c: 198 155  60;  /* #C69B3C  warm ochre */
+    --grade-d: 194 114  55;  /* #C27237  terracotta */
+    --grade-f: 178  73  63;  /* #B2493F  muted red */
 
-    --chart-1: var(--sage-500);
-    --chart-2: #3B6EA5;
-    --chart-3: #C27237;
-    --chart-4: #8A6DAD;
-    --chart-5: #C69B3C;
-    --chart-6: #5E8A8A;
+    --chart-1: 111 138  96;  /* #6F8A60  sage-500 */
+    --chart-2:  59 110 165;  /* #3B6EA5 */
+    --chart-3: 194 114  55;  /* #C27237 */
+    --chart-4: 138 109 173;  /* #8A6DAD */
+    --chart-5: 198 155  60;  /* #C69B3C */
+    --chart-6:  94 138 138;  /* #5E8A8A */
 
     /* Soft warm-shadowed elevation — never blue-tinted */
     --shadow-xs: 0 1px 2px rgba(31, 30, 27, 0.04);

--- a/src/components/AssetTimeline.tsx
+++ b/src/components/AssetTimeline.tsx
@@ -37,14 +37,18 @@ type TimelineEntry =
   | { type: "event"; event: EventData }
   | { type: "stint"; stint: StintData };
 
-const EVENT_STYLES: Record<string, { color: string; icon: string; label: string }> = {
-  draft_selected: { color: "bg-blue-500", icon: "D", label: "Drafted" },
-  trade: { color: "bg-purple-500", icon: "T", label: "Traded" },
-  pick_trade: { color: "bg-purple-500", icon: "P", label: "Pick Traded" },
-  waiver_add: { color: "bg-amber-500", icon: "W", label: "Waiver Claim" },
-  waiver_drop: { color: "bg-red-500", icon: "W", label: "Waiver Drop" },
-  free_agent_add: { color: "bg-green-500", icon: "F", label: "FA Pickup" },
-  free_agent_drop: { color: "bg-red-500", icon: "F", label: "FA Drop" },
+type EventStyle = { dot: string; text: string; icon: string; label: string };
+
+/* Add vs drop is conveyed by filled vs outlined dot, not just by opacity —
+   at 20px an alpha shift alone is near-invisible (and inaccessible). */
+const EVENT_STYLES: Record<string, EventStyle> = {
+  draft_selected: { dot: "bg-primary", text: "text-primary-foreground", icon: "D", label: "Drafted" },
+  trade: { dot: "bg-grade-b", text: "text-white", icon: "T", label: "Traded" },
+  pick_trade: { dot: "bg-grade-b", text: "text-white", icon: "P", label: "Pick traded" },
+  waiver_add: { dot: "bg-grade-c", text: "text-white", icon: "W", label: "Waiver claim" },
+  waiver_drop: { dot: "bg-background border-2 border-grade-c", text: "text-grade-c", icon: "W", label: "Waiver drop" },
+  free_agent_add: { dot: "bg-grade-a", text: "text-white", icon: "F", label: "FA pickup" },
+  free_agent_drop: { dot: "bg-background border-2 border-grade-a", text: "text-grade-a", icon: "F", label: "FA drop" },
 };
 
 function formatDate(timestamp: number | null): string {
@@ -189,8 +193,9 @@ export function AssetTimeline({
           }
 
           const event = entry.event;
-          const style = EVENT_STYLES[event.eventType] || {
-            color: "bg-gray-500",
+          const style: EventStyle = EVENT_STYLES[event.eventType] || {
+            dot: "bg-muted-foreground",
+            text: "text-white",
             icon: "?",
             label: event.eventType,
           };
@@ -201,9 +206,9 @@ export function AssetTimeline({
               <div key={event.id} className="relative pl-12">
                 {/* Event dot */}
                 <div
-                  className={`absolute left-[10px] top-3 w-5 h-5 rounded-full ${style.color} flex items-center justify-center z-10`}
+                  className={`absolute left-[10px] top-3 w-5 h-5 rounded-full ${style.dot} flex items-center justify-center z-10`}
                 >
-                  <span className="text-[9px] font-bold text-white">{style.icon}</span>
+                  <span className={`text-[9px] font-bold ${style.text}`}>{style.icon}</span>
                 </div>
 
                 <div className="mb-1">
@@ -225,9 +230,9 @@ export function AssetTimeline({
             <div key={event.id} className="relative pl-12">
               {/* Event dot */}
               <div
-                className={`absolute left-[10px] top-3 w-5 h-5 rounded-full ${style.color} flex items-center justify-center z-10`}
+                className={`absolute left-[10px] top-3 w-5 h-5 rounded-full ${style.dot} flex items-center justify-center z-10`}
               >
-                <span className="text-[9px] font-bold text-white">{style.icon}</span>
+                <span className={`text-[9px] font-bold ${style.text}`}>{style.icon}</span>
               </div>
 
               <div className="border rounded-lg p-3">
@@ -242,7 +247,7 @@ export function AssetTimeline({
                   <p className="text-xs text-muted-foreground">
                     Pick #{event.draftDetails.pickNo}, Round {event.draftDetails.round}
                     {event.draftDetails.isKeeper && (
-                      <span className="ml-1 text-blue-500">(Keeper)</span>
+                      <span className="ml-1 text-primary">(Keeper)</span>
                     )}
                   </p>
                 )}
@@ -251,13 +256,13 @@ export function AssetTimeline({
                 {event.transaction && event.eventType !== "trade" && (
                   <div className="text-sm text-muted-foreground mt-1">
                     {event.transaction.adds.map((a) => (
-                      <p key={a.playerId} className="text-green-600 dark:text-green-400">
+                      <p key={a.playerId} className="text-primary">
                         + {a.playerName} → {a.managerName}
                       </p>
                     ))}
                     {event.transaction.drops.map((d) => (
-                      <p key={d.playerId} className="text-red-600 dark:text-red-400">
-                        - {d.playerName} from {d.managerName}
+                      <p key={d.playerId} className="text-muted-foreground">
+                        − {d.playerName} from {d.managerName}
                       </p>
                     ))}
                   </div>

--- a/src/components/GradeBadge.tsx
+++ b/src/components/GradeBadge.tsx
@@ -1,13 +1,31 @@
-export const GRADE_COLORS: Record<string, string> = {
-  "A+": "bg-emerald-500/20 text-emerald-400 border-emerald-500/30",
-  A: "bg-emerald-500/15 text-emerald-400 border-emerald-500/25",
-  "B+": "bg-blue-500/15 text-blue-400 border-blue-500/25",
-  B: "bg-blue-500/10 text-blue-400 border-blue-500/20",
-  C: "bg-yellow-500/15 text-yellow-400 border-yellow-500/25",
-  D: "bg-orange-500/15 text-orange-400 border-orange-500/25",
-  "D-": "bg-orange-500/10 text-orange-400 border-orange-500/20",
-  F: "bg-red-500/15 text-red-400 border-red-500/25",
+const GRADE_TOKEN: Record<string, "a" | "b" | "c" | "d" | "f"> = {
+  "A+": "a",
+  A: "a",
+  "A-": "a",
+  "B+": "b",
+  B: "b",
+  "B-": "b",
+  "C+": "c",
+  C: "c",
+  "C-": "c",
+  "D+": "d",
+  D: "d",
+  "D-": "d",
+  F: "f",
 };
+
+const TOKEN_CLASSES: Record<"a" | "b" | "c" | "d" | "f", string> = {
+  a: "text-grade-a bg-grade-a/10 border-grade-a/25",
+  b: "text-grade-b bg-grade-b/8 border-grade-b/20",
+  c: "text-grade-c bg-grade-c/12 border-grade-c/28",
+  d: "text-grade-d bg-grade-d/12 border-grade-d/28",
+  f: "text-grade-f bg-grade-f/12 border-grade-f/28",
+};
+
+export function gradeColorClass(grade: string): string {
+  const token = GRADE_TOKEN[grade];
+  return token ? TOKEN_CLASSES[token] : "bg-muted text-muted-foreground border-border";
+}
 
 export function GradeBadge({
   grade,
@@ -16,12 +34,11 @@ export function GradeBadge({
   grade: string;
   size?: "xs" | "sm";
 }) {
-  const colorClass = GRADE_COLORS[grade] || "bg-muted text-muted-foreground";
   const sizeClass =
     size === "xs" ? "px-1.5 py-0.5 text-[10px]" : "px-2 py-0.5 text-xs";
   return (
     <span
-      className={`inline-flex items-center rounded font-bold border ${sizeClass} ${colorClass}`}
+      className={`inline-flex items-center rounded font-bold border ${sizeClass} ${gradeColorClass(grade)}`}
       aria-label={`Grade: ${grade}`}
     >
       {grade}

--- a/src/components/LineupEfficiencyCard.tsx
+++ b/src/components/LineupEfficiencyCard.tsx
@@ -118,10 +118,10 @@ function RosterRow({ roster }: { roster: RosterGrade }) {
                       <td className="px-2 py-1 text-right font-mono">
                         {w.slotBreakdown.followedBad}
                       </td>
-                      <td className="px-2 py-1 text-right font-mono text-emerald-400">
+                      <td className="px-2 py-1 text-right font-mono text-grade-a">
                         {w.slotBreakdown.brokeGood}
                       </td>
-                      <td className="px-2 py-1 text-right font-mono text-red-400">
+                      <td className="px-2 py-1 text-right font-mono text-grade-f">
                         {w.slotBreakdown.brokeBad}
                       </td>
                     </tr>

--- a/src/components/StatusBadge.tsx
+++ b/src/components/StatusBadge.tsx
@@ -1,28 +1,24 @@
-const STATUS_STYLES: Record<string, string> = {
-  shipped:
-    "bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400",
-  "in-progress":
-    "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
-  planned:
-    "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
-  exploring:
-    "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
+type Status = "shipped" | "in-progress" | "planned" | "exploring";
+
+const STATUS_STYLES: Record<Status, string> = {
+  shipped: "bg-grade-a/15 text-grade-a",
+  "in-progress": "bg-grade-b/15 text-grade-b",
+  planned: "bg-grade-c/15 text-grade-c",
+  exploring: "bg-chart-4/15 text-chart-4",
 };
 
-const STATUS_LABELS: Record<string, string> = {
+const STATUS_LABELS: Record<Status, string> = {
   shipped: "Shipped",
-  "in-progress": "In Progress",
+  "in-progress": "In progress",
   planned: "Planned",
   exploring: "Exploring",
 };
-
-type Status = "shipped" | "in-progress" | "planned" | "exploring";
 
 export function StatusBadge({ status }: { status: Status }) {
   return (
     <span
       className={`px-2 py-0.5 text-xs font-medium rounded-full whitespace-nowrap ${
-        STATUS_STYLES[status] || "bg-gray-100 text-gray-800"
+        STATUS_STYLES[status] || "bg-muted text-muted-foreground"
       }`}
     >
       {STATUS_LABELS[status] || status}

--- a/src/components/TransactionCard.tsx
+++ b/src/components/TransactionCard.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import type { AssetIdentifier } from "./AssetTimeline";
+import { GradeBadge } from "./GradeBadge";
 
 interface TransactionAdd {
   playerId: string;
@@ -89,50 +90,26 @@ function formatDate(timestamp: number | null): string {
   });
 }
 
-function TypeBadge({ type }: { type: string }) {
-  const styles: Record<string, string> = {
-    trade: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
-    waiver:
-      "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
-    free_agent:
-      "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-    commissioner:
-      "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
-  };
+const TYPE_STYLES: Record<string, string> = {
+  trade: "bg-grade-b/12 text-grade-b",
+  waiver: "bg-grade-c/15 text-grade-c",
+  free_agent: "bg-grade-a/12 text-grade-a",
+  commissioner: "bg-chart-4/15 text-chart-4",
+};
 
-  const labels: Record<string, string> = {
-    trade: "Trade",
-    waiver: "Waiver",
-    free_agent: "Free Agent",
-    commissioner: "Commissioner",
-  };
+const TYPE_LABELS: Record<string, string> = {
+  trade: "Trade",
+  waiver: "Waiver",
+  free_agent: "Free agent",
+  commissioner: "Commissioner",
+};
 
+export function TypeBadge({ type }: { type: string }) {
   return (
     <span
-      className={`px-2 py-0.5 text-xs font-medium rounded-full ${styles[type] || "bg-gray-100 text-gray-800"}`}
+      className={`px-2 py-0.5 text-xs font-medium rounded-full ${TYPE_STYLES[type] || "bg-muted text-muted-foreground"}`}
     >
-      {labels[type] || type}
-    </span>
-  );
-}
-
-function GradeBadge({ grade }: { grade: string }) {
-  const styles: Record<string, string> = {
-    "A+": "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-    A: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-    "B+": "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
-    B: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
-    C: "bg-gray-100 text-gray-800 dark:bg-gray-700/30 dark:text-gray-400",
-    D: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
-    "D-": "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400",
-    F: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-  };
-
-  return (
-    <span
-      className={`px-1.5 py-0.5 text-xs font-bold rounded ${styles[grade] || "bg-gray-100 text-gray-800"}`}
-    >
-      {grade}
+      {TYPE_LABELS[type] || type}
     </span>
   );
 }
@@ -232,7 +209,7 @@ function TradeCard({ tx, familyId, onAssetClick }: { tx: TransactionData; family
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Received</p>
                 {side.received.map((a) => (
-                  <p key={a.playerId} className="text-sm text-green-600 dark:text-green-400">
+                  <p key={a.playerId} className="text-sm text-primary">
                     + <PlayerLink playerId={a.playerId} playerName={a.playerName} familyId={familyId} />
                     {onAssetClick && (
                       <TimelineIcon onClick={() => onAssetClick({ kind: "player", playerId: a.playerId })} />
@@ -247,7 +224,7 @@ function TradeCard({ tx, familyId, onAssetClick }: { tx: TransactionData; family
                   <p className="text-xs text-muted-foreground mb-1">Received</p>
                 )}
                 {side.picksReceived.map((p, i) => (
-                  <p key={i} className="text-sm text-green-600 dark:text-green-400">
+                  <p key={i} className="text-sm text-primary">
                     + {p.season} {p.round}{getRoundSuffix(p.round)} Round Pick
                     {p.originalOwnerName && p.originalOwnerName !== side.managerName && (
                       <span className="text-xs text-muted-foreground ml-1">
@@ -270,8 +247,8 @@ function TradeCard({ tx, familyId, onAssetClick }: { tx: TransactionData; family
               <div>
                 <p className="text-xs text-muted-foreground mb-1">Sent</p>
                 {side.sent.map((d) => (
-                  <p key={d.playerId} className="text-sm text-red-600 dark:text-red-400">
-                    - <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
+                  <p key={d.playerId} className="text-sm text-muted-foreground">
+                    − <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
                     {onAssetClick && (
                       <TimelineIcon onClick={() => onAssetClick({ kind: "player", playerId: d.playerId })} />
                     )}
@@ -285,8 +262,8 @@ function TradeCard({ tx, familyId, onAssetClick }: { tx: TransactionData; family
                   <p className="text-xs text-muted-foreground mb-1">Sent</p>
                 )}
                 {side.picksSent.map((p, i) => (
-                  <p key={i} className="text-sm text-red-600 dark:text-red-400">
-                    - {p.season} {p.round}{getRoundSuffix(p.round)} Round Pick
+                  <p key={i} className="text-sm text-muted-foreground">
+                    − {p.season} {p.round}{getRoundSuffix(p.round)} Round Pick
                     {p.originalOwnerName && p.originalOwnerName !== side.managerName && (
                       <span className="text-xs text-muted-foreground ml-1">
                         ({p.originalOwnerName}&apos;s)
@@ -326,7 +303,7 @@ function SimpleTransactionCard({ tx, familyId }: { tx: TransactionData; familyId
             Week {tx.week} &middot; {formatDate(tx.createdAt)}
           </span>
           {waiverBid !== null && (
-            <span className="text-xs text-amber-600 dark:text-amber-400 font-mono">
+            <span className="text-xs text-foreground font-mono">
               ${waiverBid}
             </span>
           )}
@@ -337,7 +314,7 @@ function SimpleTransactionCard({ tx, familyId }: { tx: TransactionData; familyId
       <div className="space-y-1">
         {tx.adds.map((a) => (
           <p key={a.playerId} className="text-sm">
-            <span className="text-green-600 dark:text-green-400 font-medium">
+            <span className="text-primary font-medium">
               + <PlayerLink playerId={a.playerId} playerName={a.playerName} familyId={familyId} />
             </span>
             <span className="text-muted-foreground ml-2">
@@ -347,8 +324,8 @@ function SimpleTransactionCard({ tx, familyId }: { tx: TransactionData; familyId
         ))}
         {tx.drops.map((d) => (
           <p key={d.playerId} className="text-sm">
-            <span className="text-red-600 dark:text-red-400 font-medium">
-              - <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
+            <span className="text-muted-foreground font-medium">
+              − <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
             </span>
             <span className="text-muted-foreground ml-2">
               from {d.managerName}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -82,19 +82,19 @@ export default {
           900: "var(--sage-900)",
         },
         grade: {
-          a: "var(--grade-a)",
-          b: "var(--grade-b)",
-          c: "var(--grade-c)",
-          d: "var(--grade-d)",
-          f: "var(--grade-f)",
+          a: "rgb(var(--grade-a) / <alpha-value>)",
+          b: "rgb(var(--grade-b) / <alpha-value>)",
+          c: "rgb(var(--grade-c) / <alpha-value>)",
+          d: "rgb(var(--grade-d) / <alpha-value>)",
+          f: "rgb(var(--grade-f) / <alpha-value>)",
         },
         chart: {
-          1: "var(--chart-1)",
-          2: "var(--chart-2)",
-          3: "var(--chart-3)",
-          4: "var(--chart-4)",
-          5: "var(--chart-5)",
-          6: "var(--chart-6)",
+          1: "rgb(var(--chart-1) / <alpha-value>)",
+          2: "rgb(var(--chart-2) / <alpha-value>)",
+          3: "rgb(var(--chart-3) / <alpha-value>)",
+          4: "rgb(var(--chart-4) / <alpha-value>)",
+          5: "rgb(var(--chart-5) / <alpha-value>)",
+          6: "rgb(var(--chart-6) / <alpha-value>)",
         },
       },
       borderRadius: {
@@ -107,6 +107,12 @@ export default {
         sm: "var(--shadow-sm)",
         md: "var(--shadow-md)",
         lg: "var(--shadow-lg)",
+      },
+      opacity: {
+        8: "0.08",
+        12: "0.12",
+        15: "0.15",
+        28: "0.28",
       },
       keyframes: {
         "accordion-down": {


### PR DESCRIPTION
## Summary

Phase 3 of the [design-system rollout](https://github.com/jrygrande/dynasty-dna/issues/50). Rewrites the six highest-leverage components so every grade, status, and transaction-type signal comes from the sage/cream/slate token system. `src/components/` is now free of raw Tailwind palette classes.

### Components rewritten

- **`GradeBadge`** — `GRADE_TOKEN` maps `A+..F` to one of five token colors (`grade-a..f`). `gradeColorClass()` exported for Phase 4/5 reuse. Public props unchanged.
- **`StatusBadge`** — `status → grade/chart token` mapping; "In Progress" → sentence case per design spec.
- **`TransactionCard`** — deletes local duplicate `GradeBadge`, imports the shared one. `TypeBadge` exported and uses grade/chart tokens. `+ received` / `− sent` lines swap green/red for `text-primary` / `text-muted-foreground` with Unicode minus.
- **`LineupEfficiencyCard`** — smart-break column coloring moves from `text-emerald-400` / `text-red-400` to `text-grade-a` / `text-grade-f`.
- **`AssetTimeline`** — `EVENT_STYLES` consumes grade/chart tokens. Adds vs drops now differentiated by **filled vs outlined** dot (not opacity alone) for accessibility on 20px dots.
- **`ManagerRadarChart`** — audited; already token-native via `hsl(var(--primary))`.

### Enabling change

`--grade-a..f` and `--chart-1..6` CSS variables converted from hex to RGB-triplet form so Tailwind's `<alpha-value>` substitution works with opacity modifiers (e.g. `bg-grade-a/12`). `tailwind.config` extends the opacity scale with the non-default steps the design spec uses (`8, 12, 15, 28`).

### `/design` route

Three new specimen cards rendered via the real components: Grade badges (A–F), Status pills (shipped/in progress/planned/exploring), Transaction type pills (trade/waiver/free agent/commissioner).

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run build` clean (13 routes, /design 2.35 kB)
- [x] Preview: all three new specimen cards render at `/design` with correct earned colors
- [x] Preview: computed styles verified for A+, B+, C, D, F grades + all 4 status pills — each gets its rgba fill + token-colored text
- [x] `/simplify` pass applied 5 fixes: TypeBadge export + dedupe specimen, hoisted styles/labels to module scope, opacity-drift collapse (`/18` → `/15`), Unicode minus consistency, drop-dot a11y fix (outlined instead of opacity-only)
- [x] Checkpoint 3 passed — in-browser review approved

Part of #50 — Phase 3 of 6. Follow-up flagged: `src/app/(app)/league/[familyId]/manager/[userId]/page.tsx` lines 198-224 has the same raw-palette anti-pattern (`bg-purple-500/15`, `text-emerald-400`) and will be cleaned up in Phase 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)