### PR TITLE
fix(graph): include originating pick chain on seeded player (#69)

### DIFF
--- a/src/components/graph/layout.ts
+++ b/src/components/graph/layout.ts
@@ -50,7 +50,8 @@ export function layout(
   }
 
   const laneMap = lanes ?? new Map<string, number>();
-  const maxTransactionX = placeByLane(transactions, laneMap, seedIds ?? [], positions);
+  const effectiveTime = effectiveCreatedAt(transactions, graph.edges);
+  const maxTransactionX = placeByLane(transactions, laneMap, seedIds ?? [], effectiveTime, positions);
 
   // Current-roster nodes pin to a single x past the rightmost transaction.
   // Lane drives y so each manager's roster aligns with its connecting thread.
@@ -90,23 +91,26 @@ function placeByLane(
   transactions: TxNode[],
   lanes: Map<string, number>,
   seedIds: string[],
+  effectiveTime: Map<string, number>,
   out: Map<string, Pos>,
 ): number {
   if (transactions.length === 0) return COLUMN_X0;
 
   const seedSet = new Set(seedIds);
-  const sorted = [...transactions].sort(compareTx);
+  const timeOf = (n: TxNode): number => effectiveTime.get(n.id) ?? n.createdAt;
+  const sorted = [...transactions].sort((a, b) => compareTx(a, b, timeOf));
 
-  // Single pass: collect unique createdAts (in sorted order) AND the set of
+  // Single pass: collect unique timepoints (in sorted order) AND the set of
   // lanes touching each timepoint.
   const sortedTimes: number[] = [];
   const lanesByTime = new Map<number, Set<number>>();
   for (const n of sorted) {
-    let set = lanesByTime.get(n.createdAt);
+    const t = timeOf(n);
+    let set = lanesByTime.get(t);
     if (!set) {
       set = new Set();
-      lanesByTime.set(n.createdAt, set);
-      sortedTimes.push(n.createdAt);
+      lanesByTime.set(t, set);
+      sortedTimes.push(t);
     }
     set.add(lanes.get(n.id) ?? 0);
   }
@@ -144,7 +148,7 @@ function placeByLane(
 
   // Anchor x=COLUMN_X0 on the seed transaction's timepoint.
   const seedTx = sorted.find((n) => seedSet.has(n.id));
-  const seedT = seedTx?.createdAt ?? sortedTimes[0];
+  const seedT = seedTx ? timeOf(seedTx) : sortedTimes[0];
   const seedX = xByTime.get(seedT) ?? 0;
 
   // Place each card and track the rightmost x as we go.
@@ -152,18 +156,69 @@ function placeByLane(
   const stackByTimeLane = new Map<string, number>();
   for (const n of sorted) {
     const lane = lanes.get(n.id) ?? 0;
-    const key = `${n.createdAt}|${lane}`;
+    const t = timeOf(n);
+    const key = `${t}|${lane}`;
     const stackIdx = stackByTimeLane.get(key) ?? 0;
     stackByTimeLane.set(key, stackIdx + 1);
-    const x = COLUMN_X0 + ((xByTime.get(n.createdAt) ?? 0) - seedX);
+    const x = COLUMN_X0 + ((xByTime.get(t) ?? 0) - seedX);
     out.set(n.id, { x, y: ROW_Y0 + lane * LANE_GAP + stackIdx * ROW_HEIGHT });
     if (x > maxX) maxX = x;
   }
   return maxX;
 }
 
-function compareTx(a: TxNode, b: TxNode): number {
-  if (a.createdAt !== b.createdAt) return a.createdAt - b.createdAt;
+/**
+ * Compute an effective `createdAt` per transaction that respects edge
+ * direction. Sleeper occasionally records pick_trade transactions with a
+ * `created_at` after the draft's start_time (commissioner approval lands
+ * during/after the draft), which would visually place the trade card to the
+ * right of the draft it feeds. This propagation pulls every source's
+ * effective time strictly below its target's, in BFS order from sinks.
+ */
+function effectiveCreatedAt(
+  transactions: TxNode[],
+  edges: Graph["edges"],
+): Map<string, number> {
+  const time = new Map<string, number>();
+  for (const n of transactions) time.set(n.id, n.createdAt);
+
+  // Adjacency: node id -> outgoing edges' target ids (transactions only).
+  const txIds = new Set(time.keys());
+  const outgoing = new Map<string, string[]>();
+  for (const e of edges) {
+    if (!txIds.has(e.source) || !txIds.has(e.target)) continue;
+    let arr = outgoing.get(e.source);
+    if (!arr) { arr = []; outgoing.set(e.source, arr); }
+    arr.push(e.target);
+  }
+
+  // Iterate to fixpoint. Each pass shrinks any source whose time isn't
+  // strictly less than every reachable target. Bound iterations defensively.
+  const MAX_ITER = 16;
+  for (let i = 0; i < MAX_ITER; i++) {
+    let changed = false;
+    for (const [src, targets] of outgoing) {
+      const ts = time.get(src);
+      if (ts == null) continue;
+      let earliestTarget = Infinity;
+      for (const tgt of targets) {
+        const tt = time.get(tgt);
+        if (tt != null && tt < earliestTarget) earliestTarget = tt;
+      }
+      if (earliestTarget !== Infinity && ts >= earliestTarget) {
+        time.set(src, earliestTarget - 1);
+        changed = true;
+      }
+    }
+    if (!changed) break;
+  }
+  return time;
+}
+
+function compareTx(a: TxNode, b: TxNode, timeOf: (n: TxNode) => number): number {
+  const ta = timeOf(a);
+  const tb = timeOf(b);
+  if (ta !== tb) return ta - tb;
   if (a.season !== b.season) return a.season.localeCompare(b.season);
   if (a.week !== b.week) return a.week - b.week;
   return a.id.localeCompare(b.id);

--- a/src/lib/assetGraph.ts
+++ b/src/lib/assetGraph.ts
@@ -563,6 +563,19 @@ export function buildGraphFromEvents(input: BuildGraphInput): Graph {
     const origUserName = origUser ? managerName(origUser) : null;
     const label = pickLabel(first, origUserName);
 
+    // A pick can never be traded after it's been used. When Sleeper records
+    // the pick_trade with a created_at after the draft's start_time (e.g.
+    // commissioner-approved during/after the draft), the global compareEvents
+    // sort puts draft_selected first and the trade orphans. Force the
+    // pick_trade events to stay in createdAt order, but always close with
+    // draft_selected last.
+    events.sort((a, b) => {
+      const aIsDraft = a.eventType === "draft_selected";
+      const bIsDraft = b.eventType === "draft_selected";
+      if (aIsDraft !== bIsDraft) return aIsDraft ? 1 : -1;
+      return (a.createdAt ?? 0) - (b.createdAt ?? 0);
+    });
+
     let tenureOwner: string | null = null;
     let tenureStart: { nodeId: string; season: string; week: number } | null = null;
 

--- a/src/lib/useGraphVisibility.ts
+++ b/src/lib/useGraphVisibility.ts
@@ -115,20 +115,20 @@ export function useGraphVisibility(
     // computation. Whole-node expansion entries don't contribute here.
     const expandedAssetKeySet = new Set<string>();
 
-    // The seed asset is auto-expanded — its full thread (e.g. a player's
-    // draft → trades → current roster) shows by default without the user
-    // having to click `+` on the seed asset's row. Treat it like an
-    // expansion entry for the purposes of edge/node visibility AND chain
-    // membership.
-    if (seedAssetKey) {
-      expandedAssetKeySet.add(seedAssetKey);
-      const matching = edgesByAsset.get(seedAssetKey) ?? [];
-      for (const e of matching) {
+    const revealThread = (key: string | undefined) => {
+      if (!key || expandedAssetKeySet.has(key)) return;
+      expandedAssetKeySet.add(key);
+      for (const e of edgesByAsset.get(key) ?? []) {
         visible.add(e.source);
         visible.add(e.target);
         visibleEdgeIds.add(e.id);
       }
-    }
+    };
+
+    // The seed asset is auto-expanded — its full thread (e.g. a player's
+    // draft → trades → current roster) shows by default without the user
+    // having to click `+` on the seed asset's row.
+    revealThread(seedAssetKey);
 
     for (const entry of expanded) {
       const sepIdx = entry.indexOf("~");
@@ -143,37 +143,31 @@ export function useGraphVisibility(
         visible.add(entry);
         continue;
       }
-      // Per-asset expansion: nodeId ~ assetKey
-      // Reveal ALL edges for this asset across the entire graph (full thread).
-      const assetKey = entry.slice(sepIdx + 1);
-      expandedAssetKeySet.add(assetKey);
-      const matching = edgesByAsset.get(assetKey) ?? [];
-      for (const e of matching) {
-        visible.add(e.source);
-        visible.add(e.target);
-        visibleEdgeIds.add(e.id);
-      }
+      // Per-asset expansion: reveal ALL edges for this asset across the graph.
+      revealThread(entry.slice(sepIdx + 1));
     }
 
-    // For any draft node reached by an expanded pick thread, auto-expand
-    // the player's thread too — the user's mental model of "this pick
-    // became this player" wants the connection visible without an extra
-    // click. Single-pass: only the immediately-revealed player's edges
-    // are auto-expanded (no recursive cascade).
+    // For any visible draft node, auto-expand both halves of the lineage:
+    //   - the player drafted at this node (so seeding by a pick reveals
+    //     pick → draft → player → roster without an extra click), and
+    //   - the originating pick (so seeding by a player reveals the pick's
+    //     pre-draft trade history backwards from the draft).
+    // Single-pass: pick auto-expansion only reveals pick_trade nodes (never
+    // new drafts), so no recursive cascade is needed.
     for (const node of graph.nodes) {
       if (node.kind !== "transaction" || node.txKind !== "draft") continue;
       if (!visible.has(node.id)) continue;
       for (const asset of node.assets) {
-        if (asset.kind !== "player" || !asset.playerId) continue;
-        const playerKey = `player:${asset.playerId}`;
-        if (expandedAssetKeySet.has(playerKey)) continue;
-        expandedAssetKeySet.add(playerKey);
-        const matching = edgesByAsset.get(playerKey) ?? [];
-        for (const e of matching) {
-          visible.add(e.source);
-          visible.add(e.target);
-          visibleEdgeIds.add(e.id);
+        if (asset.kind === "player" && asset.playerId) {
+          revealThread(`player:${asset.playerId}`);
         }
+      }
+      // Pick identity lives on the incoming pick tenure edge (draft_selected
+      // closes the pick tenure at this node). Picks never traded before the
+      // draft have no incoming pick edge, so this is a no-op for them.
+      for (const e of edgesByNode.get(node.id) ?? []) {
+        if (e.target !== node.id || e.assetKind !== "pick") continue;
+        revealThread(edgeAssetKey(e));
       }
     }
 


### PR DESCRIPTION
## Summary

Closes #69. When seeding the asset graph by a player, the lineage chain now extends backwards through the originating pick's trade history, not just forward through the player's own thread.

Three small fixes that compose into one user-facing change:

1. **Auto-expand the pick on a visible draft** (`useGraphVisibility.ts`) — symmetric with the existing "drafts auto-expand the drafted player" rule. Pick identity comes from the incoming pick tenure edge that `draft_selected` closes; picks never traded pre-draft have no incoming edge, so the rule is a no-op for them. Also extracts a local `revealThread()` helper that collapsed four near-identical thread-reveal blocks.

2. **Pick walk closes with `draft_selected` regardless of timestamp** (`assetGraph.ts`) — Sleeper sometimes records a `pick_trade` with `created_at` after the draft's `start_time` (commissioner approval during/after the draft), so the global `compareEvents` sort puts `draft_selected` first and the trade orphans. Within the per-pick walk we re-sort so `draft_selected` is always last; pick_trades keep their relative `createdAt` order.

3. **Layout respects edge direction** (`layout.ts`) — column placement still used raw `createdAt`, which would have placed the during-draft trade card visually right of the draft it feeds. Compute an effective time per transaction by propagating each source strictly below every reachable target (BFS fixpoint, capped at 16 iterations).

## Test plan

- [ ] Seed by **Drake London** (`?seedPlayerId=8112`): full pick chain (3 pick_trade nodes → draft → roster) visible left to right.
- [ ] Seed by **Emeka Egbuka** (`?seedPlayerId=12514`): pick chain visible — `CrackaJack→kingjustin` trade card sits LEFT of the draft, then draft, then current roster.
- [ ] Seed by **player 6768** (pick never traded): chain unchanged from before, no errors, no extra cards.
- [ ] Seed by a **pick** (e.g. `?seedPickKey=2022:1:3`): pick → draft → player chain still works (regression check).
- [ ] No new console errors at any of the above URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)