### PR TITLE
feat(design): Phase 4 — public pages on tokens + editorial serif

### DIFF
--- a/src/app/(public)/changelog/page.tsx
+++ b/src/app/(public)/changelog/page.tsx
@@ -59,7 +59,7 @@ export default function ChangelogPage() {
     <div className="min-h-screen bg-background">
       <main className="container mx-auto px-6 py-12 max-w-3xl">
         <div className="mb-10">
-          <h1 className="text-3xl font-bold tracking-tight mb-2">Changelog</h1>
+          <h1 className="font-serif text-4xl font-medium tracking-tight mb-2">Changelog</h1>
           <p className="text-muted-foreground">
             What we&apos;ve shipped and why. Every feature starts with a
             hypothesis — here&apos;s what made it to production.
@@ -105,7 +105,7 @@ export default function ChangelogPage() {
                       <div className="flex items-start gap-4">
                         {/* Timeline dot */}
                         <div className="flex flex-col items-center pt-1.5">
-                          <div className="w-2.5 h-2.5 rounded-full bg-emerald-500" />
+                          <div className="w-2.5 h-2.5 rounded-full bg-primary" />
                           <div className="w-px h-full bg-border mt-1" />
                         </div>
 

--- a/src/app/(public)/experiments/page.tsx
+++ b/src/app/(public)/experiments/page.tsx
@@ -72,31 +72,31 @@ function formatLift(lift: number): string {
 
 const VERDICT_STYLES: Record<string, { bg: string; border: string; text: string; dot: string }> = {
   confirmed: {
-    bg: "bg-emerald-50 dark:bg-emerald-950/40",
-    border: "border-emerald-200 dark:border-emerald-800",
-    text: "text-emerald-800 dark:text-emerald-200",
-    dot: "bg-emerald-500",
+    bg: "bg-grade-a/8",
+    border: "border-grade-a/25",
+    text: "text-grade-a",
+    dot: "bg-grade-a",
   },
   rejected: {
-    bg: "bg-red-50 dark:bg-red-950/40",
-    border: "border-red-200 dark:border-red-800",
-    text: "text-red-800 dark:text-red-200",
-    dot: "bg-red-500",
+    bg: "bg-grade-f/8",
+    border: "border-grade-f/25",
+    text: "text-grade-f",
+    dot: "bg-grade-f",
   },
   inconclusive: {
-    bg: "bg-amber-50 dark:bg-amber-950/40",
-    border: "border-amber-200 dark:border-amber-800",
-    text: "text-amber-800 dark:text-amber-200",
-    dot: "bg-amber-500",
+    bg: "bg-grade-c/8",
+    border: "border-grade-c/25",
+    text: "text-grade-c",
+    dot: "bg-grade-c",
   },
 };
 
 function VerdictBlock({ verdict, reason }: { verdict: string | null; reason: string | null }) {
   const style = VERDICT_STYLES[verdict ?? ""] ?? {
-    bg: "bg-gray-50 dark:bg-gray-900",
-    border: "border-gray-200 dark:border-gray-700",
-    text: "text-gray-500 dark:text-gray-400",
-    dot: "bg-gray-400",
+    bg: "bg-muted/50",
+    border: "border-border",
+    text: "text-muted-foreground",
+    dot: "bg-muted-foreground",
   };
 
   return (
@@ -131,8 +131,8 @@ function LiftCell({ metric }: { metric: ScorecardMetric }) {
   const color = metric.lift === 0
     ? "text-muted-foreground"
     : isGood
-      ? "text-emerald-600 dark:text-emerald-400"
-      : "text-red-600 dark:text-red-400";
+      ? "text-grade-a"
+      : "text-grade-f";
 
   return (
     <span className={`font-mono font-medium ${color}`}>
@@ -159,7 +159,7 @@ function ScorecardTable({
     variant === "primary"
       ? "text-foreground"
       : variant === "guardrail"
-        ? "text-amber-700 dark:text-amber-400"
+        ? "text-grade-c"
         : "text-muted-foreground";
 
   return (
@@ -293,7 +293,7 @@ function ExperimentCard({ run }: { run: ExperimentRun }) {
         )}
 
         {run.error && (
-          <div className="p-3 bg-red-50 dark:bg-red-900/20 rounded-md text-sm text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">
+          <div className="p-3 bg-grade-f/8 rounded-md text-sm text-grade-f border border-grade-f/25">
             {run.error}
           </div>
         )}
@@ -302,7 +302,7 @@ function ExperimentCard({ run }: { run: ExperimentRun }) {
       <div className="border-t px-5 py-3 bg-muted/20">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3 text-xs text-muted-foreground">
-            <span className={`inline-flex items-center gap-1 ${run.status === "success" ? "text-emerald-600 dark:text-emerald-400" : run.status === "failed" ? "text-red-600 dark:text-red-400" : "text-blue-600"}`}>
+            <span className={`inline-flex items-center gap-1 ${run.status === "success" ? "text-grade-a" : run.status === "failed" ? "text-grade-f" : "text-grade-b"}`}>
               <span className="inline-block h-1.5 w-1.5 rounded-full bg-current" />
               {run.status}
             </span>
@@ -396,7 +396,7 @@ export default function ExperimentsPage() {
     <div className="min-h-screen bg-background">
       <main className="container mx-auto px-6 py-8 max-w-3xl">
         <div className="mb-10">
-          <h1 className="text-2xl font-bold tracking-tight">Experiments</h1>
+          <h1 className="font-serif text-4xl font-medium tracking-tight">Experiments</h1>
           <p className="text-muted-foreground mt-2 text-sm leading-relaxed max-w-2xl">
             Experiments tune Manager Process Score (MPS) — our composite
             grading algorithm — to be predictive of actual fantasy league
@@ -411,7 +411,7 @@ export default function ExperimentsPage() {
         )}
 
         {error && (
-          <div className="p-4 bg-red-50 dark:bg-red-900/20 rounded-lg text-sm text-red-700 dark:text-red-300 mb-6">
+          <div className="p-4 bg-grade-f/8 rounded-lg text-sm text-grade-f border border-grade-f/25 mb-6">
             {error}
           </div>
         )}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -15,10 +15,10 @@ export default function LandingPage() {
     <div className="min-h-screen bg-gradient-to-b from-background to-secondary/20">
       {/* Hero */}
       <section className="container mx-auto px-6 py-24 text-center max-w-3xl">
-        <h1 className="text-5xl font-bold tracking-tight mb-4">
+        <h1 className="font-serif text-5xl md:text-6xl font-medium tracking-tight mb-4 leading-[1.05]">
           Decode your dynasty <span className="text-primary">DNA</span>
         </h1>
-        <p className="text-xl text-muted-foreground mb-8 max-w-xl mx-auto">
+        <p className="text-lg text-muted-foreground mb-8 max-w-xl mx-auto leading-relaxed">
           Find out if you won the trade, graded every pick right, and where
           you&apos;re leaving points on your bench — all from your Sleeper data.
         </p>
@@ -58,7 +58,7 @@ export default function LandingPage() {
       {/* How It's Built */}
       <section className="border-t bg-muted/30">
         <div className="container mx-auto px-6 py-16 max-w-5xl">
-          <h2 className="text-2xl font-bold tracking-tight mb-2 text-center">
+          <h2 className="font-serif text-3xl md:text-4xl font-medium tracking-tight mb-3 text-center">
             Built by a dynasty player, for dynasty players
           </h2>
           <p className="text-muted-foreground text-center mb-10 max-w-lg mx-auto">
@@ -114,7 +114,7 @@ function FeatureCard({
   description: string;
 }) {
   return (
-    <div className="rounded-lg border bg-card p-6">
+    <div className="rounded-lg border bg-card p-6 hover:border-primary/50 transition-colors">
       <div className="mb-3">{icon}</div>
       <h3 className="font-semibold mb-1">{title}</h3>
       <p className="text-sm text-muted-foreground">{description}</p>

--- a/src/app/(public)/roadmap/page.tsx
+++ b/src/app/(public)/roadmap/page.tsx
@@ -63,10 +63,10 @@ function groupByPhase(
 
 function ExperimentCard({ flag }: { flag: FeatureFlag }) {
   return (
-    <div className="border border-dashed border-purple-300 dark:border-purple-700 rounded-lg p-4 bg-purple-50/50 dark:bg-purple-950/20">
+    <div className="border border-dashed border-chart-4/40 rounded-lg p-4 bg-chart-4/5">
       <div className="flex items-start justify-between gap-3 mb-2">
         <h3 className="text-sm font-semibold">{flag.title}</h3>
-        <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400 whitespace-nowrap">
+        <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-chart-4/15 text-chart-4 whitespace-nowrap">
           {flag.rolloutPercent}% rollout
         </span>
       </div>
@@ -126,7 +126,7 @@ export default function RoadmapPage() {
       <main className="container mx-auto px-6 py-12 max-w-3xl">
         {/* Header */}
         <div className="mb-10">
-          <h1 className="text-3xl font-bold tracking-tight mb-2">Roadmap</h1>
+          <h1 className="font-serif text-4xl font-medium tracking-tight mb-2">Roadmap</h1>
           <p className="text-muted-foreground">
             How we think about building Dynasty DNA. Every feature starts with a
             hypothesis and measurable success criteria.

--- a/src/components/AppNav.tsx
+++ b/src/components/AppNav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { signOut, useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { Menu, X } from "lucide-react";
+import { BrandLockup } from "./BrandMark";
 
 export function AppNav() {
   const { data: session } = useSession();
@@ -20,10 +21,8 @@ export function AppNav() {
   return (
     <header className="border-b">
       <div className="container mx-auto px-6 py-4 flex items-center justify-between">
-        <Link href="/dashboard" className="flex items-center gap-2">
-          <span className="text-lg font-bold tracking-tight">
-            Dynasty <span className="text-primary">DNA</span>
-          </span>
+        <Link href="/dashboard" aria-label="Dynasty DNA dashboard">
+          <BrandLockup />
         </Link>
 
         {/* Desktop nav */}

--- a/src/components/BrandMark.tsx
+++ b/src/components/BrandMark.tsx
@@ -1,0 +1,31 @@
+export function BrandMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 64 64"
+      className={className}
+      aria-hidden="true"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="3"
+      strokeLinecap="round"
+    >
+      <path d="M16 10 C 48 22, 16 42, 48 54" />
+      <path d="M48 10 C 16 22, 48 42, 16 54" />
+      <path d="M22 16 L 42 16" opacity="0.55" />
+      <path d="M18 26 L 46 26" opacity="0.55" />
+      <path d="M18 38 L 46 38" opacity="0.55" />
+      <path d="M22 48 L 42 48" opacity="0.55" />
+    </svg>
+  );
+}
+
+export function BrandLockup({ className }: { className?: string }) {
+  return (
+    <span className={`inline-flex items-center gap-2 ${className ?? ""}`}>
+      <BrandMark className="h-6 w-6 text-primary" />
+      <span className="font-serif text-lg font-medium tracking-tight text-foreground">
+        Dynasty <span className="text-primary">DNA</span>
+      </span>
+    </span>
+  );
+}

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -5,6 +5,7 @@ import { usePathname } from "next/navigation";
 import { useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 import { Menu, X } from "lucide-react";
+import { BrandLockup } from "./BrandMark";
 
 const navLinks = [
   { href: "/roadmap", label: "Roadmap" },
@@ -59,10 +60,8 @@ export function PublicNav() {
   return (
     <header className="border-b">
       <div className="container mx-auto px-6 py-4 flex items-center justify-between">
-        <Link href="/" className="flex items-center gap-2">
-          <span className="text-lg font-bold tracking-tight">
-            Dynasty <span className="text-primary">DNA</span>
-          </span>
+        <Link href="/" aria-label="Dynasty DNA home">
+          <BrandLockup />
         </Link>
 
         {/* Desktop nav */}


### PR DESCRIPTION
## Summary

Phase 4 of the [design-system rollout](https://github.com/jrygrande/dynasty-dna/issues/50). Four public-facing pages now read on-brand: cream canvas, sage accent, Source Serif 4 on hero + section headings, zero raw Tailwind palette classes.

- **Landing** — hero h1 and "Built by a dynasty player" h2 now use `font-serif` with display scale per spec; sub-copy drops to `text-lg leading-relaxed` (editorial lead); FeatureCards gain the `hover:border-primary/50` treatment that BuildCards already had.
- **Roadmap** — h1 serif; experiment-flag ExperimentCard pill + dashed outline swap purple-100/300 for `chart-4` tokens (mauve).
- **Changelog** — h1 serif; timeline dot `bg-emerald-500` → `bg-primary` (sage).
- **Experiments** — `VERDICT_STYLES` confirmed/rejected/inconclusive map to `grade-a`/`grade-f`/`grade-c` tokens with muted fallback; LiftCell good/bad coloring → `text-grade-a` / `text-grade-f`; guardrail header → `text-grade-c`; error banners + status indicators use grade tokens.

No structural changes. Phase 5 covers the authenticated app pages.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `grep -rnE '(text|bg|border)-(blue|emerald|red|green|yellow|gray|amber|orange|purple|slate)-[0-9]' src/app/(public)/` returns zero hits
- [x] Preview: `/` renders hero in Source Serif 4 with sage "DNA" accent
- [x] Preview: `/design` still renders all specimens + live primitives correctly
- [x] `/simplify` self-review: no issues to fix (small diff of class swaps; no duplication worth extracting at 3 instances)
- [x] Checkpoint 4 passed implicitly via in-browser screenshot showing serif landing hero

Part of #50 — Phase 4 of 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)