### PR TITLE
fix(auth): defer DrizzleAdapter / getDb() until first adapter call

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,4 +1,5 @@
 import { type NextAuthOptions } from "next-auth";
+import type { Adapter } from "next-auth/adapters";
 import GoogleProvider from "next-auth/providers/google";
 import GitHubProvider from "next-auth/providers/github";
 import { DrizzleAdapter } from "@auth/drizzle-adapter";
@@ -41,13 +42,39 @@ if (providers.length === 0) {
   console.error("No OAuth providers configured! Users will not be able to sign in.");
 }
 
+/**
+ * Lazy adapter: defers `DrizzleAdapter(getDb(), ...)` until next-auth invokes
+ * its first method (sign-in, link account, etc.). Without this, the adapter —
+ * and therefore `getDb()` — runs at module-load time, which means:
+ *   - any cold start that imports this module pays the DB-init cost even when
+ *     the request never touches auth, and
+ *   - the production build fails outright if `DATABASE_URL` isn't visible to
+ *     Next.js during static analysis (collect page data).
+ */
+function createLazyAdapter(): Adapter {
+  let real: Adapter | null = null;
+  const resolve = (): Adapter => {
+    if (!real) {
+      real = DrizzleAdapter(getDb(), {
+        usersTable: users,
+        accountsTable: accounts,
+        sessionsTable: sessions,
+        verificationTokensTable: verificationTokens,
+      }) as Adapter;
+    }
+    return real;
+  };
+  return new Proxy({} as Adapter, {
+    get(_target, prop) {
+      const target = resolve() as unknown as Record<string | symbol, unknown>;
+      const value = target[prop];
+      return typeof value === "function" ? (value as (...args: unknown[]) => unknown).bind(target) : value;
+    },
+  });
+}
+
 export const authOptions: NextAuthOptions = {
-  adapter: DrizzleAdapter(getDb(), {
-    usersTable: users,
-    accountsTable: accounts,
-    sessionsTable: sessions,
-    verificationTokensTable: verificationTokens,
-  }) as NextAuthOptions["adapter"],
+  adapter: createLazyAdapter(),
   providers,
   session: {
     strategy: "jwt",


### PR DESCRIPTION
## Summary

- Wrap `DrizzleAdapter(getDb(), ...)` in a Proxy that defers DB init until the first adapter method call
- `getDb()` was running at module-load time, which (a) would fail `next build` if `DATABASE_URL` is absent and (b) runs DB init on every cold start even for non-auth requests
- Now only auth flows (sign-in, link-account) trigger the adapter, and all other requests skip DB init entirely

Cherry-picked from `claude/dynasty-dna-asset-graph-O849H` (`af87cc0`). Independent of the graph feature work.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npm run build` succeeds without `DATABASE_URL` set
- [ ] Sign-in flow still works (adapter resolves lazily on first auth call)
- [ ] Vercel preview deploy is READY

🤖 Generated with [Claude Code](https://claude.com/claude-code)