### PR TITLE
chore(graph): /simplify pass before main merge

### DIFF
--- a/src/components/graph/AssetGraph.tsx
+++ b/src/components/graph/AssetGraph.tsx
@@ -167,19 +167,12 @@ function AssetGraphInner({
     [seedIds, expandedEntries, edges, nodes, seedAssetKey],
   );
 
-  // Anchor-relative layout: prior positions stick, new nodes fan out from
-  // their spawn parent. The ref captures the previous render's targets so the
-  // next layout call can preserve them.
+  // Track the previous render's target positions so `deriveSpawnParents`
+  // (below) can identify newly-appearing nodes for the tween launch.
   const priorPositionsRef = useRef<Map<string, Pos>>(new Map());
 
   const targetPositions = useMemo(() => {
-    const computed = layout(
-      { nodes, edges },
-      layoutMode,
-      lanes,
-      priorPositionsRef.current,
-      seedIds,
-    );
+    const computed = layout({ nodes, edges }, lanes, seedIds);
     // User-dragged positions override the auto-layout. Layered here so the
     // tween hook treats a manual position as the new target and settles.
     if (manualPositions && manualPositions.size > 0) {
@@ -188,7 +181,7 @@ function AssetGraphInner({
       }
     }
     return computed;
-  }, [nodes, edges, layoutMode, lanes, manualPositions, seedIds]);
+  }, [nodes, edges, lanes, manualPositions, seedIds]);
 
   const spawnParents = useMemo(
     () => deriveSpawnParents(nodes, edges, new Set(priorPositionsRef.current.keys())),

--- a/src/components/graph/layout.ts
+++ b/src/components/graph/layout.ts
@@ -9,10 +9,8 @@
  * Y: derived from the lane index assigned by `assignLanes`. Sequential
  * lanes (0, +1, −1, +2, −2 …) produce vertical separation per thread.
  *
- * Current-roster pseudo-nodes pin to the column AFTER their lane's
- * rightmost transaction (per-lane, not global) so each manager's roster
- * sits compactly at the end of its branch instead of being pushed to
- * the global maxX.
+ * Current-roster pseudo-nodes are conceptually dated "today"; they pin
+ * to a single rightmost x and inherit their connecting thread's lane.
  *
  * Smooth motion across renders is the responsibility of
  * `useGraphPositionTween` — layout itself stays pure and deterministic.
@@ -30,8 +28,6 @@ const COLUMN_WIDTH = 270;
 // the canvas without losing chronological direction.
 const COMPRESSED_GAP = 150;
 const ROW_HEIGHT = 200;
-// Card height (collapsed) is ~140px; LANE_GAP at 240 leaves ~100px gap
-// between bands for edge routing while compacting the vertical span.
 const LANE_GAP = 240;
 const COLUMN_X0 = 80;
 const ROW_Y0 = 40;
@@ -40,44 +36,31 @@ export type Pos = { x: number; y: number };
 
 export function layout(
   graph: Pick<Graph, "nodes" | "edges">,
-  _mode: LayoutMode = "band",
   lanes?: Map<string, number>,
-  // `priorPositions` is retained for API compatibility (and read by the
-  // tween wiring), but the layout itself is purely chronological-by-lane
-  // now — smooth motion is the tween hook's job.
-  priorPositions?: Map<string, Pos>,
   seedIds?: string[],
 ): Map<string, Pos> {
   const positions = new Map<string, Pos>();
   if (graph.nodes.length === 0) return positions;
 
-  const transactions = graph.nodes.filter(
-    (n): n is Extract<GraphNode, { kind: "transaction" }> => n.kind === "transaction",
-  );
-  const currentRosters = graph.nodes.filter(
-    (n): n is Extract<GraphNode, { kind: "current_roster" }> => n.kind === "current_roster",
-  );
-
-  placeByLane(transactions, lanes ?? new Map(), seedIds ?? [], positions);
-
-  // -------------------------------------------------------------------------
-  // Current-roster nodes are conceptually dated "today" — newer than any
-  // transaction. Pin them all to the same x at the right edge so they
-  // form a clean right-edge anchor. Lane still drives y so each
-  // manager's roster aligns vertically with its branch.
-  // -------------------------------------------------------------------------
-  let globalMaxX = COLUMN_X0;
-  for (const pos of positions.values()) {
-    if (pos.x > globalMaxX) globalMaxX = pos.x;
+  const transactions: TxNode[] = [];
+  const currentRosters: Extract<GraphNode, { kind: "current_roster" }>[] = [];
+  for (const n of graph.nodes) {
+    if (n.kind === "transaction") transactions.push(n);
+    else if (n.kind === "current_roster") currentRosters.push(n);
   }
-  const rosterX = globalMaxX + COLUMN_WIDTH;
 
+  const laneMap = lanes ?? new Map<string, number>();
+  const maxTransactionX = placeByLane(transactions, laneMap, seedIds ?? [], positions);
+
+  // Current-roster nodes pin to a single x past the rightmost transaction.
+  // Lane drives y so each manager's roster aligns with its connecting thread.
+  const rosterX = maxTransactionX + COLUMN_WIDTH;
   const sortedRosters = [...currentRosters].sort((a, b) =>
     a.displayName.localeCompare(b.displayName),
   );
   const rosterStackByLane = new Map<number, number>();
   for (const n of sortedRosters) {
-    const lane = lanes?.get(n.id) ?? 0;
+    const lane = laneMap.get(n.id) ?? 0;
     const stackIdx = rosterStackByLane.get(lane) ?? 0;
     rosterStackByLane.set(lane, stackIdx + 1);
     positions.set(n.id, {
@@ -85,7 +68,6 @@ export function layout(
       y: ROW_Y0 + lane * LANE_GAP + stackIdx * ROW_HEIGHT,
     });
   }
-  void priorPositions;
 
   return positions;
 }
@@ -95,62 +77,60 @@ type TxNode = Extract<GraphNode, { kind: "transaction" }>;
 /**
  * Place transactions on a global chronological grid with VARIABLE column
  * gaps. Each unique `createdAt` becomes a timepoint with a single x.
- * Adjacent timepoints whose cards live on different lanes (no shared
- * lane) get a tighter `COMPRESSED_GAP`; same-lane neighbors get the
- * full `COLUMN_WIDTH` so they don't overlap on the same y. The
- * cumulative x is then anchored on the seed transaction so its column
- * sits at COLUMN_X0.
+ * Adjacent timepoints whose cards share a lane get full `COLUMN_WIDTH`
+ * separation so they don't visually overlap; cross-lane neighbors get
+ * the tighter `COMPRESSED_GAP`. A non-adjacent same-lane pair is also
+ * forced to ≥ `COLUMN_WIDTH` apart so compression can't sneak past.
  *
- * A safety constraint enforces that any two timepoints whose lane sets
- * share a lane are at least `COLUMN_WIDTH` apart, so non-adjacent
- * same-lane cards can't end up overlapping after compression.
+ * The seed transaction's column anchors x=COLUMN_X0 — older cards land
+ * left, newer right. Returns the rightmost x placed (for the roster
+ * column anchor in the caller).
  */
 function placeByLane(
   transactions: TxNode[],
   lanes: Map<string, number>,
   seedIds: string[],
   out: Map<string, Pos>,
-): void {
+): number {
+  if (transactions.length === 0) return COLUMN_X0;
+
   const seedSet = new Set(seedIds);
   const sorted = [...transactions].sort(compareTx);
 
-  const sortedTimes = [...new Set(sorted.map((n) => n.createdAt))].sort(
-    (a, b) => a - b,
-  );
-
-  // For each timepoint, the set of lanes that have cards at that time.
+  // Single pass: collect unique createdAts (in sorted order) AND the set of
+  // lanes touching each timepoint.
+  const sortedTimes: number[] = [];
   const lanesByTime = new Map<number, Set<number>>();
   for (const n of sorted) {
     let set = lanesByTime.get(n.createdAt);
-    if (!set) { set = new Set(); lanesByTime.set(n.createdAt, set); }
+    if (!set) {
+      set = new Set();
+      lanesByTime.set(n.createdAt, set);
+      sortedTimes.push(n.createdAt);
+    }
     set.add(lanes.get(n.id) ?? 0);
   }
 
-  // Cumulative x for each timepoint, with variable gap rule:
-  //  - same-lane neighbor (any prior lane appears at this time too) → COLUMN_WIDTH
-  //  - else → COMPRESSED_GAP
-  // Then enforce that any same-lane pair across non-adjacent timepoints
-  // still has ≥ COLUMN_WIDTH between them.
+  // Cumulative x for each timepoint with variable-gap rules.
   const xByTime = new Map<number, number>();
-  // Track each lane's last placed timepoint for the COLUMN_WIDTH safety check.
   const lastTimeByLane = new Map<number, number>();
-
   for (let i = 0; i < sortedTimes.length; i++) {
     const t = sortedTimes[i];
+    const currLanes = lanesByTime.get(t) as Set<number>;
     if (i === 0) {
       xByTime.set(t, 0);
-      for (const lane of lanesByTime.get(t) ?? []) lastTimeByLane.set(lane, t);
+      for (const lane of currLanes) lastTimeByLane.set(lane, t);
       continue;
     }
     const prevT = sortedTimes[i - 1];
-    const prevLanes = lanesByTime.get(prevT) ?? new Set<number>();
-    const currLanes = lanesByTime.get(t) ?? new Set<number>();
-    const sharedAdjacent = [...currLanes].some((l) => prevLanes.has(l));
-    const baseGap = sharedAdjacent ? COLUMN_WIDTH : COMPRESSED_GAP;
+    const prevLanes = lanesByTime.get(prevT) as Set<number>;
+    let sharedAdjacent = false;
+    for (const l of currLanes) {
+      if (prevLanes.has(l)) { sharedAdjacent = true; break; }
+    }
+    let x = (xByTime.get(prevT) ?? 0) + (sharedAdjacent ? COLUMN_WIDTH : COMPRESSED_GAP);
 
-    let x = (xByTime.get(prevT) ?? 0) + baseGap;
-
-    // Safety: ensure ≥ COLUMN_WIDTH from the most recent same-lane timepoint.
+    // Non-adjacent same-lane pairs must still be ≥ COLUMN_WIDTH apart.
     for (const lane of currLanes) {
       const lastT = lastTimeByLane.get(lane);
       if (lastT == null) continue;
@@ -165,9 +145,10 @@ function placeByLane(
   // Anchor x=COLUMN_X0 on the seed transaction's timepoint.
   const seedTx = sorted.find((n) => seedSet.has(n.id));
   const seedT = seedTx?.createdAt ?? sortedTimes[0];
-  const seedX = xByTime.get(seedT ?? 0) ?? 0;
+  const seedX = xByTime.get(seedT) ?? 0;
 
-  // Place each card.
+  // Place each card and track the rightmost x as we go.
+  let maxX = COLUMN_X0;
   const stackByTimeLane = new Map<string, number>();
   for (const n of sorted) {
     const lane = lanes.get(n.id) ?? 0;
@@ -175,11 +156,10 @@ function placeByLane(
     const stackIdx = stackByTimeLane.get(key) ?? 0;
     stackByTimeLane.set(key, stackIdx + 1);
     const x = COLUMN_X0 + ((xByTime.get(n.createdAt) ?? 0) - seedX);
-    out.set(n.id, {
-      x,
-      y: ROW_Y0 + lane * LANE_GAP + stackIdx * ROW_HEIGHT,
-    });
+    out.set(n.id, { x, y: ROW_Y0 + lane * LANE_GAP + stackIdx * ROW_HEIGHT });
+    if (x > maxX) maxX = x;
   }
+  return maxX;
 }
 
 function compareTx(a: TxNode, b: TxNode): number {

--- a/src/lib/graph/laneAssignment.ts
+++ b/src/lib/graph/laneAssignment.ts
@@ -67,11 +67,14 @@ export function assignLanes(
     (n): n is TransactionNode => n.kind === "transaction" && seedIds.includes(n.id),
   );
   const seedAssetOrder = seedNode ? buildSeedAssetVisualOrder(seedNode) : new Map<string, number>();
+  // Pre-compute insertion-order index so the comparator stays O(1) per
+  // call instead of O(n) via `indexOf`.
+  const insertionIdx = new Map(visibleAssetKeys.map((k, i) => [k, i]));
   const orderedKeys = visibleAssetKeys.slice().sort((a, b) => {
     const aIdx = seedAssetOrder.get(a) ?? Number.POSITIVE_INFINITY;
     const bIdx = seedAssetOrder.get(b) ?? Number.POSITIVE_INFINITY;
     if (aIdx !== bIdx) return aIdx - bIdx;
-    return visibleAssetKeys.indexOf(a) - visibleAssetKeys.indexOf(b);
+    return (insertionIdx.get(a) ?? 0) - (insertionIdx.get(b) ?? 0);
   });
 
   // Sequential lane assignment anchored on the seed asset. Use position

--- a/src/lib/useGraphVisibility.ts
+++ b/src/lib/useGraphVisibility.ts
@@ -161,8 +161,7 @@ export function useGraphVisibility(
     // click. Single-pass: only the immediately-revealed player's edges
     // are auto-expanded (no recursive cascade).
     for (const node of graph.nodes) {
-      if (node.kind !== "transaction") continue;
-      if (node.txKind !== "draft") continue;
+      if (node.kind !== "transaction" || node.txKind !== "draft") continue;
       if (!visible.has(node.id)) continue;
       for (const asset of node.assets) {
         if (asset.kind !== "player" || !asset.playerId) continue;


### PR DESCRIPTION
## Summary
Pre-merge cleanup pass on the layout-iteration commits that landed via PR #68. No behavior change — pure simplification.

### Changes
- **layout.ts**: drop dead \`_mode\` and \`priorPositions\` parameters; single-pass partition of transactions/currentRosters; track maxX during placement instead of re-iterating; merge sortedTimes/lanesByTime into one pass; trim stale iteration-history comments.
- **laneAssignment.ts**: pre-compute insertion-order index map for the sort comparator. Was using \`Array.indexOf\` inside the comparator (O(N²)); now O(N log N) total.
- **AssetGraph.tsx**: update \`layout()\` call site for the slimmer signature.

### Why now
Per project convention (\`feedback_pr_simplify.md\`): /simplify before finalizing a PR. PR #67 (\`feat/graph-asset-picker → main\`) is the production deploy and benefits from a clean integration tip.

## Test plan
- [x] \`npx tsc --noEmit\` clean
- [ ] Vercel preview renders the graph identically (no behavior change expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)