### PR TITLE
feat(design): Phase 6 — guardrails (ESLint rule + CI + CLAUDE.md)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,24 @@
+{
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "JSXAttribute[name.name='className'] Literal[value=/\\b(text|bg|border|ring|divide|from|to|via|outline|decoration|placeholder|caret|accent|fill|stroke)-(blue|emerald|red|green|yellow|amber|orange|purple|pink|sky|teal|lime|rose|fuchsia|cyan|indigo|violet|gray|zinc|neutral|stone)-\\d/]",
+        "message": "Use design-system tokens (primary, muted, grade-*, chart-*, sage-*, cream-*) instead of raw Tailwind palette classes. See CLAUDE.md § Design system and /design for examples."
+      },
+      {
+        "selector": "JSXAttribute[name.name='className'] TemplateElement[value.raw=/\\b(text|bg|border|ring|divide|from|to|via|outline|decoration|placeholder|caret|accent|fill|stroke)-(blue|emerald|red|green|yellow|amber|orange|purple|pink|sky|teal|lime|rose|fuchsia|cyan|indigo|violet|gray|zinc|neutral|stone)-\\d/]",
+        "message": "Use design-system tokens (primary, muted, grade-*, chart-*, sage-*, cream-*) instead of raw Tailwind palette classes. See CLAUDE.md § Design system and /design for examples."
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": ["src/app/design/page.tsx", "src/components/ui/**/*.tsx"],
+      "rules": {
+        "no-restricted-syntax": "off"
+      }
+    }
+  ]
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,34 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Build
+        run: npm run build
+        env:
+          DATABASE_URL: postgres://stub:stub@localhost:5432/stub
+          NEXTAUTH_SECRET: stub-secret-for-ci
+          NEXTAUTH_URL: http://localhost:3000

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,3 +70,55 @@ npm run db:push      # Push schema changes
 - **Deployment:** Vercel
 - **Styling:** Tailwind CSS + shadcn/ui components
 - **External APIs:** Sleeper Fantasy Sports API
+
+## Design system
+
+Dynasty DNA uses a Claude-inspired token system: warm cream canvas, warm slate ink, sage as the only chromatic accent. **Never use raw Tailwind palette classes** (`bg-blue-500`, `text-emerald-400`, `bg-gray-100`, etc.) — an ESLint rule (`.eslintrc.json`) enforces this.
+
+Visit [`/design`](http://localhost:3000/design) in dev for the live reference: 20 specimen cards + the real shadcn primitives rendered with current tokens.
+
+### Color tokens
+
+| Role | Use | Class |
+|---|---|---|
+| Canvas | Page background, never pure white | `bg-background` (cream-50) |
+| Ink | Primary text, never pure black | `text-foreground` (slate-900) |
+| Accent | Links, primary buttons, positive signals, brand mark | `text-primary` / `bg-primary` (sage-500) |
+| Muted | Secondary text, inactive states, subtle fills | `text-muted-foreground` / `bg-muted` |
+| Cards | Raised surfaces | `bg-card` (white), with `border-border` hairline |
+| Destructive | Errors, irreversible actions | `bg-destructive` / `text-destructive` |
+| Grades A–F | ONLY in `GradeBadge` / grade columns | `text-grade-a..f` + `bg-grade-a..f/12` for fills |
+| Charts | Recharts series + muted categorical tags | `text-chart-1..6` / `bg-chart-1..6/15` |
+| Brand scales | Direct access when needed | `sage-{50..900}`, `cream-{50..300}`, `slate-{300..900}` |
+
+### Common recipes
+
+- **Positive/gain**: `text-primary` (not `text-green-*`)
+- **Negative/drop**: `text-muted-foreground` with Unicode `−` (not `text-red-*`)
+- **Error/danger**: `bg-grade-f/8 text-grade-f border-grade-f/25`
+- **Success/confirmed**: `bg-grade-a/8 text-grade-a border-grade-a/25`
+- **Warning/in-progress**: `bg-grade-c/8 text-grade-c border-grade-c/25`
+- **Info/neutral badge**: `bg-grade-b/8 text-grade-b`
+
+### Typography
+
+| Font | When | Class |
+|---|---|---|
+| Inter | Default UI everywhere | `font-sans` (default, no class needed) |
+| Source Serif 4 | **Marketing/editorial display only** — landing hero, public-page h1 | `font-serif` |
+| JetBrains Mono | **Every number** — stats, points, percentiles, grades, IDs | `font-mono` (tabular by default) |
+
+In-app headings (dashboard, league, player) stay Inter — the density is in the data, not the chrome.
+
+### Badges vs tags
+
+- **Grade badges** (A+, B, D−): bordered rectangle chip, `font-bold`, earned-rating treatment — use `<GradeBadge />`.
+- **Categorical tags** (positions, statuses, transaction types): `rounded-full` pill, `font-mono uppercase tracking-wide`, no border — metadata treatment. See `POSITION_COLORS` in drafts page + `<StatusBadge />` + `<TypeBadge />`.
+
+### Where to look
+
+- Tokens: [`src/app/globals.css`](src/app/globals.css) + [`tailwind.config.ts`](tailwind.config.ts)
+- Shared primitives: [`src/components/GradeBadge.tsx`](src/components/GradeBadge.tsx), [`StatusBadge.tsx`](src/components/StatusBadge.tsx), [`TransactionCard.tsx`](src/components/TransactionCard.tsx) (exports `TypeBadge`)
+- Shadcn primitives: [`src/components/ui/`](src/components/ui/) — prefer these for new components
+- Brand mark: [`src/components/BrandMark.tsx`](src/components/BrandMark.tsx)
+- Full handoff bundle (preview HTML cards): [`public/design-preview/`](public/design-preview/)

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -106,6 +106,22 @@ export default function DesignSystemPage() {
             eyeball tokens + components as we roll the redesign into real
             screens.
           </p>
+          <p className="mt-4 text-xs text-muted-foreground max-w-2xl">
+            Conventions + token reference live in{" "}
+            <a
+              href="https://github.com/jrygrande/dynasty-dna/blob/main/CLAUDE.md#design-system"
+              target="_blank"
+              rel="noreferrer"
+              className="text-primary hover:underline"
+            >
+              CLAUDE.md § Design system
+            </a>
+            . Raw Tailwind palette classes (<code className="font-mono">bg-blue-500</code>,{" "}
+            <code className="font-mono">text-red-400</code>, etc.) are lint errors —
+            use <code className="font-mono">text-primary</code>,{" "}
+            <code className="font-mono">text-grade-a..f</code>,{" "}
+            <code className="font-mono">bg-chart-1..6</code> instead.
+          </p>
         </div>
       </header>
 

--- a/src/services/batchHelper.ts
+++ b/src/services/batchHelper.ts
@@ -9,10 +9,8 @@ export const BATCH_SIZE = 200;
  * (with .onConflictDoUpdate/DoNothing/etc applied).
  */
 export async function batchInsert<T extends Record<string, unknown>>(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   table: any,
   values: T[],
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   onConflict: (query: any) => any,
   chunkSize = BATCH_SIZE
 ): Promise<void> {


### PR DESCRIPTION
## Summary

Final phase of the [design-system rollout](https://github.com/jrygrande/dynasty-dna/issues/50). Locks in the work so future PRs — human or Claude — can't drift back to raw Tailwind palette classes.

### What lands

- **`.eslintrc.json`** — new `no-restricted-syntax` rule bans raw palette classes (`bg-blue-500`, `text-emerald-400`, `bg-gray-100`, `hover:text-red-300`, etc.) in JSX `className` attributes, matching both string literals and template elements. Allow-lists `src/app/design/page.tsx` and `src/components/ui/**` (design reference + vendor). Error message points authors at CLAUDE.md + `/design`.
- **`.github/workflows/ci.yml`** — runs `npm ci && npm run lint && npx tsc --noEmit && npm run build` on every PR to `main` and push to `main`. The lint gate enforces the token rule at merge time.
- **`CLAUDE.md` § Design system** — token reference table, common recipes (positive/negative/error/success/warning), typography rules (Inter default, Source Serif 4 marketing-only, JetBrains Mono for numbers), badge-vs-tag distinction, and file pointers.
- **`/design`** — small callout under the hero linking to CLAUDE.md and reminding authors that raw palette classes are lint errors.
- **`src/services/batchHelper.ts`** — removes two dead `// eslint-disable-next-line @typescript-eslint/no-explicit-any` comments that referenced a rule not registered in this project (they were causing ESLint errors now that lint actually runs).

### Verification

- [x] `npm run lint` exits 0 — zero errors, 3 pre-existing `react-hooks/exhaustive-deps` warnings (out of scope)
- [x] `npx tsc --noEmit` clean
- [x] Intentionally dropped `<div className="bg-blue-500">` into `src/components/_LintTest.tsx`; lint fired with the design-system error message; file removed. Rule works end-to-end.
- [x] Preview: `/design` renders the new pointer paragraph linking to CLAUDE.md

### Rollout complete

Closes #50 — Phases 1–6 merged (#51, #52, #53, #54, #55, this).

Every color signal in `src/` now comes from the sage/cream/slate token system. Lint + CI enforce that invariant automatically. CLAUDE.md and `/design` give future authors (human and Claude) the rules and live examples they need to stay on-system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)