### PR TITLE
feat(graph): Phase 1 — progressive disclosure state model

### DIFF
--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -5,14 +5,12 @@ import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import {
   applyGraphFilters,
-  pickKey,
   type Graph,
   type GraphEdgeKind,
-  type GraphFocus,
   type GraphResponse,
   type GraphSelection,
 } from "@/lib/assetGraph";
-import type { EnrichedTransaction } from "@/lib/transactionEnrichment";
+import { useGraphVisibility } from "@/lib/useGraphVisibility";
 import { GraphFilterSidebar } from "@/components/graph/GraphFilterSidebar";
 import { GraphDetailDrawer } from "@/components/graph/GraphDetailDrawer";
 import { GraphHeaderStats } from "@/components/graph/GraphHeaderStats";
@@ -76,7 +74,7 @@ export default function GraphPage() {
   const searchParams = useSearchParams();
   const familyId = params.familyId as string;
 
-  // Parse URL params into strongly-typed state.
+  // URL state.
   const selectedSeasons = useMemo(() => parseCsv(searchParams.get("seasons")), [searchParams]);
   const selectedManagers = useMemo(() => parseCsv(searchParams.get("managers")), [searchParams]);
   const selectedEventTypes = useMemo<GraphEdgeKind[]>(() => {
@@ -84,10 +82,13 @@ export default function GraphPage() {
     return parsed.length > 0 ? parsed : DEFAULT_EVENT_TYPES;
   }, [searchParams]);
 
-  const focusPlayerId = searchParams.get("focusPlayerId");
-  const focusPickKey = searchParams.get("focusPickKey");
-  const focusManagerId = searchParams.get("focusManagerId");
-  const focusHops = Number.parseInt(searchParams.get("focusHops") ?? "2", 10) || 2;
+  const seedRaw = searchParams.get("seed");
+  const expandedRaw = searchParams.get("expanded");
+  const removedRaw = searchParams.get("removed");
+  const seed = useMemo(() => parseCsv(seedRaw), [seedRaw]);
+  const expanded = useMemo(() => new Set(parseCsv(expandedRaw)), [expandedRaw]);
+  const removed = useMemo(() => new Set(parseCsv(removedRaw)), [removedRaw]);
+
   const layoutMode: "band" | "dagre" =
     searchParams.get("layout") === "dagre" ? "dagre" : "band";
   const selection = parseSelection(searchParams.get("selection"));
@@ -99,30 +100,6 @@ export default function GraphPage() {
     return "deeplink";
   })();
 
-  const focus: GraphFocus | null = useMemo(() => {
-    if (focusPlayerId) return { kind: "player", playerId: focusPlayerId };
-    if (focusPickKey) {
-      const parts = focusPickKey.split(":");
-      if (parts.length === 4) {
-        const [leagueId, pickSeason, roundStr, originalRosterStr] = parts;
-        const pickRound = Number.parseInt(roundStr, 10);
-        const pickOriginalRosterId = Number.parseInt(originalRosterStr, 10);
-        if (!Number.isNaN(pickRound) && !Number.isNaN(pickOriginalRosterId)) {
-          return {
-            kind: "pick",
-            leagueId,
-            pickSeason,
-            pickRound,
-            pickOriginalRosterId,
-          };
-        }
-      }
-    }
-    if (focusManagerId) return { kind: "manager", userId: focusManagerId };
-    return null;
-  }, [focusPlayerId, focusPickKey, focusManagerId]);
-
-  // URL mutation helper — preserves unspecified params.
   const updateUrl = useCallback(
     (updates: Record<string, string | null>) => {
       const next = new URLSearchParams(searchParams.toString());
@@ -135,7 +112,6 @@ export default function GraphPage() {
     [router, searchParams],
   );
 
-  // Responsive breakpoint detection.
   const [isNarrow, setIsNarrow] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
     return window.innerWidth < 1024;
@@ -148,32 +124,15 @@ export default function GraphPage() {
     return () => window.removeEventListener("resize", onResize);
   }, []);
 
-  // Fetch graph data when filter params change.
   const [response, setResponse] = useState<GraphResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const analyticsFiredRef = useRef(false);
   const seasonsBootstrappedRef = useRef(false);
-  const focusBootstrappedRef = useRef(false);
   const [tooltipDismissed, setTooltipDismissed] = useState<boolean>(() => {
     if (typeof window === "undefined") return true;
     return Boolean(window.localStorage.getItem("graph_tooltip_dismissed"));
   });
-
-  // Only focus / layout changes trigger a refetch — seasons/managers/eventTypes
-  // are applied client-side via applyGraphFilters (see fetched-graph useMemo
-  // below). This keeps filter toggles instant and avoids DB round-trips.
-  const fetchKey = useMemo(
-    () =>
-      JSON.stringify({
-        focusPlayerId,
-        focusPickKey,
-        focusManagerId,
-        focusHops,
-        layout: layoutMode,
-      }),
-    [focusPlayerId, focusPickKey, focusManagerId, focusHops, layoutMode],
-  );
 
   useEffect(() => {
     let cancelled = false;
@@ -181,13 +140,7 @@ export default function GraphPage() {
       setLoading(true);
       setError(null);
       try {
-        const qs = new URLSearchParams();
-        if (focusPlayerId) qs.set("focusPlayerId", focusPlayerId);
-        if (focusPickKey) qs.set("focusPickKey", focusPickKey);
-        if (focusManagerId) qs.set("focusManagerId", focusManagerId);
-        qs.set("focusHops", String(focusHops));
-        qs.set("layout", layoutMode);
-        const res = await fetch(`/api/leagues/${familyId}/graph?${qs.toString()}`);
+        const res = await fetch(`/api/leagues/${familyId}/graph`);
         if (!res.ok) {
           throw new Error(`Graph API ${res.status}`);
         }
@@ -205,12 +158,9 @@ export default function GraphPage() {
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [familyId, fetchKey]);
+  }, [familyId]);
 
-  // Apply user filters client-side against the fetched graph. Only seasons /
-  // managers / eventTypes participate here; focus+hops+layout were already
-  // applied server-side (see route.ts `focusSubgraph` + layout()).
+  // Season/manager/eventType filters are client-side on the fetched graph.
   const filteredGraph: Graph | null = useMemo(() => {
     if (!response) return null;
     return applyGraphFilters(
@@ -226,7 +176,19 @@ export default function GraphPage() {
     );
   }, [response, selectedSeasons, selectedManagers, selectedEventTypes, layoutMode]);
 
-  // Bootstrap: default seasons = latest season once first response lands.
+  // Progressive-disclosure visibility: seed + expansions − removed.
+  const visibility = useGraphVisibility(filteredGraph, { seed, expanded, removed });
+
+  const visibleGraph: Graph | null = useMemo(() => {
+    if (!filteredGraph) return null;
+    return {
+      nodes: visibility.visibleNodes,
+      edges: visibility.visibleEdges,
+      stats: filteredGraph.stats,
+    };
+  }, [filteredGraph, visibility]);
+
+  // Bootstrap default seasons once response lands.
   useEffect(() => {
     if (!response || seasonsBootstrappedRef.current) return;
     if (selectedSeasons.length === 0 && response.seasons.length > 0) {
@@ -238,48 +200,6 @@ export default function GraphPage() {
     }
   }, [response, selectedSeasons.length, updateUrl]);
 
-  // Bootstrap: auto-focus on highest-hop transaction on first load (if no focus set).
-  useEffect(() => {
-    if (!response || focusBootstrappedRef.current) return;
-    if (focus) {
-      focusBootstrappedRef.current = true;
-      return;
-    }
-    const trades = Object.values(response.transactions).filter((t) => t.type === "trade");
-    if (trades.length === 0) {
-      focusBootstrappedRef.current = true;
-      return;
-    }
-    const top = trades.reduce<EnrichedTransaction | null>((best, tx) => {
-      const hops = (tx.adds?.length ?? 0) + (tx.draftPicks?.length ?? 0);
-      if (!best) return tx;
-      const bestHops = (best.adds?.length ?? 0) + (best.draftPicks?.length ?? 0);
-      return hops > bestHops ? tx : best;
-    }, null);
-    if (!top) {
-      focusBootstrappedRef.current = true;
-      return;
-    }
-    focusBootstrappedRef.current = true;
-    // Manager userId is stable across leagues but EnrichedTransaction only
-    // carries per-league rosterId/name — match by display name against the
-    // graph's manager nodes to recover the userId.
-    const managerName = top.managers[0]?.name;
-    const managerNode = managerName
-      ? response.nodes.find((n) => n.kind === "manager" && n.displayName === managerName)
-      : undefined;
-    if (managerNode && managerNode.kind === "manager") {
-      updateUrl({ focusManagerId: managerNode.userId });
-      trackEvent("graph_focus_set", { focusType: "manager", hops: focusHops });
-      return;
-    }
-    if (top.adds.length > 0) {
-      updateUrl({ focusPlayerId: top.adds[0].playerId });
-      trackEvent("graph_focus_set", { focusType: "player", hops: focusHops });
-    }
-  }, [response, focus, focusHops, updateUrl]);
-
-  // Analytics: fire graph_view_opened once per response.
   useEffect(() => {
     if (!response || analyticsFiredRef.current) return;
     analyticsFiredRef.current = true;
@@ -292,9 +212,8 @@ export default function GraphPage() {
     });
   }, [response, familyId, from, selectedSeasons]);
 
-  // Dismissable onboarding toast.
   const showOnboarding =
-    !tooltipDismissed && response !== null && response.nodes.length > 0;
+    !tooltipDismissed && visibility.visibleNodes.length > 0;
   const dismissOnboarding = useCallback(() => {
     if (typeof window !== "undefined") {
       window.localStorage.setItem("graph_tooltip_dismissed", "1");
@@ -302,7 +221,6 @@ export default function GraphPage() {
     setTooltipDismissed(true);
   }, []);
 
-  // Filter change handlers.
   const handleSeasonsChange = useCallback(
     (seasons: string[]) => updateUrl({ seasons: seasons.join(",") || null }),
     [updateUrl],
@@ -315,25 +233,6 @@ export default function GraphPage() {
     (e: GraphEdgeKind[]) => updateUrl({ eventTypes: e.join(",") || null }),
     [updateUrl],
   );
-  const handleFocusChange = useCallback(
-    (f: GraphFocus | null) => {
-      const updates: Record<string, string | null> = {
-        focusPlayerId: null,
-        focusPickKey: null,
-        focusManagerId: null,
-      };
-      if (f?.kind === "player") updates.focusPlayerId = f.playerId;
-      else if (f?.kind === "pick") updates.focusPickKey = pickKey(f);
-      else if (f?.kind === "manager") updates.focusManagerId = f.userId;
-      updateUrl(updates);
-      if (f) trackEvent("graph_focus_set", { focusType: f.kind, hops: focusHops });
-    },
-    [updateUrl, focusHops],
-  );
-  const handleFocusHopsChange = useCallback(
-    (n: number) => updateUrl({ focusHops: String(n) }),
-    [updateUrl],
-  );
   const handleLayoutModeChange = useCallback(
     (m: "band" | "dagre") => updateUrl({ layout: m }),
     [updateUrl],
@@ -344,15 +243,50 @@ export default function GraphPage() {
     [updateUrl],
   );
 
+  const handleExpand = useCallback(
+    (nodeId: string) => {
+      if (expanded.has(nodeId)) return;
+      const next = Array.from(expanded);
+      next.push(nodeId);
+      updateUrl({
+        expanded: next.join(","),
+        selection: `node:${nodeId}`,
+      });
+      trackEvent("graph_node_expanded", { nodeId });
+    },
+    [expanded, updateUrl],
+  );
+
+  const handleRemove = useCallback(
+    (nodeId: string) => {
+      const nextRemoved = new Set(removed);
+      nextRemoved.add(nodeId);
+      const nextExpanded = new Set(expanded);
+      nextExpanded.delete(nodeId);
+      const nextSeed = seed.filter((id) => id !== nodeId);
+      const updates: Record<string, string | null> = {
+        removed: Array.from(nextRemoved).join(",") || null,
+        expanded: Array.from(nextExpanded).join(",") || null,
+        seed: nextSeed.join(",") || null,
+      };
+      if (selection?.type === "node" && selection.nodeId === nodeId) {
+        updates.selection = null;
+      }
+      updateUrl(updates);
+      trackEvent("graph_node_removed", { nodeId });
+    },
+    [expanded, removed, seed, selection, updateUrl],
+  );
+
   const filterCount = useMemo(() => {
     let n = 0;
     if (selectedSeasons.length > 0) n += 1;
     if (selectedManagers.length > 0) n += 1;
     if (selectedEventTypes.length !== DEFAULT_EVENT_TYPES.length) n += 1;
-    if (focus) n += 1;
+    if (seed.length > 0) n += 1;
     if (layoutMode !== "band") n += 1;
     return n;
-  }, [selectedSeasons, selectedManagers, selectedEventTypes, focus, layoutMode]);
+  }, [selectedSeasons, selectedManagers, selectedEventTypes, seed, layoutMode]);
 
   const seasonLabel = useMemo(() => {
     if (selectedSeasons.length === 1) return selectedSeasons[0];
@@ -364,14 +298,14 @@ export default function GraphPage() {
     return "";
   }, [selectedSeasons, response]);
 
-  // Mobile digest for narrow viewports.
   if (isNarrow) {
     return <MobileDigest familyId={familyId} response={response} loading={loading} />;
   }
 
+  const hasSeed = seed.length > 0;
+
   return (
     <div className="flex flex-col flex-1 min-h-0">
-      {/* Top header */}
       <div className="border-b">
         <div className="px-6 py-3 flex items-center gap-4">
           <Link
@@ -385,13 +319,11 @@ export default function GraphPage() {
           {filteredGraph && (
             <GraphHeaderStats stats={filteredGraph.stats} seasonLabel={seasonLabel} />
           )}
-          <CopyLinkButton hasFocus={Boolean(focus)} filterCount={filterCount} />
+          <CopyLinkButton hasFocus={hasSeed} filterCount={filterCount} />
         </div>
       </div>
 
-      {/* Main three-column area */}
       <div className="flex-1 flex min-h-0 relative">
-        {/* Sidebar */}
         <div className="w-72 border-r overflow-y-auto p-4 shrink-0">
           {response ? (
             <GraphFilterSidebar
@@ -400,14 +332,10 @@ export default function GraphPage() {
               selectedSeasons={selectedSeasons}
               selectedManagers={selectedManagers}
               selectedEventTypes={selectedEventTypes}
-              focus={focus}
-              focusHops={focusHops}
               layoutMode={layoutMode}
               onSeasonsChange={handleSeasonsChange}
               onManagersChange={handleManagersChange}
               onEventTypesChange={handleEventTypesChange}
-              onFocusChange={handleFocusChange}
-              onFocusHopsChange={handleFocusHopsChange}
               onLayoutModeChange={handleLayoutModeChange}
             />
           ) : (
@@ -415,7 +343,6 @@ export default function GraphPage() {
           )}
         </div>
 
-        {/* Center canvas */}
         <div className="flex-1 relative min-w-0">
           {loading && !response && <CanvasSkeleton />}
           {error && !loading && (
@@ -432,24 +359,27 @@ export default function GraphPage() {
               </div>
             </div>
           )}
-          {filteredGraph && !error && (
+          {!hasSeed && response && !error && <EmptyState familyId={familyId} />}
+          {hasSeed && visibleGraph && !error && (
             <AssetGraph
-              nodes={filteredGraph.nodes}
-              edges={filteredGraph.edges}
+              nodes={visibleGraph.nodes}
+              edges={visibleGraph.edges}
               layoutMode={layoutMode}
               selection={selection}
               onSelect={handleSelectionChange}
+              expandedNodeIds={expanded}
+              onExpand={handleExpand}
+              onRemove={handleRemove}
             />
           )}
 
-          {/* Onboarding toast */}
           {showOnboarding && (
             <div
               role="status"
               className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 max-w-md px-4 py-2.5 rounded-md bg-foreground text-background shadow-lg flex items-center gap-3"
             >
               <span className="text-xs">
-                Click a manager to see their assets. Click an edge to see the trade.
+                Click a node to expand its trade partners. Click again to see details. Hover for the × to remove.
               </span>
               <button
                 type="button"
@@ -462,17 +392,45 @@ export default function GraphPage() {
           )}
         </div>
 
-        {/* Right drawer (conditional) */}
-        {selection && filteredGraph && response && (
+        {selection && visibleGraph && response && (
           <GraphDetailDrawer
             selection={selection}
-            nodes={filteredGraph.nodes}
-            edges={filteredGraph.edges}
+            nodes={visibleGraph.nodes}
+            edges={visibleGraph.edges}
             transactions={response.transactions}
             familyId={familyId}
             onClose={handleCloseSelection}
           />
         )}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState({ familyId }: { familyId: string }) {
+  return (
+    <div className="flex items-center justify-center h-full p-8">
+      <div className="max-w-md text-center space-y-4">
+        <h2 className="text-lg font-semibold">Start with an asset</h2>
+        <p className="text-sm text-muted-foreground leading-relaxed">
+          The trade network grows around whatever you seed it with. Open a player,
+          manager, or transaction to start — then click nodes to pull in their
+          partners one hop at a time.
+        </p>
+        <div className="flex items-center justify-center gap-3 pt-2">
+          <Link
+            href={`/league/${familyId}`}
+            className="px-3 py-1.5 text-sm rounded-md border bg-card hover:bg-accent hover:text-accent-foreground"
+          >
+            Back to league
+          </Link>
+          <Link
+            href={`/league/${familyId}/transactions`}
+            className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90"
+          >
+            Browse transactions
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -111,7 +111,7 @@ export default function ManagerPage() {
           </div>
           {graphEnabled && (
             <Link
-              href={`/league/${familyId}/graph?focusManagerId=${userId}&focusHops=2&from=manager`}
+              href={`/league/${familyId}/graph?seed=manager:${userId}&from=manager`}
               className="text-sm text-muted-foreground hover:text-foreground"
             >
               Trade network for this manager &rarr;

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -198,7 +198,7 @@ export default function PlayerDetailPage() {
               </Link>
               {graphEnabled && (
                 <Link
-                  href={`/league/${familyId}/graph?focusPlayerId=${playerId}&focusHops=2&from=player`}
+                  href={`/league/${familyId}/graph?seed=player:${playerId}&from=player`}
                   className="text-sm text-muted-foreground hover:text-foreground"
                 >
                   See trade network &rarr;

--- a/src/app/api/leagues/[familyId]/graph/route.ts
+++ b/src/app/api/leagues/[familyId]/graph/route.ts
@@ -23,16 +23,11 @@ import { resolveFamily } from "@/lib/familyResolution";
 import { resolveDraftPicks, findOriginalSlot, calculatePickNumber } from "@/lib/draft";
 import {
   buildGraphFromEvents,
-  focusSubgraph,
   pickKey,
   type BuildGraphInput,
   type GraphEdgeKind,
-  type GraphFocus,
-  type GraphNode,
   type GraphResponse,
-  type Graph,
 } from "@/lib/assetGraph";
-import { layout } from "@/components/graph/layout";
 
 const ALLOWED_EVENT_TYPES: ReadonlyArray<string> = [
   "trade",
@@ -70,9 +65,6 @@ function parseEdgeKinds(value: string | null): GraphEdgeKind[] {
 function parsePickKey(key: string):
   | { leagueId: string; pickSeason: string; pickRound: number; pickOriginalRosterId: number }
   | null {
-  // Format: "{leagueId}:{season}:{round}:{origRosterId}"
-  // leagueId can contain no colons (Sleeper ids are numeric), so split on last
-  // 3 colons.
   const parts = key.split(":");
   if (parts.length < 4) return null;
   const pickOriginalRosterId = parseInt(parts[parts.length - 1], 10);
@@ -83,13 +75,6 @@ function parsePickKey(key: string):
   return { leagueId, pickSeason, pickRound, pickOriginalRosterId };
 }
 
-function applyLayout(graph: Graph, mode: "band" | "dagre"): void {
-  const positions = layout(graph, mode);
-  for (const n of graph.nodes) {
-    const pos = positions.get(n.id);
-    if (pos) (n as GraphNode & { layout?: { x: number; y: number } }).layout = pos;
-  }
-}
 
 export async function GET(
   req: NextRequest,
@@ -105,13 +90,6 @@ export async function GET(
   const seasonsParam = parseCsvParam(url.searchParams.get("seasons"));
   const managersParam = parseCsvParam(url.searchParams.get("managers"));
   const eventTypesParam = parseEdgeKinds(url.searchParams.get("eventTypes"));
-  const focusPlayerId = url.searchParams.get("focusPlayerId") || undefined;
-  const focusPickKey = url.searchParams.get("focusPickKey") || undefined;
-  const focusManagerId = url.searchParams.get("focusManagerId") || undefined;
-  const focusHopsRaw = url.searchParams.get("focusHops");
-  const focusHops = focusHopsRaw ? Math.max(0, parseInt(focusHopsRaw, 10) || 0) : 2;
-  const layoutRaw = url.searchParams.get("layout");
-  const layoutMode: "band" | "dagre" = layoutRaw === "dagre" ? "dagre" : "band";
 
   // ---------------------------------------------------------------
   // 2. Resolve family
@@ -355,7 +333,7 @@ export async function GET(
   // ---------------------------------------------------------------
   // 12. Build the graph
   // ---------------------------------------------------------------
-  let graph: Graph = buildGraphFromEvents({
+  const graph = buildGraphFromEvents({
     assetEvents: events.map((e) => ({
       id: e.id,
       leagueId: e.leagueId,
@@ -382,36 +360,14 @@ export async function GET(
     rosterToUser,
   });
 
-  // ---------------------------------------------------------------
-  // 13. Apply focus subgraph if requested
-  // ---------------------------------------------------------------
-  const focus: GraphFocus | null = (() => {
-    if (focusPlayerId) return { kind: "player", playerId: focusPlayerId };
-    if (focusManagerId) return { kind: "manager", userId: focusManagerId };
-    if (focusPickKey) {
-      const parsed = parsePickKey(focusPickKey);
-      if (parsed) return { kind: "pick", ...parsed };
-    }
-    return null;
-  })();
-  if (focus) {
-    graph = focusSubgraph(graph, focus, focusHops);
-  }
-
-  // ---------------------------------------------------------------
-  // 14. Apply server-side layout
-  // ---------------------------------------------------------------
-  applyLayout(graph, layoutMode);
-
-  // Noop-touch of filter params (for future in-query filtering). The current
-  // MVP applies filters client-side via applyGraphFilters(); we simply echo
-  // unused params here to keep the route contract consistent.
+  // Seasons/managers/eventTypes are applied client-side via applyGraphFilters;
+  // layout + visibility are derived client-side from seed/expanded/removed URL state.
   void seasonsParam;
   void managersParam;
   void eventTypesParam;
 
   // ---------------------------------------------------------------
-  // 15. Build response
+  // 13. Build response
   // ---------------------------------------------------------------
   const distinctSeasons = Array.from(new Set(members.map((m) => m.season))).sort(
     (a, b) => Number(a) - Number(b),

--- a/src/components/graph/AssetGraph.tsx
+++ b/src/components/graph/AssetGraph.tsx
@@ -24,7 +24,6 @@ import "reactflow/dist/style.css";
 
 import type {
   GraphEdge,
-  GraphFocus,
   GraphNode,
   GraphSelection,
 } from "@/lib/assetGraph";
@@ -40,8 +39,10 @@ export interface AssetGraphProps {
   edges: GraphEdge[];
   selection: GraphSelection | null;
   onSelect: (s: GraphSelection | null) => void;
-  onFocus?: (focus: GraphFocus) => void;
   layoutMode?: LayoutMode;
+  expandedNodeIds?: Set<string>;
+  onExpand?: (nodeId: string) => void;
+  onRemove?: (nodeId: string) => void;
 }
 
 type FlowNodeData = ManagerNodeData | PlayerNodeData | PickNodeData;
@@ -72,6 +73,9 @@ function AssetGraphInner({
   selection,
   onSelect,
   layoutMode = "band",
+  expandedNodeIds,
+  onExpand,
+  onRemove,
 }: AssetGraphProps) {
   const [hoveredNodeId, setHoveredNodeId] = useState<string | null>(null);
   const [hoveredEdgeId, setHoveredEdgeId] = useState<string | null>(null);
@@ -155,6 +159,8 @@ function AssetGraphInner({
             (e.target === hoveredNodeId && e.source === n.id),
         );
 
+      const isExpanded = expandedNodeIds?.has(n.id) ?? false;
+
       if (n.kind === "manager") {
         return {
           id: n.id,
@@ -167,6 +173,8 @@ function AssetGraphInner({
             tradeCount: n.tradeCount,
             selected: isSelected,
             dimmed: isDimmed,
+            expanded: isExpanded,
+            onRemove,
           },
         };
       }
@@ -183,6 +191,8 @@ function AssetGraphInner({
             team: n.team,
             selected: isSelected,
             dimmed: isDimmed,
+            expanded: isExpanded,
+            onRemove,
           },
         };
       }
@@ -199,14 +209,22 @@ function AssetGraphInner({
           resolvedPlayerName: n.resolvedPlayerName,
           selected: isSelected,
           dimmed: isDimmed,
+          expanded: isExpanded,
+          onRemove,
         },
       };
     });
-  }, [nodes, edges, positions, selection, hoveredNodeId]);
+  }, [nodes, edges, positions, selection, hoveredNodeId, expandedNodeIds, onRemove]);
 
   const onNodeClick = useCallback<NodeMouseHandler>(
-    (_, node) => onSelect({ type: "node", nodeId: node.id }),
-    [onSelect],
+    (_, node) => {
+      if (expandedNodeIds && !expandedNodeIds.has(node.id) && onExpand) {
+        onExpand(node.id);
+        return;
+      }
+      onSelect({ type: "node", nodeId: node.id });
+    },
+    [expandedNodeIds, onExpand, onSelect],
   );
 
   const onEdgeClick = useCallback<EdgeMouseHandler>(
@@ -242,7 +260,6 @@ function AssetGraphInner({
         onNodeMouseLeave={onNodeMouseLeave}
         onEdgeMouseEnter={onEdgeMouseEnter}
         onEdgeMouseLeave={onEdgeMouseLeave}
-        onlyRenderVisibleElements
         fitView
         proOptions={{ hideAttribution: true }}
       >

--- a/src/components/graph/GraphFilterSidebar.tsx
+++ b/src/components/graph/GraphFilterSidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import type { GraphEdgeKind, GraphFocus } from "@/lib/assetGraph";
+import type { GraphEdgeKind } from "@/lib/assetGraph";
 import { trackEvent } from "@/lib/analytics";
 
 interface ManagerOption {
@@ -16,14 +16,10 @@ interface GraphFilterSidebarProps {
   selectedSeasons: string[];
   selectedManagers: string[];
   selectedEventTypes: GraphEdgeKind[];
-  focus: GraphFocus | null;
-  focusHops: number;
   layoutMode: "band" | "dagre";
   onSeasonsChange: (s: string[]) => void;
   onManagersChange: (m: string[]) => void;
   onEventTypesChange: (e: GraphEdgeKind[]) => void;
-  onFocusChange: (f: GraphFocus | null) => void;
-  onFocusHopsChange: (n: number) => void;
   onLayoutModeChange: (m: "band" | "dagre") => void;
 }
 
@@ -79,14 +75,10 @@ export function GraphFilterSidebar({
   selectedSeasons,
   selectedManagers,
   selectedEventTypes,
-  focus,
-  focusHops,
   layoutMode,
   onSeasonsChange,
   onManagersChange,
   onEventTypesChange,
-  onFocusChange,
-  onFocusHopsChange,
   onLayoutModeChange,
 }: GraphFilterSidebarProps) {
   const [managerQuery, setManagerQuery] = useState("");
@@ -117,20 +109,6 @@ export function GraphFilterSidebar({
     onEventTypesChange(next);
     trackEvent("graph_filter_changed", { filterName: "eventTypes", newValue: next });
   }
-
-  function handleFocusKindChange(value: string) {
-    if (value === "none") {
-      onFocusChange(null);
-      return;
-    }
-    if (value === "manager" && managers.length > 0) {
-      const next: GraphFocus = { kind: "manager", userId: managers[0].userId };
-      onFocusChange(next);
-      trackEvent("graph_focus_set", { focusType: "manager", hops: focusHops });
-    }
-  }
-
-  const focusKind = focus?.kind ?? "none";
 
   return (
     <aside
@@ -240,62 +218,6 @@ export function GraphFilterSidebar({
             </label>
           </li>
         </ul>
-      </Section>
-
-      <Section title="Focus">
-        <div className="space-y-2">
-          <label className="block text-xs text-muted-foreground">Focus type</label>
-          <select
-            value={focusKind}
-            onChange={(e) => handleFocusKindChange(e.target.value)}
-            className="w-full px-2 py-1 text-xs rounded-md border bg-background"
-          >
-            <option value="none">None</option>
-            <option value="manager">Manager</option>
-          </select>
-
-          {focus?.kind === "manager" && (
-            <div>
-              <label className="block text-xs text-muted-foreground mb-1">Manager</label>
-              <select
-                value={focus.userId}
-                onChange={(e) => {
-                  const next: GraphFocus = { kind: "manager", userId: e.target.value };
-                  onFocusChange(next);
-                  trackEvent("graph_focus_set", { focusType: "manager", hops: focusHops });
-                }}
-                className="w-full px-2 py-1 text-xs rounded-md border bg-background"
-              >
-                {managers.map((m) => (
-                  <option key={m.userId} value={m.userId}>
-                    {m.displayName}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          <div>
-            <label className="block text-xs text-muted-foreground mb-1">
-              Hops: <span className="font-medium text-foreground">{focusHops}</span>
-            </label>
-            <input
-              type="range"
-              min={0}
-              max={4}
-              step={1}
-              value={focusHops}
-              onChange={(e) => {
-                const n = Number.parseInt(e.target.value, 10);
-                onFocusHopsChange(n);
-                if (focus) {
-                  trackEvent("graph_focus_set", { focusType: focus.kind, hops: n });
-                }
-              }}
-              className="w-full"
-            />
-          </div>
-        </div>
       </Section>
 
       <Section title="Layout" defaultOpen={false}>

--- a/src/components/graph/nodes/ManagerNode.tsx
+++ b/src/components/graph/nodes/ManagerNode.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import { Handle, Position, type NodeProps } from "reactflow";
 
 import { cn } from "@/lib/utils";
+import { RemoveButton } from "./RemoveButton";
 
 export interface ManagerNodeData {
   displayName: string;
@@ -11,6 +12,8 @@ export interface ManagerNodeData {
   tradeCount?: number;
   selected?: boolean;
   dimmed?: boolean;
+  expanded?: boolean;
+  onRemove?: (nodeId: string) => void;
 }
 
 function initials(name: string): string {
@@ -20,14 +23,16 @@ function initials(name: string): string {
   return (parts[0]![0]! + parts[parts.length - 1]![0]!).toUpperCase();
 }
 
-function ManagerNodeImpl({ data, selected }: NodeProps<ManagerNodeData>) {
+function ManagerNodeImpl({ id, data, selected }: NodeProps<ManagerNodeData>) {
   const isSelected = selected || data.selected;
+  const unexpanded = data.expanded === false;
   return (
     <div
       className={cn(
-        "flex items-center gap-2 rounded-md border bg-card px-3 py-2 shadow-sm",
+        "group relative flex items-center gap-2 rounded-md border bg-card px-3 py-2 shadow-sm",
         "text-card-foreground transition-opacity",
         isSelected && "ring-2 ring-primary",
+        unexpanded && !isSelected && "border-dashed",
         data.dimmed && "opacity-30",
       )}
       style={{ width: 140, height: 56 }}
@@ -42,7 +47,6 @@ function ManagerNodeImpl({ data, selected }: NodeProps<ManagerNodeData>) {
         aria-hidden="true"
       >
         {data.avatar ? (
-          // Avatar URL from Sleeper — render as background image so we don't add next/image config.
           <span
             className="block h-full w-full rounded-full bg-cover bg-center"
             style={{ backgroundImage: `url(${data.avatar})` }}
@@ -61,6 +65,7 @@ function ManagerNodeImpl({ data, selected }: NodeProps<ManagerNodeData>) {
           </div>
         ) : null}
       </div>
+      {data.onRemove && <RemoveButton onRemove={() => data.onRemove?.(id)} />}
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0" />
     </div>
   );

--- a/src/components/graph/nodes/PickNode.tsx
+++ b/src/components/graph/nodes/PickNode.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import { Handle, Position, type NodeProps } from "reactflow";
 
 import { cn } from "@/lib/utils";
+import { RemoveButton } from "./RemoveButton";
 
 export interface PickNodeData {
   pickSeason: string;
@@ -12,23 +13,26 @@ export interface PickNodeData {
   resolvedPlayerName?: string;
   selected?: boolean;
   dimmed?: boolean;
+  expanded?: boolean;
+  onRemove?: (nodeId: string) => void;
 }
 
-function PickNodeImpl({ data, selected }: NodeProps<PickNodeData>) {
+function PickNodeImpl({ id, data, selected }: NodeProps<PickNodeData>) {
   const isSelected = selected || data.selected;
+  const unexpanded = data.expanded === false;
   return (
     <div
       className={cn(
-        "relative flex flex-col justify-center rounded-md border bg-card px-2 py-1 shadow-sm",
+        "group relative flex flex-col justify-center rounded-md border bg-card px-2 py-1 shadow-sm",
         "text-card-foreground transition-opacity",
         isSelected && "ring-2 ring-primary",
+        unexpanded && !isSelected && "border-dashed",
         data.dimmed && "opacity-30",
       )}
       style={{ width: 112, height: 48 }}
       aria-label={`Draft pick ${data.pickSeason} round ${data.pickRound}`}
     >
       <Handle type="target" position={Position.Top} className="!bg-transparent !border-0" />
-      {/* Diamond accent in the top-right corner. */}
       <span
         className="absolute right-1 top-1 block h-2 w-2 rotate-45 bg-primary/70"
         aria-hidden="true"
@@ -49,6 +53,7 @@ function PickNodeImpl({ data, selected }: NodeProps<PickNodeData>) {
           &rarr; {data.resolvedPlayerName}
         </div>
       ) : null}
+      {data.onRemove && <RemoveButton onRemove={() => data.onRemove?.(id)} />}
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0" />
     </div>
   );

--- a/src/components/graph/nodes/PlayerNode.tsx
+++ b/src/components/graph/nodes/PlayerNode.tsx
@@ -4,6 +4,7 @@ import { memo } from "react";
 import { Handle, Position, type NodeProps } from "reactflow";
 
 import { cn } from "@/lib/utils";
+import { RemoveButton } from "./RemoveButton";
 
 export interface PlayerNodeData {
   name: string;
@@ -11,6 +12,8 @@ export interface PlayerNodeData {
   team: string | null;
   selected?: boolean;
   dimmed?: boolean;
+  expanded?: boolean;
+  onRemove?: (nodeId: string) => void;
 }
 
 const POSITION_STRIPE: Record<string, string> = {
@@ -22,15 +25,17 @@ const POSITION_STRIPE: Record<string, string> = {
   DEF: "bg-muted-foreground",
 };
 
-function PlayerNodeImpl({ data, selected }: NodeProps<PlayerNodeData>) {
+function PlayerNodeImpl({ id, data, selected }: NodeProps<PlayerNodeData>) {
   const isSelected = selected || data.selected;
   const stripe = (data.position && POSITION_STRIPE[data.position]) || "bg-muted-foreground";
+  const unexpanded = data.expanded === false;
   return (
     <div
       className={cn(
-        "relative flex items-center gap-2 overflow-hidden rounded-md border bg-card px-3 py-1.5 shadow-sm",
+        "group relative flex items-center gap-2 overflow-hidden rounded-md border bg-card px-3 py-1.5 shadow-sm",
         "text-card-foreground transition-opacity",
         isSelected && "ring-2 ring-primary",
+        unexpanded && !isSelected && "border-dashed",
         data.dimmed && "opacity-30",
       )}
       style={{ width: 128, height: 48 }}
@@ -49,6 +54,7 @@ function PlayerNodeImpl({ data, selected }: NodeProps<PlayerNodeData>) {
           {[data.position ?? "?", data.team ?? "--"].join(" · ")}
         </div>
       </div>
+      {data.onRemove && <RemoveButton onRemove={() => data.onRemove?.(id)} />}
       <Handle type="source" position={Position.Bottom} className="!bg-transparent !border-0" />
     </div>
   );

--- a/src/components/graph/nodes/RemoveButton.tsx
+++ b/src/components/graph/nodes/RemoveButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import type { MouseEvent } from "react";
+
+export function RemoveButton({ onRemove }: { onRemove: () => void }) {
+  function handleClick(e: MouseEvent<HTMLButtonElement>) {
+    e.stopPropagation();
+    e.preventDefault();
+    onRemove();
+  }
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      onMouseDown={(e) => e.stopPropagation()}
+      aria-label="Remove from graph"
+      className="absolute -right-1.5 -top-1.5 hidden h-4 w-4 items-center justify-center rounded-full border border-border bg-background text-[10px] leading-none text-muted-foreground shadow-sm group-hover:flex hover:text-destructive hover:border-destructive/50"
+    >
+      ×
+    </button>
+  );
+}

--- a/src/lib/useGraphVisibility.ts
+++ b/src/lib/useGraphVisibility.ts
@@ -1,0 +1,74 @@
+import { useMemo } from "react";
+import type { Graph, GraphEdge, GraphNode } from "./assetGraph";
+
+export interface VisibilityState {
+  seed: string[];
+  expanded: Set<string>;
+  removed: Set<string>;
+}
+
+export interface Visibility {
+  visibleNodes: GraphNode[];
+  visibleEdges: GraphEdge[];
+  isExpanded: (nodeId: string) => boolean;
+  isSeed: (nodeId: string) => boolean;
+}
+
+const EMPTY: Visibility = {
+  visibleNodes: [],
+  visibleEdges: [],
+  isExpanded: () => false,
+  isSeed: () => false,
+};
+
+export function useGraphVisibility(
+  graph: Graph | null,
+  { seed, expanded, removed }: VisibilityState,
+): Visibility {
+  return useMemo<Visibility>(() => {
+    if (!graph) return EMPTY;
+
+    const seedSet = new Set(seed);
+
+    const adjacency = new Map<string, string[]>();
+    for (const e of graph.edges) {
+      let a = adjacency.get(e.source);
+      if (!a) {
+        a = [];
+        adjacency.set(e.source, a);
+      }
+      a.push(e.target);
+      let b = adjacency.get(e.target);
+      if (!b) {
+        b = [];
+        adjacency.set(e.target, b);
+      }
+      b.push(e.source);
+    }
+
+    const visible = new Set<string>(seedSet);
+    for (const nodeId of expanded) {
+      const neighbors = adjacency.get(nodeId);
+      if (!neighbors) continue;
+      for (const nid of neighbors) visible.add(nid);
+      visible.add(nodeId);
+    }
+
+    for (const id of removed) visible.delete(id);
+
+    const visibleNodes = graph.nodes
+      .filter((n) => visible.has(n.id))
+      .map((n) => ({ ...n, layout: undefined }));
+
+    const visibleEdges = graph.edges.filter(
+      (e) => visible.has(e.source) && visible.has(e.target),
+    );
+
+    return {
+      visibleNodes,
+      visibleEdges,
+      isExpanded: (id) => expanded.has(id),
+      isSeed: (id) => seedSet.has(id),
+    };
+  }, [graph, seed, expanded, removed]);
+}


### PR DESCRIPTION
## Summary

First of the graph-feature phases. Replaces the "fetch full graph + focus-mode hide" paradigm with **seed → click to expand one hop → hover × to remove**. The graph grows around whatever asset the user seeded from, instead of loading everything and narrowing down.

## What changed

**URL state**
- OUT: `focusPlayerId`, `focusPickKey`, `focusManagerId`, `focusHops`
- IN: `seed` (CSV of node ids), `expanded` (CSV), `removed` (CSV)

**New:** [`src/lib/useGraphVisibility.ts`](../tree/feat/graph-progressive-disclosure/src/lib/useGraphVisibility.ts) — a pure hook that derives `{ visibleNodes, visibleEdges }` from `seed + expanded neighbors − removed` on top of the already-filtered graph. Also strips server `layout` positions so the canvas re-lays out the visible subset.

**API** ([route.ts](../tree/feat/graph-progressive-disclosure/src/app/api/leagues/%5BfamilyId%5D/graph/route.ts)): drop `focus*` params + server-side `focusSubgraph()` + `applyLayout()`. Server now returns the full graph; narrowing happens client-side.

**Nodes:**
- Unexpanded render with a dashed border (visual affordance).
- Click unexpanded → expand + select; click expanded → select (drawer).
- Hover → `×` button in top-right (new [`RemoveButton`](../tree/feat/graph-progressive-disclosure/src/components/graph/nodes/RemoveButton.tsx)). Click × → remove, clear stale selection, strip from expanded set.

**Sidebar:** drop Focus section (dropdown + hops slider). Seasons / Managers / Event types / Layout remain.

**Entry points:** player → `?seed=player:<id>`; manager → `?seed=manager:<id>`. Overview and transactions links unchanged; they land on the new empty state prompting the user to open an asset. (Per-transaction multi-seed and seed picker land in Phase 3.)

**Compat:** `focusSubgraph()` stays exported from [`assetGraph.ts`](../tree/feat/graph-progressive-disclosure/src/lib/assetGraph.ts) with tests intact — removal deferred to Phase 4.

**ReactFlow:** drop `onlyRenderVisibleElements` — its viewport culling was hiding expanded neighbors before `fitView` caught up. Visible subsets stay small (tens of nodes), so the optimization isn't needed.

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` clean (pre-existing warnings only)
- `npm test` → 31/31 pass
- `npm run build` clean; `/league/[familyId]/graph` bundle at 79 kB
- Walked end-to-end at `/league/afc3acf8-…/graph?seed=manager:…&seasons=2023`:
  - Fresh load → 1 dashed manager
  - Click → 13 nodes / 13 edges, drawer opens
  - Click a player → 15 nodes / 19 edges
  - × on that player → 12 nodes / 12 edges; URL gains `removed=…`; removed nodes stay removed under re-expansion

## Test plan

- [ ] `/league/afc3acf8-2d18-47c9-80c1-998252c9a06a/graph?seed=manager:719188103478198272&seasons=2023` renders one dashed manager node
- [ ] Click manager → it goes solid, neighbors fan out dashed
- [ ] Click a neighbor → it goes solid + drawer opens with its details
- [ ] Hover a node → `×` shows top-right; click → node + orphans leave the graph
- [ ] Refresh the page with `removed=…` in the URL → state restores
- [ ] Empty `/graph` (no seed) shows "Start with an asset" copy + buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)