### PR TITLE
copy(landing): tighter hero sub + specific credits

### DIFF
--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -19,13 +19,12 @@ export default function LandingPage() {
           Decode your dynasty <span className="text-primary">DNA</span>
         </h1>
         <p className="text-lg text-muted-foreground mb-8 max-w-xl mx-auto leading-relaxed">
-          Find out if you won the trade, graded every pick right, and where
-          you&apos;re leaving points on your bench — all from your Sleeper data.
+          Trace how every decision ripples through your dynasty league.
         </p>
         <AuthCTA />
         <p className="text-xs text-muted-foreground mt-6">
-          Powered by 50+ data points per player &middot; FantasyCalc &middot;
-          nflverse
+          Only for Sleeper leagues &middot; Player valuations by FantasyCalc
+          and NFL data from nflverse
         </p>
       </section>
 

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -22,9 +22,9 @@ export default function LandingPage() {
           Trace how every decision ripples through your dynasty league.
         </p>
         <AuthCTA />
-        <p className="text-xs text-muted-foreground mt-6">
-          Only for Sleeper leagues &middot; Player valuations by FantasyCalc
-          &middot; NFL data from nflverse
+        <p className="text-xs text-muted-foreground mt-6 flex flex-wrap justify-center gap-x-2 gap-y-0.5">
+          <span>Only for Sleeper leagues</span>
+          <span>&middot; Player valuations by FantasyCalc &middot; NFL data from nflverse</span>
         </p>
       </section>
 

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -24,7 +24,7 @@ export default function LandingPage() {
         <AuthCTA />
         <p className="text-xs text-muted-foreground mt-6">
           Only for Sleeper leagues &middot; Player valuations by FantasyCalc
-          and NFL data from nflverse
+          &middot; NFL data from nflverse
         </p>
       </section>
 


### PR DESCRIPTION
## Summary

Two small copy changes on the landing page:

- **Hero sub** (under "Decode your dynasty DNA"): was "Find out if you won the trade, graded every pick right, and where you're leaving points on your bench — all from your Sleeper data." → "Trace how every decision ripples through your dynasty league." Drops the trade/pick/bench itemization (that list is already the feature cards below) in favor of a tighter dynasty-framed metaphor.
- **Credits footer**: was "Powered by 50+ data points per player · FantasyCalc · nflverse" → "Only for Sleeper leagues · Player valuations by FantasyCalc · NFL data from nflverse." Makes the Sleeper-only constraint explicit and names what each source contributes.

## Test plan

- [x] Preview: both lines render correctly on `/`, dot separators consistent with rest of the copy, serif hero still in Source Serif 4
- [x] `npx tsc --noEmit` unaffected (copy-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)