### PR TITLE
feat(design): Phase 5 — authenticated app pages on tokens

### DIFF
--- a/src/app/(app)/league/[familyId]/drafts/page.tsx
+++ b/src/app/(app)/league/[familyId]/drafts/page.tsx
@@ -47,12 +47,12 @@ interface DraftsResponse {
 }
 
 const POSITION_COLORS: Record<string, string> = {
-  QB: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400",
-  RB: "bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400",
-  WR: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400",
-  TE: "bg-orange-100 text-orange-800 dark:bg-orange-900/30 dark:text-orange-400",
-  K: "bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400",
-  DEF: "bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-400",
+  QB: "bg-grade-f/12 text-grade-f",
+  RB: "bg-grade-b/12 text-grade-b",
+  WR: "bg-grade-a/12 text-grade-a",
+  TE: "bg-grade-d/12 text-grade-d",
+  K: "bg-chart-4/15 text-chart-4",
+  DEF: "bg-muted text-muted-foreground",
 };
 
 import { GradeBadge } from "@/components/GradeBadge";
@@ -141,7 +141,7 @@ export default function DraftsPage() {
         )}
 
         {error && (
-          <div className="text-center py-8 text-red-500">{error}</div>
+          <div className="text-center py-8 text-grade-f">{error}</div>
         )}
 
         {!loading && !error && data && (
@@ -271,7 +271,7 @@ function DraftBoard({ draft, familyId }: { draft: DraftData; familyId: string })
                         <p className="text-xs text-muted-foreground truncate">
                           {pick.managerName}
                           {pick.isKeeper && (
-                            <span className="ml-1 text-amber-600 dark:text-amber-400">
+                            <span className="ml-1 text-primary">
                               (K)
                             </span>
                           )}

--- a/src/app/(app)/league/[familyId]/drafts/page.tsx
+++ b/src/app/(app)/league/[familyId]/drafts/page.tsx
@@ -247,7 +247,7 @@ function DraftBoard({ draft, familyId }: { draft: DraftData; familyId: string })
                         <div className="flex items-center gap-1.5">
                           {pick.position && (
                             <span
-                              className={`px-1.5 py-0.5 text-[10px] font-semibold rounded ${POSITION_COLORS[pick.position] || ""}`}
+                              className={`px-1.5 py-0 text-[10px] font-mono font-medium tracking-wide uppercase rounded-full ${POSITION_COLORS[pick.position] || ""}`}
                             >
                               {pick.position}
                             </span>

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -6,6 +6,7 @@ import Link from "next/link";
 import { GradeBadge } from "@/components/GradeBadge";
 import { ManagerRadarChart } from "@/components/ManagerRadarChart";
 import { ManagerGradeCard } from "@/components/ManagerGradeCard";
+import { TypeBadge } from "@/components/TransactionCard";
 import { PILLAR_LABELS } from "@/lib/pillars";
 
 interface SeasonRow {
@@ -195,22 +196,14 @@ export default function ManagerPage() {
                 >
                   <div className="flex-1 min-w-0">
                     <div className="flex items-center gap-2 mb-1">
-                      <span
-                        className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                          tx.type === "trade"
-                            ? "bg-purple-500/15 text-purple-400"
-                            : "bg-amber-500/15 text-amber-400"
-                        }`}
-                      >
-                        {tx.type === "free_agent" ? "FA" : tx.type}
-                      </span>
+                      <TypeBadge type={tx.type} />
                       <span className="text-xs text-muted-foreground">
                         {tx.season} W{tx.week}
                       </span>
                     </div>
                     <div className="text-sm">
                       {tx.adds.length > 0 && (
-                        <span className="text-emerald-400">
+                        <span className="text-primary">
                           +{tx.adds.map((p) => p.name).join(", ")}
                         </span>
                       )}
@@ -218,8 +211,8 @@ export default function ManagerPage() {
                         <span className="text-muted-foreground mx-1">/</span>
                       )}
                       {tx.drops.length > 0 && (
-                        <span className="text-red-400">
-                          -{tx.drops.map((p) => p.name).join(", ")}
+                        <span className="text-muted-foreground">
+                          −{tx.drops.map((p) => p.name).join(", ")}
                         </span>
                       )}
                     </div>

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -51,14 +51,14 @@ function nflStatusLabel(status: string | null, isByeWeek: boolean): string {
 }
 
 function nflStatusColor(status: string | null, isByeWeek: boolean): string {
-  if (isByeWeek) return "text-sky-600 dark:text-sky-400";
+  if (isByeWeek) return "text-grade-b";
   if (!status) return "text-muted-foreground";
   switch (status) {
-    case "ACT": return "text-green-600 dark:text-green-400";
-    case "RES": return "text-red-600 dark:text-red-400";
-    case "INA": return "text-amber-600 dark:text-amber-400";
-    case "DEV": return "text-blue-600 dark:text-blue-400";
-    case "CUT": return "text-red-600 dark:text-red-400";
+    case "ACT": return "text-grade-a";
+    case "RES": return "text-grade-d";
+    case "INA": return "text-muted-foreground";
+    case "DEV": return "text-grade-b";
+    case "CUT": return "text-grade-f";
     default: return "text-muted-foreground";
   }
 }
@@ -66,15 +66,13 @@ function nflStatusColor(status: string | null, isByeWeek: boolean): string {
 function fantasyStatusBadge(entry: WeekEntry): { label: string; className: string } {
   if (entry.fantasyStatus === "starter") {
     const slot = entry.lineupSlot || "Starter";
-    // Color based on whether they actually played
     if (entry.nflStatus === "RES" || entry.nflStatus === "INA") {
-      return { label: slot, className: "bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300" };
+      return { label: slot, className: "bg-grade-f/12 text-grade-f" };
     }
-    return { label: slot, className: "bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300" };
+    return { label: slot, className: "bg-grade-a/12 text-grade-a" };
   }
-  // Bench — highlight if they scored well (wasted points)
   if (entry.points >= 15) {
-    return { label: "Bench", className: "bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300" };
+    return { label: "Bench", className: "bg-grade-c/15 text-grade-c" };
   }
   return { label: "Bench", className: "bg-secondary text-secondary-foreground" };
 }

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -28,7 +28,7 @@ function LoginContent() {
     <div className="min-h-screen flex items-center justify-center bg-gradient-to-b from-background to-secondary/20">
       <div className="max-w-sm w-full mx-auto px-6">
         <div className="text-center mb-8">
-          <h1 className="text-4xl font-bold tracking-tight mb-2">
+          <h1 className="font-serif text-4xl font-medium tracking-tight mb-2">
             Dynasty <span className="text-primary">DNA</span>
           </h1>
           <p className="text-muted-foreground">
@@ -37,7 +37,7 @@ function LoginContent() {
         </div>
 
         {error && (
-          <div className="text-sm text-red-600 bg-red-50 border border-red-200 rounded-lg p-3 mb-4 text-center dark:bg-red-950 dark:border-red-900 dark:text-red-400">
+          <div className="text-sm text-grade-f bg-grade-f/8 border border-grade-f/25 rounded-lg p-3 mb-4 text-center">
             Sign-in failed. Please try again.
           </div>
         )}
@@ -45,14 +45,14 @@ function LoginContent() {
         <div className="flex flex-col gap-3">
           <button
             onClick={() => signIn("google")}
-            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-white text-gray-800 border border-gray-300 hover:bg-gray-50 transition-colors font-medium"
+            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-card text-foreground border border-border hover:border-primary/50 transition-colors font-medium"
           >
             <GoogleIcon />
             Sign in with Google
           </button>
           <button
             onClick={() => signIn("github")}
-            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-gray-900 text-white hover:bg-gray-800 transition-colors font-medium"
+            className="flex items-center justify-center gap-3 px-6 py-3 rounded-lg bg-foreground text-background hover:bg-foreground/90 transition-colors font-medium"
           >
             <GitHubIcon />
             Sign in with GitHub


### PR DESCRIPTION
## Summary

Phase 5 of the [design-system rollout](https://github.com/jrygrande/dynasty-dna/issues/50). Closes the last raw Tailwind palette hits across `src/`. **Every color signal in the app now comes from the sage/cream/slate token system** — a full-repo grep for raw palette classes returns zero hits.

- **`/login`** — serif h1, sign-in error uses `grade-f` fill tokens, Google button uses `bg-card` + `border-border` + sage hover, GitHub button uses `bg-foreground` + `text-background` (warm slate, not pure black).
- **`/league/[familyId]/drafts`** — `POSITION_COLORS` swaps red/blue/green/orange/purple/gray for `grade-a..f` + `chart-4` tokens; keeper "(K)" tag uses `text-primary`; error banner `text-grade-f`.
- **`/league/[familyId]/manager/[userId]`** — inline trade/FA type pill replaced with the shared `TypeBadge`; `+`/`-` add/drop lines use `text-primary` / `text-muted-foreground` (matches TransactionCard + AssetTimeline).
- **`/league/[familyId]/player/[playerId]`** — `nflStatusColor` maps ACT/RES/INA/DEV/CUT + bye-week to grade + chart tokens; `fantasyStatusBadge` uses `grade-a/f/c` fills for starter-healthy / starter-injured / bench-wasted.

Dashboard + league index already use Inter for in-app headings per spec ("density is in the data, not the chrome") — no typography changes needed there.

### Minor behavior note

Manager page's `recentTransactions` previously abbreviated `free_agent → "FA"`; now uses the shared `TypeBadge` which spells out "Free agent". Consistent with the rest of the app but slightly wider; can add a `compact` prop later if it looks cramped in practice.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `grep -rnE '(text|bg|border)-(blue|emerald|red|green|yellow|gray|amber|orange|purple|slate|sky|pink|teal|lime|rose|fuchsia|cyan|indigo|violet)-[0-9]' src/` returns **zero hits**
- [x] Preview: `/login` renders serif h1, cream+sage Google button, dark warm-slate GitHub button, no console errors
- [x] Preview: `/design` still renders all specimens correctly
- [x] Self-review: 61 lines of class swaps + 1 import; no duplication; semantic tokens (`bg-card`, `bg-foreground`, etc.) used where appropriate

Part of #50 — Phase 5 of 6. Phase 6 adds the guardrails (ESLint rule + CLAUDE.md doc + GitHub Actions CI) so future work stays on-system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)