### PR TITLE
feat(graph): stint stats + compare mode in edge drawer (#71)

### DIFF
--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -256,7 +256,6 @@ export default function GraphPage() {
     setTooltipDismissed(true);
   }, []);
 
-  const handleCloseSelection = useCallback(() => updateUrl({ selection: null }), [updateUrl]);
   const handleSelectionChange = useCallback(
     (next: GraphSelection | null) => updateUrl({ selection: serializeSelection(next) }),
     [updateUrl],
@@ -378,7 +377,6 @@ export default function GraphPage() {
             edges={visibility.visibleEdges}
             transactions={response.transactions}
             familyId={familyId}
-            onClose={handleCloseSelection}
             onSelectionChange={handleSelectionChange}
             variant="sheet"
           />
@@ -494,7 +492,6 @@ export default function GraphPage() {
             edges={visibleGraph.edges}
             transactions={response.transactions}
             familyId={familyId}
-            onClose={handleCloseSelection}
             onSelectionChange={handleSelectionChange}
           />
         )}

--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -38,7 +38,9 @@ function parseSelection(value: string | null): GraphSelection | null {
     return { type: "node", nodeId: value.slice(5) };
   }
   if (value.startsWith("edge:")) {
-    return { type: "edge", edgeId: value.slice(5) };
+    const ids = value.slice(5).split(",").map((s) => s.trim()).filter(Boolean);
+    if (ids.length === 0) return null;
+    return { type: "edge", edgeIds: ids };
   }
   return null;
 }
@@ -46,7 +48,8 @@ function parseSelection(value: string | null): GraphSelection | null {
 function serializeSelection(sel: GraphSelection | null): string | null {
   if (!sel) return null;
   if (sel.type === "node") return `node:${sel.nodeId}`;
-  return `edge:${sel.edgeId}`;
+  if (sel.edgeIds.length === 0) return null;
+  return `edge:${sel.edgeIds.join(",")}`;
 }
 
 export default function GraphPage() {
@@ -376,6 +379,7 @@ export default function GraphPage() {
             transactions={response.transactions}
             familyId={familyId}
             onClose={handleCloseSelection}
+            onSelectionChange={handleSelectionChange}
             variant="sheet"
           />
         )}
@@ -491,6 +495,7 @@ export default function GraphPage() {
             transactions={response.transactions}
             familyId={familyId}
             onClose={handleCloseSelection}
+            onSelectionChange={handleSelectionChange}
           />
         )}
       </div>

--- a/src/app/api/leagues/[familyId]/player/[playerId]/stint-stats/route.ts
+++ b/src/app/api/leagues/[familyId]/player/[playerId]/stint-stats/route.ts
@@ -1,0 +1,62 @@
+import { NextRequest, NextResponse } from "next/server";
+import { computePlayerStintStats } from "@/services/playerStintStats";
+
+/**
+ * GET /api/leagues/[familyId]/player/[playerId]/stint-stats
+ *
+ * Returns stint-scoped aggregates (PPG, PPG-while-starting, Start %, Active %)
+ * for a player on a single manager's roster across a date window. Bye weeks
+ * are excluded from rate denominators.
+ *
+ * Query params (all required except endSeason/endWeek for ongoing stints):
+ *   ?managerUserId=123456789
+ *   &startSeason=2024
+ *   &startWeek=1
+ *   &endSeason=2024     — omit for ongoing
+ *   &endWeek=14         — omit for ongoing
+ */
+export async function GET(
+  req: NextRequest,
+  { params }: { params: { familyId: string; playerId: string } },
+) {
+  const { familyId, playerId } = params;
+  const sp = req.nextUrl.searchParams;
+
+  const managerUserId = sp.get("managerUserId");
+  const startSeason = sp.get("startSeason");
+  const startWeekRaw = sp.get("startWeek");
+  const endSeason = sp.get("endSeason");
+  const endWeekRaw = sp.get("endWeek");
+
+  if (!managerUserId || !startSeason || !startWeekRaw) {
+    return NextResponse.json(
+      { error: "managerUserId, startSeason, and startWeek are required" },
+      { status: 400 },
+    );
+  }
+
+  const startWeek = parseInt(startWeekRaw, 10);
+  const endWeek = endWeekRaw ? parseInt(endWeekRaw, 10) : null;
+  if (Number.isNaN(startWeek)) {
+    return NextResponse.json(
+      { error: "startWeek must be an integer" },
+      { status: 400 },
+    );
+  }
+
+  const stats = await computePlayerStintStats({
+    familyId,
+    playerId,
+    managerUserId,
+    startSeason,
+    startWeek,
+    endSeason: endSeason || null,
+    endWeek,
+  });
+
+  if (!stats) {
+    return NextResponse.json({ error: "Family not found" }, { status: 404 });
+  }
+
+  return NextResponse.json(stats);
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -119,3 +119,31 @@
     font-variant-numeric: tabular-nums;
   }
 }
+
+@layer utilities {
+  /* Soft sage shimmer for tip text. Uses background-clip:text so the
+     gradient animates across the glyph fills rather than the box. */
+  .tip-shimmer {
+    background-image: linear-gradient(
+      90deg,
+      hsl(var(--muted-foreground)) 0%,
+      hsl(var(--muted-foreground)) 40%,
+      hsl(var(--primary)) 50%,
+      hsl(var(--muted-foreground)) 60%,
+      hsl(var(--muted-foreground)) 100%
+    );
+    background-size: 300% 100%;
+    background-clip: text;
+    -webkit-background-clip: text;
+    color: transparent;
+    -webkit-text-fill-color: transparent;
+    @apply animate-tip-shimmer;
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .tip-shimmer {
+      animation: none;
+      color: hsl(var(--muted-foreground));
+      -webkit-text-fill-color: hsl(var(--muted-foreground));
+    }
+  }
+}

--- a/src/components/graph/AssetGraph.tsx
+++ b/src/components/graph/AssetGraph.tsx
@@ -331,7 +331,8 @@ function AssetGraphInner({
         targetHandle: isExpanded && !rosterNodeIds.has(e.target) ? `asset-target-${aKey}` : "card-target",
         type: "transaction",
         zIndex: isExpanded ? 10 : undefined,
-        selected: selection?.type === "edge" && selection.edgeId === e.id,
+        selected:
+          selection?.type === "edge" && selection.edgeIds.includes(e.id),
         data: {
           assetKind: e.assetKind,
           assetKey: aKey,
@@ -442,8 +443,19 @@ function AssetGraphInner({
   );
 
   const onEdgeClick = useCallback<EdgeMouseHandler>(
-    (_, edge) => onSelect({ type: "edge", edgeId: edge.id }),
-    [onSelect],
+    (event, edge) => {
+      const additive = event.metaKey || event.ctrlKey || event.shiftKey;
+      if (!additive) {
+        onSelect({ type: "edge", edgeIds: [edge.id] });
+        return;
+      }
+      const current = selection?.type === "edge" ? selection.edgeIds : [];
+      const next = current.includes(edge.id)
+        ? current.filter((id) => id !== edge.id)
+        : [...current, edge.id];
+      onSelect(next.length === 0 ? null : { type: "edge", edgeIds: next });
+    },
+    [onSelect, selection],
   );
 
   const onPaneClick = useCallback(() => onSelect(null), [onSelect]);

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -279,8 +279,8 @@ interface StintStatsResponse {
   ppgStarting: number | null;
   startPct: number | null;
   activePct: number | null;
-  weeksInWindow: number;
-  weeksRostered: number;
+  weeksAvailable: number;
+  weeksActive: number;
   starterWeeks: number;
 }
 
@@ -346,10 +346,10 @@ function PlayerStintStats({
     );
   }
 
-  if (error || !stats || stats.weeksRostered === 0) {
+  if (error || !stats || stats.weeksActive === 0) {
     return (
       <p className="text-xs text-muted-foreground">
-        No scoring weeks recorded for this stint.
+        No active scoring weeks recorded for this stint.
       </p>
     );
   }
@@ -361,7 +361,7 @@ function PlayerStintStats({
         <StatTile
           label="PPG"
           value={fmtNumber(stats.ppg)}
-          hint={`${stats.weeksRostered} wk${stats.weeksRostered === 1 ? "" : "s"}`}
+          hint={`${stats.weeksActive} wk${stats.weeksActive === 1 ? "" : "s"}`}
         />
         <StatTile
           label="PPG starting"
@@ -371,12 +371,12 @@ function PlayerStintStats({
         <StatTile
           label="Start %"
           value={fmtPercent(stats.startPct)}
-          hint={`${stats.starterWeeks}/${stats.weeksRostered}`}
+          hint={`${stats.starterWeeks}/${stats.weeksActive}`}
         />
         <StatTile
           label="Active %"
           value={fmtPercent(stats.activePct)}
-          hint={`${stats.weeksRostered}/${stats.weeksInWindow}`}
+          hint={`${stats.weeksActive}/${stats.weeksAvailable}`}
         />
       </div>
     </div>

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -25,6 +25,8 @@ interface GraphDetailDrawerProps {
   transactions: Record<string, EnrichedTransaction>;
   familyId: string;
   onClose: () => void;
+  /** Replace the current selection (called when removing a single column from compare mode). */
+  onSelectionChange?: (next: GraphSelection | null) => void;
   /**
    * "drawer" (default): right-side fixed panel for desktop.
    * "sheet": full-screen overlay for mobile.
@@ -39,24 +41,31 @@ export function GraphDetailDrawer({
   transactions,
   familyId,
   onClose,
+  onSelectionChange,
   variant = "drawer",
 }: GraphDetailDrawerProps) {
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
 
+  const selectionFingerprint =
+    selection.type === "node"
+      ? `node:${selection.nodeId}`
+      : `edge:${selection.edgeIds.join(",")}`;
   useEffect(() => {
     if (selection.type === "node") {
       const node = nodes.find((n) => n.id === selection.nodeId);
       trackEvent("graph_node_selected", { kind: node?.kind ?? "unknown" });
-    } else {
-      const edge = edges.find((e) => e.id === selection.edgeId);
+    } else if (selection.edgeIds.length === 1) {
+      const edge = edges.find((e) => e.id === selection.edgeIds[0]);
       trackEvent("graph_edge_selected", {
         assetKind: edge?.assetKind ?? "unknown",
         isOpen: edge?.isOpen ?? false,
       });
+    } else {
+      trackEvent("graph_edges_compared", { count: selection.edgeIds.length });
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selection.type, selection.type === "node" ? selection.nodeId : selection.edgeId]);
+  }, [selectionFingerprint]);
 
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
@@ -89,10 +98,20 @@ export function GraphDetailDrawer({
     return () => document.removeEventListener("keydown", handleKey);
   }, [onClose]);
 
+  const isCompare = selection.type === "edge" && selection.edgeIds.length >= 2;
+  const widthClass = isCompare ? "w-[40rem]" : "w-96";
   const containerClass =
     variant === "sheet"
       ? "fixed inset-0 bg-card overflow-y-auto z-50"
-      : "absolute top-0 right-0 bottom-0 w-96 bg-card border-l border-border/60 shadow-lg overflow-y-auto z-10";
+      : `absolute top-0 right-0 bottom-0 ${widthClass} bg-card border-l border-border/60 shadow-lg overflow-y-auto z-10`;
+
+  const handleRemoveEdge = onSelectionChange
+    ? (edgeId: string) => {
+        if (selection.type !== "edge") return;
+        const next = selection.edgeIds.filter((id) => id !== edgeId);
+        onSelectionChange(next.length === 0 ? null : { type: "edge", edgeIds: next });
+      }
+    : undefined;
 
   return (
     <div
@@ -104,7 +123,11 @@ export function GraphDetailDrawer({
     >
       <div className="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-border/60 bg-card">
         {/* Allowed per design: graph headers may use Source Serif 4 (relaxes marketing-only rule). */}
-        <h2 className="font-serif text-base text-sage-800">Details</h2>
+        <h2 className="font-serif text-base text-sage-800">
+          {isCompare
+            ? `Comparing ${(selection as { edgeIds: string[] }).edgeIds.length} stints`
+            : "Details"}
+        </h2>
         <button
           ref={closeBtnRef}
           type="button"
@@ -123,9 +146,17 @@ export function GraphDetailDrawer({
             transactions={transactions}
             familyId={familyId}
           />
+        ) : selection.edgeIds.length >= 2 ? (
+          <EdgeCompare
+            edges={selection.edgeIds
+              .map((id) => edges.find((e) => e.id === id))
+              .filter((e): e is GraphEdge => Boolean(e))}
+            familyId={familyId}
+            onRemove={handleRemoveEdge}
+          />
         ) : (
           <EdgeDetail
-            edge={edges.find((e) => e.id === selection.edgeId) ?? null}
+            edge={edges.find((e) => e.id === selection.edgeIds[0]) ?? null}
             familyId={familyId}
           />
         )}
@@ -270,6 +301,11 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
       <p className="text-xs text-muted-foreground">
         {edge.startSeason} W{edge.startWeek} → {endLabel}
       </p>
+      {edge.assetKind === "player" && edge.playerId && (
+        <p className="text-[11px] text-muted-foreground pt-1 border-t border-border/40">
+          Tip: <kbd className="font-mono">⌘</kbd>-click another stint to compare.
+        </p>
+      )}
     </div>
   );
 }
@@ -284,6 +320,48 @@ interface StintStatsResponse {
   starterWeeks: number;
 }
 
+type StintStatsState =
+  | { status: "loading" }
+  | { status: "error" }
+  | { status: "ok"; data: StintStatsResponse };
+
+function buildStintStatsUrl(familyId: string, edge: GraphEdge): string | null {
+  if (!edge.playerId) return null;
+  const sp = new URLSearchParams({
+    managerUserId: edge.managerUserId,
+    startSeason: edge.startSeason,
+    startWeek: String(edge.startWeek),
+  });
+  if (edge.endSeason) sp.set("endSeason", edge.endSeason);
+  if (edge.endWeek != null) sp.set("endWeek", String(edge.endWeek));
+  return `/api/leagues/${familyId}/player/${encodeURIComponent(edge.playerId)}/stint-stats?${sp.toString()}`;
+}
+
+function useStintStats(familyId: string, edge: GraphEdge): StintStatsState {
+  const [state, setState] = useState<StintStatsState>({ status: "loading" });
+  const url = buildStintStatsUrl(familyId, edge);
+  useEffect(() => {
+    if (!url) {
+      setState({ status: "error" });
+      return;
+    }
+    let cancelled = false;
+    setState({ status: "loading" });
+    fetch(url)
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data: StintStatsResponse) => {
+        if (!cancelled) setState({ status: "ok", data });
+      })
+      .catch(() => {
+        if (!cancelled) setState({ status: "error" });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [url]);
+  return state;
+}
+
 function PlayerStintStats({
   familyId,
   edge,
@@ -291,52 +369,9 @@ function PlayerStintStats({
   familyId: string;
   edge: GraphEdge;
 }) {
-  const [stats, setStats] = useState<StintStatsResponse | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const state = useStintStats(familyId, edge);
 
-  useEffect(() => {
-    if (!edge.playerId) return;
-    let cancelled = false;
-    setLoading(true);
-    setError(false);
-
-    const sp = new URLSearchParams({
-      managerUserId: edge.managerUserId,
-      startSeason: edge.startSeason,
-      startWeek: String(edge.startWeek),
-    });
-    if (edge.endSeason) sp.set("endSeason", edge.endSeason);
-    if (edge.endWeek != null) sp.set("endWeek", String(edge.endWeek));
-
-    fetch(
-      `/api/leagues/${familyId}/player/${encodeURIComponent(edge.playerId)}/stint-stats?${sp.toString()}`,
-    )
-      .then((res) => (res.ok ? res.json() : Promise.reject()))
-      .then((data: StintStatsResponse) => {
-        if (!cancelled) setStats(data);
-      })
-      .catch(() => {
-        if (!cancelled) setError(true);
-      })
-      .finally(() => {
-        if (!cancelled) setLoading(false);
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [
-    familyId,
-    edge.playerId,
-    edge.managerUserId,
-    edge.startSeason,
-    edge.startWeek,
-    edge.endSeason,
-    edge.endWeek,
-  ]);
-
-  if (loading) {
+  if (state.status === "loading") {
     return (
       <div className="grid grid-cols-2 gap-2">
         {[0, 1, 2, 3].map((i) => (
@@ -346,7 +381,7 @@ function PlayerStintStats({
     );
   }
 
-  if (error || !stats || stats.weeksActive === 0) {
+  if (state.status === "error" || state.data.weeksActive === 0) {
     return (
       <p className="text-xs text-muted-foreground">
         No active scoring weeks recorded for this stint.
@@ -354,6 +389,7 @@ function PlayerStintStats({
     );
   }
 
+  const stats = state.data;
   return (
     <div>
       <p className="text-xs text-muted-foreground mb-1.5">Stint stats</p>
@@ -379,6 +415,243 @@ function PlayerStintStats({
           hint={`${stats.weeksActive}/${stats.weeksAvailable}`}
         />
       </div>
+    </div>
+  );
+}
+
+const COMPARE_METRIC_ROWS = [
+  {
+    label: "PPG",
+    value: (s: StintStatsResponse) => fmtNumber(s.ppg),
+    hint: (s: StintStatsResponse) =>
+      `${s.weeksActive} wk${s.weeksActive === 1 ? "" : "s"}`,
+  },
+  {
+    label: "PPG starting",
+    value: (s: StintStatsResponse) => fmtNumber(s.ppgStarting),
+    hint: (s: StintStatsResponse) =>
+      `${s.starterWeeks} wk${s.starterWeeks === 1 ? "" : "s"}`,
+  },
+  {
+    label: "Start %",
+    value: (s: StintStatsResponse) => fmtPercent(s.startPct),
+    hint: (s: StintStatsResponse) => `${s.starterWeeks}/${s.weeksActive}`,
+  },
+  {
+    label: "Active %",
+    value: (s: StintStatsResponse) => fmtPercent(s.activePct),
+    hint: (s: StintStatsResponse) => `${s.weeksActive}/${s.weeksAvailable}`,
+  },
+] as const;
+
+function useStintStatsByEdge(
+  familyId: string,
+  edges: GraphEdge[],
+): Map<string, StintStatsState> {
+  const [results, setResults] = useState<Map<string, StintStatsState>>(
+    () => new Map(),
+  );
+  const urlByEdge = edges
+    .map((e) => `${e.id}|${buildStintStatsUrl(familyId, e) ?? ""}`)
+    .join("\n");
+
+  useEffect(() => {
+    let cancelled = false;
+    const next = new Map<string, StintStatsState>();
+    for (const edge of edges) {
+      next.set(edge.id, { status: "loading" });
+    }
+    setResults(next);
+
+    edges.forEach((edge) => {
+      const url = buildStintStatsUrl(familyId, edge);
+      if (!url) {
+        setResults((prev) => {
+          const m = new Map(prev);
+          m.set(edge.id, { status: "error" });
+          return m;
+        });
+        return;
+      }
+      fetch(url)
+        .then((res) => (res.ok ? res.json() : Promise.reject()))
+        .then((data: StintStatsResponse) => {
+          if (cancelled) return;
+          setResults((prev) => {
+            const m = new Map(prev);
+            m.set(edge.id, { status: "ok", data });
+            return m;
+          });
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setResults((prev) => {
+            const m = new Map(prev);
+            m.set(edge.id, { status: "error" });
+            return m;
+          });
+        });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [urlByEdge]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  return results;
+}
+
+function EdgeCompare({
+  edges,
+  familyId,
+  onRemove,
+}: {
+  edges: GraphEdge[];
+  familyId: string;
+  onRemove?: (edgeId: string) => void;
+}) {
+  const statsByEdge = useStintStatsByEdge(familyId, edges);
+  if (edges.length === 0) {
+    return <p className="text-sm text-muted-foreground">No stints to compare.</p>;
+  }
+  const colTemplate = `100px repeat(${edges.length}, minmax(120px, 1fr))`;
+
+  return (
+    <div className="space-y-3">
+      <div className="overflow-x-auto -mx-4 px-4">
+        <div className="min-w-max space-y-2">
+          <div
+            className="grid gap-2 items-stretch"
+            style={{ gridTemplateColumns: colTemplate }}
+          >
+            <div />
+            {edges.map((edge) => (
+              <CompareColumnHeader
+                key={edge.id}
+                edge={edge}
+                familyId={familyId}
+                onRemove={onRemove}
+              />
+            ))}
+          </div>
+
+          {COMPARE_METRIC_ROWS.map((row) => (
+            <div
+              key={row.label}
+              className="grid gap-2 items-center"
+              style={{ gridTemplateColumns: colTemplate }}
+            >
+              <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                {row.label}
+              </p>
+              {edges.map((edge) => (
+                <CompareCell
+                  key={edge.id}
+                  edge={edge}
+                  state={statsByEdge.get(edge.id) ?? { status: "loading" }}
+                  row={row}
+                />
+              ))}
+            </div>
+          ))}
+        </div>
+      </div>
+      <p className="text-[11px] text-muted-foreground">
+        Tip: <kbd className="font-mono">⌘</kbd>-click an edge to add or remove it from this comparison.
+      </p>
+    </div>
+  );
+}
+
+function CompareColumnHeader({
+  edge,
+  familyId,
+  onRemove,
+}: {
+  edge: GraphEdge;
+  familyId: string;
+  onRemove?: (edgeId: string) => void;
+}) {
+  const endLabel = edge.isOpen
+    ? "Ongoing"
+    : `${edge.endSeason ?? ""}${edge.endWeek ? ` W${edge.endWeek}` : ""}`;
+  const isPlayer = edge.assetKind === "player";
+  return (
+    <div className="rounded-md border border-border/60 bg-background px-2 py-1.5 text-xs space-y-0.5 relative">
+      {onRemove && (
+        <button
+          type="button"
+          onClick={() => onRemove(edge.id)}
+          className="absolute top-1 right-1 inline-flex items-center justify-center h-5 w-5 rounded hover:bg-accent hover:text-accent-foreground"
+          aria-label="Remove from comparison"
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+      {isPlayer ? (
+        <Link
+          href={
+            edge.playerId
+              ? `/league/${familyId}/player/${encodeURIComponent(edge.playerId)}`
+              : "#"
+          }
+          className="block pr-5 font-semibold leading-tight hover:underline"
+        >
+          {edge.playerPosition ? `${edge.playerPosition} · ` : ""}
+          {edge.playerName}
+        </Link>
+      ) : (
+        <p className="pr-5 font-semibold leading-tight">{edge.pickLabel}</p>
+      )}
+      <p className="text-muted-foreground truncate">{edge.managerName}</p>
+      <p className="font-mono text-[10px] text-muted-foreground">
+        {edge.startSeason} W{edge.startWeek} → {endLabel}
+      </p>
+    </div>
+  );
+}
+
+function CompareCell({
+  edge,
+  state,
+  row,
+}: {
+  edge: GraphEdge;
+  state: StintStatsState;
+  row: (typeof COMPARE_METRIC_ROWS)[number];
+}) {
+  const isPlayer = edge.assetKind === "player" && Boolean(edge.playerId);
+
+  if (!isPlayer) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background px-2 py-1.5 text-center">
+        <p className="font-mono text-base font-semibold text-muted-foreground leading-tight">
+          —
+        </p>
+        <p className="font-mono text-[10px] text-muted-foreground">pick</p>
+      </div>
+    );
+  }
+  if (state.status === "loading") {
+    return <div className="h-12 rounded-md bg-muted animate-pulse" />;
+  }
+  if (state.status === "error" || state.data.weeksActive === 0) {
+    return (
+      <div className="rounded-md border border-border/60 bg-background px-2 py-1.5 text-center">
+        <p className="font-mono text-base font-semibold text-muted-foreground leading-tight">
+          —
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div className="rounded-md border border-border/60 bg-background px-2 py-1.5 text-center">
+      <p className="font-mono text-base font-semibold text-foreground leading-tight">
+        {row.value(state.data)}
+      </p>
+      <p className="font-mono text-[10px] text-muted-foreground">
+        {row.hint(state.data)}
+      </p>
     </div>
   );
 }

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowRight, X } from "lucide-react";
 import type { GraphEdge, GraphNode, GraphSelection } from "@/lib/assetGraph";
@@ -302,7 +302,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
         {edge.startSeason} W{edge.startWeek} → {endLabel}
       </p>
       {edge.assetKind === "player" && edge.playerId && (
-        <p className="text-[11px] text-muted-foreground pt-1 border-t border-border/40">
+        <p className="text-[11px] tip-shimmer pt-1 border-t border-border/40">
           Tip: <kbd className="font-mono">⌘</kbd>-click another stint to compare.
         </p>
       )}
@@ -422,23 +422,27 @@ function PlayerStintStats({
 const COMPARE_METRIC_ROWS = [
   {
     label: "PPG",
+    raw: (s: StintStatsResponse) => s.ppg,
     value: (s: StintStatsResponse) => fmtNumber(s.ppg),
     hint: (s: StintStatsResponse) =>
       `${s.weeksActive} wk${s.weeksActive === 1 ? "" : "s"}`,
   },
   {
     label: "PPG starting",
+    raw: (s: StintStatsResponse) => s.ppgStarting,
     value: (s: StintStatsResponse) => fmtNumber(s.ppgStarting),
     hint: (s: StintStatsResponse) =>
       `${s.starterWeeks} wk${s.starterWeeks === 1 ? "" : "s"}`,
   },
   {
     label: "Start %",
+    raw: (s: StintStatsResponse) => s.startPct,
     value: (s: StintStatsResponse) => fmtPercent(s.startPct),
     hint: (s: StintStatsResponse) => `${s.starterWeeks}/${s.weeksActive}`,
   },
   {
     label: "Active %",
+    raw: (s: StintStatsResponse) => s.activePct,
     value: (s: StintStatsResponse) => fmtPercent(s.activePct),
     hint: (s: StintStatsResponse) => `${s.weeksActive}/${s.weeksAvailable}`,
   },
@@ -511,6 +515,27 @@ function EdgeCompare({
   onRemove?: (edgeId: string) => void;
 }) {
   const statsByEdge = useStintStatsByEdge(familyId, edges);
+  const leadersByRow = useMemo(() => {
+    const map = new Map<string, Set<string>>();
+    for (const row of COMPARE_METRIC_ROWS) {
+      const candidates: Array<{ id: string; value: number }> = [];
+      for (const edge of edges) {
+        const state = statsByEdge.get(edge.id);
+        if (state?.status !== "ok") continue;
+        if (state.data.weeksActive === 0) continue;
+        const raw = row.raw(state.data);
+        if (raw == null) continue;
+        candidates.push({ id: edge.id, value: raw });
+      }
+      if (candidates.length < 2) continue;
+      const max = Math.max(...candidates.map((c) => c.value));
+      map.set(
+        row.label,
+        new Set(candidates.filter((c) => c.value === max).map((c) => c.id)),
+      );
+    }
+    return map;
+  }, [edges, statsByEdge]);
   if (edges.length === 0) {
     return <p className="text-sm text-muted-foreground">No stints to compare.</p>;
   }
@@ -550,13 +575,14 @@ function EdgeCompare({
                   edge={edge}
                   state={statsByEdge.get(edge.id) ?? { status: "loading" }}
                   row={row}
+                  isLeader={leadersByRow.get(row.label)?.has(edge.id) ?? false}
                 />
               ))}
             </div>
           ))}
         </div>
       </div>
-      <p className="text-[11px] text-muted-foreground">
+      <p className="text-[11px] tip-shimmer">
         Tip: <kbd className="font-mono">⌘</kbd>-click an edge to add or remove it from this comparison.
       </p>
     </div>
@@ -615,10 +641,12 @@ function CompareCell({
   edge,
   state,
   row,
+  isLeader,
 }: {
   edge: GraphEdge;
   state: StintStatsState;
   row: (typeof COMPARE_METRIC_ROWS)[number];
+  isLeader: boolean;
 }) {
   const isPlayer = edge.assetKind === "player" && Boolean(edge.playerId);
 
@@ -644,11 +672,15 @@ function CompareCell({
       </div>
     );
   }
+  const containerClass = isLeader
+    ? "rounded-md border border-primary/40 bg-primary/5 px-2 py-1.5 text-center"
+    : "rounded-md border border-border/60 bg-background px-2 py-1.5 text-center";
+  const valueClass = isLeader
+    ? "font-mono text-base font-semibold text-primary leading-tight"
+    : "font-mono text-base font-semibold text-foreground leading-tight";
   return (
-    <div className="rounded-md border border-border/60 bg-background px-2 py-1.5 text-center">
-      <p className="font-mono text-base font-semibold text-foreground leading-tight">
-        {row.value(state.data)}
-      </p>
+    <div className={containerClass} aria-label={isLeader ? "Top value" : undefined}>
+      <p className={valueClass}>{row.value(state.data)}</p>
       <p className="font-mono text-[10px] text-muted-foreground">
         {row.hint(state.data)}
       </p>

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 import { ArrowRight, X } from "lucide-react";
 import type { GraphEdge, GraphNode, GraphSelection } from "@/lib/assetGraph";
@@ -264,11 +264,155 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
         <p className="text-xs text-muted-foreground">Manager</p>
         <p className="text-sm">{edge.managerName}</p>
       </div>
+      {edge.assetKind === "player" && edge.playerId && (
+        <PlayerStintStats familyId={familyId} edge={edge} />
+      )}
       <p className="text-xs text-muted-foreground">
         {edge.startSeason} W{edge.startWeek} → {endLabel}
       </p>
     </div>
   );
+}
+
+interface StintStatsResponse {
+  ppg: number | null;
+  ppgStarting: number | null;
+  startPct: number | null;
+  activePct: number | null;
+  weeksInWindow: number;
+  weeksRostered: number;
+  starterWeeks: number;
+}
+
+function PlayerStintStats({
+  familyId,
+  edge,
+}: {
+  familyId: string;
+  edge: GraphEdge;
+}) {
+  const [stats, setStats] = useState<StintStatsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    if (!edge.playerId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+
+    const sp = new URLSearchParams({
+      managerUserId: edge.managerUserId,
+      startSeason: edge.startSeason,
+      startWeek: String(edge.startWeek),
+    });
+    if (edge.endSeason) sp.set("endSeason", edge.endSeason);
+    if (edge.endWeek != null) sp.set("endWeek", String(edge.endWeek));
+
+    fetch(
+      `/api/leagues/${familyId}/player/${encodeURIComponent(edge.playerId)}/stint-stats?${sp.toString()}`,
+    )
+      .then((res) => (res.ok ? res.json() : Promise.reject()))
+      .then((data: StintStatsResponse) => {
+        if (!cancelled) setStats(data);
+      })
+      .catch(() => {
+        if (!cancelled) setError(true);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [
+    familyId,
+    edge.playerId,
+    edge.managerUserId,
+    edge.startSeason,
+    edge.startWeek,
+    edge.endSeason,
+    edge.endWeek,
+  ]);
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-2 gap-2">
+        {[0, 1, 2, 3].map((i) => (
+          <div key={i} className="h-14 rounded-md bg-muted animate-pulse" />
+        ))}
+      </div>
+    );
+  }
+
+  if (error || !stats || stats.weeksRostered === 0) {
+    return (
+      <p className="text-xs text-muted-foreground">
+        No scoring weeks recorded for this stint.
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      <p className="text-xs text-muted-foreground mb-1.5">Stint stats</p>
+      <div className="grid grid-cols-2 gap-2">
+        <StatTile
+          label="PPG"
+          value={fmtNumber(stats.ppg)}
+          hint={`${stats.weeksRostered} wk${stats.weeksRostered === 1 ? "" : "s"}`}
+        />
+        <StatTile
+          label="PPG starting"
+          value={fmtNumber(stats.ppgStarting)}
+          hint={`${stats.starterWeeks} wk${stats.starterWeeks === 1 ? "" : "s"}`}
+        />
+        <StatTile
+          label="Start %"
+          value={fmtPercent(stats.startPct)}
+          hint={`${stats.starterWeeks}/${stats.weeksRostered}`}
+        />
+        <StatTile
+          label="Active %"
+          value={fmtPercent(stats.activePct)}
+          hint={`${stats.weeksRostered}/${stats.weeksInWindow}`}
+        />
+      </div>
+    </div>
+  );
+}
+
+function StatTile({
+  label,
+  value,
+  hint,
+}: {
+  label: string;
+  value: string;
+  hint: string;
+}) {
+  return (
+    <div className="rounded-md border border-border/60 bg-background px-2.5 py-1.5">
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+        {label}
+      </p>
+      <p className="font-mono text-base font-semibold text-foreground leading-tight">
+        {value}
+      </p>
+      <p className="font-mono text-[10px] text-muted-foreground">{hint}</p>
+    </div>
+  );
+}
+
+function fmtNumber(n: number | null): string {
+  if (n == null) return "—";
+  return n.toFixed(1);
+}
+
+function fmtPercent(n: number | null): string {
+  if (n == null) return "—";
+  return `${Math.round(n * 100)}%`;
 }
 
 export default GraphDetailDrawer;

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -24,9 +24,8 @@ interface GraphDetailDrawerProps {
   edges: GraphEdge[];
   transactions: Record<string, EnrichedTransaction>;
   familyId: string;
-  onClose: () => void;
-  /** Replace the current selection (called when removing a single column from compare mode). */
-  onSelectionChange?: (next: GraphSelection | null) => void;
+  /** Replace the current selection. Called with `null` to close the drawer. */
+  onSelectionChange: (next: GraphSelection | null) => void;
   /**
    * "drawer" (default): right-side fixed panel for desktop.
    * "sheet": full-screen overlay for mobile.
@@ -40,7 +39,6 @@ export function GraphDetailDrawer({
   edges,
   transactions,
   familyId,
-  onClose,
   onSelectionChange,
   variant = "drawer",
 }: GraphDetailDrawerProps) {
@@ -67,11 +65,12 @@ export function GraphDetailDrawer({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [selectionFingerprint]);
 
+  const handleClose = () => onSelectionChange(null);
   useEffect(() => {
     function handleKey(e: KeyboardEvent) {
       if (e.key === "Escape") {
         e.preventDefault();
-        onClose();
+        onSelectionChange(null);
         return;
       }
       if (e.key === "Tab" && panelRef.current) {
@@ -96,22 +95,27 @@ export function GraphDetailDrawer({
     document.addEventListener("keydown", handleKey);
     closeBtnRef.current?.focus();
     return () => document.removeEventListener("keydown", handleKey);
-  }, [onClose]);
+  }, [onSelectionChange]);
+
+  const edgesById = useMemo(
+    () => new Map(edges.map((e) => [e.id, e])),
+    [edges],
+  );
 
   const isCompare = selection.type === "edge" && selection.edgeIds.length >= 2;
+  const compareEdgeCount =
+    selection.type === "edge" ? selection.edgeIds.length : 0;
   const widthClass = isCompare ? "w-[40rem]" : "w-96";
   const containerClass =
     variant === "sheet"
       ? "fixed inset-0 bg-card overflow-y-auto z-50"
       : `absolute top-0 right-0 bottom-0 ${widthClass} bg-card border-l border-border/60 shadow-lg overflow-y-auto z-10`;
 
-  const handleRemoveEdge = onSelectionChange
-    ? (edgeId: string) => {
-        if (selection.type !== "edge") return;
-        const next = selection.edgeIds.filter((id) => id !== edgeId);
-        onSelectionChange(next.length === 0 ? null : { type: "edge", edgeIds: next });
-      }
-    : undefined;
+  const handleRemoveEdge = (edgeId: string) => {
+    if (selection.type !== "edge") return;
+    const next = selection.edgeIds.filter((id) => id !== edgeId);
+    onSelectionChange(next.length === 0 ? null : { type: "edge", edgeIds: next });
+  };
 
   return (
     <div
@@ -124,14 +128,12 @@ export function GraphDetailDrawer({
       <div className="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-border/60 bg-card">
         {/* Allowed per design: graph headers may use Source Serif 4 (relaxes marketing-only rule). */}
         <h2 className="font-serif text-base text-sage-800">
-          {isCompare
-            ? `Comparing ${(selection as { edgeIds: string[] }).edgeIds.length} stints`
-            : "Details"}
+          {isCompare ? `Comparing ${compareEdgeCount} stints` : "Details"}
         </h2>
         <button
           ref={closeBtnRef}
           type="button"
-          onClick={onClose}
+          onClick={handleClose}
           className="inline-flex items-center justify-center h-7 w-7 rounded-md hover:bg-accent hover:text-accent-foreground"
           aria-label="Close details"
         >
@@ -146,17 +148,17 @@ export function GraphDetailDrawer({
             transactions={transactions}
             familyId={familyId}
           />
-        ) : selection.edgeIds.length >= 2 ? (
+        ) : isCompare ? (
           <EdgeCompare
             edges={selection.edgeIds
-              .map((id) => edges.find((e) => e.id === id))
+              .map((id) => edgesById.get(id))
               .filter((e): e is GraphEdge => Boolean(e))}
             familyId={familyId}
             onRemove={handleRemoveEdge}
           />
         ) : (
           <EdgeDetail
-            edge={edges.find((e) => e.id === selection.edgeIds[0]) ?? null}
+            edge={edgesById.get(selection.edgeIds[0]) ?? null}
             familyId={familyId}
           />
         )}
@@ -423,27 +425,27 @@ const COMPARE_METRIC_ROWS = [
   {
     label: "PPG",
     raw: (s: StintStatsResponse) => s.ppg,
-    value: (s: StintStatsResponse) => fmtNumber(s.ppg),
+    format: fmtNumber,
     hint: (s: StintStatsResponse) =>
       `${s.weeksActive} wk${s.weeksActive === 1 ? "" : "s"}`,
   },
   {
     label: "PPG starting",
     raw: (s: StintStatsResponse) => s.ppgStarting,
-    value: (s: StintStatsResponse) => fmtNumber(s.ppgStarting),
+    format: fmtNumber,
     hint: (s: StintStatsResponse) =>
       `${s.starterWeeks} wk${s.starterWeeks === 1 ? "" : "s"}`,
   },
   {
     label: "Start %",
     raw: (s: StintStatsResponse) => s.startPct,
-    value: (s: StintStatsResponse) => fmtPercent(s.startPct),
+    format: fmtPercent,
     hint: (s: StintStatsResponse) => `${s.starterWeeks}/${s.weeksActive}`,
   },
   {
     label: "Active %",
     raw: (s: StintStatsResponse) => s.activePct,
-    value: (s: StintStatsResponse) => fmtPercent(s.activePct),
+    format: fmtPercent,
     hint: (s: StintStatsResponse) => `${s.weeksActive}/${s.weeksAvailable}`,
   },
 ] as const;
@@ -515,35 +517,35 @@ function EdgeCompare({
   onRemove?: (edgeId: string) => void;
 }) {
   const statsByEdge = useStintStatsByEdge(familyId, edges);
-  const leadersByRow = useMemo(() => {
-    const map = new Map<string, Set<string>>();
-    for (const row of COMPARE_METRIC_ROWS) {
-      const candidates: Array<{ id: string; value: number }> = [];
-      for (const edge of edges) {
-        const state = statsByEdge.get(edge.id);
-        if (state?.status !== "ok") continue;
-        if (state.data.weeksActive === 0) continue;
-        const raw = row.raw(state.data);
-        if (raw == null) continue;
-        candidates.push({ id: edge.id, value: raw });
-      }
-      if (candidates.length < 2) continue;
-      const max = Math.max(...candidates.map((c) => c.value));
-      map.set(
-        row.label,
-        new Set(candidates.filter((c) => c.value === max).map((c) => c.id)),
-      );
-    }
-    return map;
-  }, [edges, statsByEdge]);
   if (edges.length === 0) {
     return <p className="text-sm text-muted-foreground">No stints to compare.</p>;
+  }
+  // Computed inline: deps (edges, statsByEdge) get fresh references on every
+  // setState in useStintStatsByEdge, so useMemo wouldn't actually cache. The
+  // work is N*4 lookups — cheap.
+  const leadersByRow = new Map<string, Set<string>>();
+  for (const row of COMPARE_METRIC_ROWS) {
+    const candidates: Array<{ id: string; value: number }> = [];
+    for (const edge of edges) {
+      const state = statsByEdge.get(edge.id);
+      if (state?.status !== "ok") continue;
+      if (state.data.weeksActive === 0) continue;
+      const raw = row.raw(state.data);
+      if (raw == null) continue;
+      candidates.push({ id: edge.id, value: raw });
+    }
+    if (candidates.length < 2) continue;
+    const max = Math.max(...candidates.map((c) => c.value));
+    leadersByRow.set(
+      row.label,
+      new Set(candidates.filter((c) => c.value === max).map((c) => c.id)),
+    );
   }
   const colTemplate = `100px repeat(${edges.length}, minmax(120px, 1fr))`;
 
   return (
     <div className="space-y-3">
-      <div className="overflow-x-auto -mx-4 px-4">
+      <div className="-mx-4 px-4 overflow-x-auto">
         <div className="min-w-max space-y-2">
           <div
             className="grid gap-2 items-stretch"
@@ -680,7 +682,7 @@ function CompareCell({
     : "font-mono text-base font-semibold text-foreground leading-tight";
   return (
     <div className={containerClass} aria-label={isLeader ? "Top value" : undefined}>
-      <p className={valueClass}>{row.value(state.data)}</p>
+      <p className={valueClass}>{row.format(row.raw(state.data))}</p>
       <p className="font-mono text-[10px] text-muted-foreground">
         {row.hint(state.data)}
       </p>

--- a/src/lib/assetGraph.ts
+++ b/src/lib/assetGraph.ts
@@ -169,7 +169,7 @@ export interface Graph {
 
 export type GraphSelection =
   | { type: "node"; nodeId: string }
-  | { type: "edge"; edgeId: string };
+  | { type: "edge"; edgeIds: string[] };
 
 /** Seed focus for the graph — which asset to anchor the view on. */
 export type GraphFocus =

--- a/src/services/playerStintStats.ts
+++ b/src/services/playerStintStats.ts
@@ -18,10 +18,15 @@ export interface StintStats {
   ppgStarting: number | null;
   startPct: number | null;
   activePct: number | null;
-  weeksInWindow: number;
-  weeksRostered: number;
+  /** Stint weeks that weren't byes (denominator for Active %). */
+  weeksAvailable: number;
+  /** Non-bye stint weeks where the player was on an NFL active roster (status=ACT). */
+  weeksActive: number;
+  /** Subset of weeksActive where the manager started the player. */
   starterWeeks: number;
+  /** Sum of points across active weeks only (bye and inactive weeks excluded). */
   totalPoints: number;
+  /** Sum of points across active+starter weeks. */
   starterPoints: number;
   byeWeeksExcluded: number;
 }
@@ -108,6 +113,8 @@ export async function computePlayerStintStats(
 
   const seasonsInWindow = [...new Set([...windowKeys].map((k) => parseInt(k.split("|")[0], 10)))];
   const byeKeys = new Set<string>();
+  const activeKeys = new Set<string>();
+
   if (gsisId && seasonsInWindow.length > 0) {
     const [statusRows, scheduleRows] = await Promise.all([
       db
@@ -126,8 +133,11 @@ export async function computePlayerStintStats(
     ]);
 
     const playerTeamByWeek = new Map<string, string>();
+    const playerStatusByWeek = new Map<string, string>();
     for (const r of statusRows) {
-      if (r.team) playerTeamByWeek.set(`${r.season}|${r.week}`, r.team);
+      const key = `${r.season}|${r.week}`;
+      if (r.team) playerTeamByWeek.set(key, r.team);
+      playerStatusByWeek.set(key, r.status);
     }
 
     const teamPlayedWeeks = new Map<string, Set<number>>();
@@ -171,9 +181,20 @@ export async function computePlayerStintStats(
         byeKeys.add(key);
       }
     }
+
+    for (const key of windowKeys) {
+      if (byeKeys.has(key)) continue;
+      if (playerStatusByWeek.get(key) === "ACT") activeKeys.add(key);
+    }
+  } else {
+    // No NFL status data available — treat every non-bye window week as active
+    // so we don't artificially deflate Active % for older or unsigned players.
+    for (const key of windowKeys) {
+      if (!byeKeys.has(key)) activeKeys.add(key);
+    }
   }
 
-  const weeksInWindow = windowKeys.size - byeKeys.size;
+  const weeksAvailable = windowKeys.size - byeKeys.size;
 
   const perLeaguePairs = [...leagueRosterMap.entries()].map(([lid, rid]) =>
     and(
@@ -196,7 +217,6 @@ export async function computePlayerStintStats(
       ),
     );
 
-  let weeksRostered = 0;
   let starterWeeks = 0;
   let totalPoints = 0;
   let starterPoints = 0;
@@ -204,9 +224,7 @@ export async function computePlayerStintStats(
     const season = leagueSeasonMap.get(s.leagueId);
     if (!season) continue;
     const key = `${season}|${s.week}`;
-    if (!windowKeys.has(key)) continue;
-    if (byeKeys.has(key)) continue;
-    weeksRostered += 1;
+    if (!activeKeys.has(key)) continue;
     const pts = s.points ?? 0;
     totalPoints += pts;
     if (s.isStarter) {
@@ -215,13 +233,14 @@ export async function computePlayerStintStats(
     }
   }
 
+  const weeksActive = activeKeys.size;
   return {
-    ppg: weeksRostered > 0 ? totalPoints / weeksRostered : null,
+    ppg: weeksActive > 0 ? totalPoints / weeksActive : null,
     ppgStarting: starterWeeks > 0 ? starterPoints / starterWeeks : null,
-    startPct: weeksRostered > 0 ? starterWeeks / weeksRostered : null,
-    activePct: weeksInWindow > 0 ? weeksRostered / weeksInWindow : null,
-    weeksInWindow,
-    weeksRostered,
+    startPct: weeksActive > 0 ? starterWeeks / weeksActive : null,
+    activePct: weeksAvailable > 0 ? weeksActive / weeksAvailable : null,
+    weeksAvailable,
+    weeksActive,
     starterWeeks,
     totalPoints,
     starterPoints,
@@ -235,8 +254,8 @@ function emptyStats(): StintStats {
     ppgStarting: null,
     startPct: null,
     activePct: null,
-    weeksInWindow: 0,
-    weeksRostered: 0,
+    weeksAvailable: 0,
+    weeksActive: 0,
     starterWeeks: 0,
     totalPoints: 0,
     starterPoints: 0,

--- a/src/services/playerStintStats.ts
+++ b/src/services/playerStintStats.ts
@@ -1,0 +1,264 @@
+import { and, eq, inArray, or } from "drizzle-orm";
+import { getDb, schema } from "@/db";
+import { resolveFamily } from "@/lib/familyResolution";
+
+export interface StintStatsInput {
+  familyId: string;
+  playerId: string;
+  managerUserId: string;
+  startSeason: string;
+  startWeek: number;
+  /** null/undefined ⇒ ongoing — runs through the latest played week in the family */
+  endSeason?: string | null;
+  endWeek?: number | null;
+}
+
+export interface StintStats {
+  ppg: number | null;
+  ppgStarting: number | null;
+  startPct: number | null;
+  activePct: number | null;
+  weeksInWindow: number;
+  weeksRostered: number;
+  starterWeeks: number;
+  totalPoints: number;
+  starterPoints: number;
+  byeWeeksExcluded: number;
+}
+
+/**
+ * Compute stint-scoped stats for a player on a single roster across the family
+ * leagues. Bye weeks are excluded from rate denominators.
+ */
+export async function computePlayerStintStats(
+  input: StintStatsInput,
+): Promise<StintStats | null> {
+  const {
+    familyId,
+    playerId,
+    managerUserId,
+    startSeason,
+    startWeek,
+    endSeason,
+    endWeek,
+  } = input;
+
+  const db = getDb();
+  const resolvedFamilyId = await resolveFamily(familyId);
+  if (!resolvedFamilyId) return null;
+
+  const members = await db
+    .select()
+    .from(schema.leagueFamilyMembers)
+    .where(eq(schema.leagueFamilyMembers.familyId, resolvedFamilyId));
+  if (members.length === 0) return emptyStats();
+
+  const startSeasonNum = parseInt(startSeason, 10);
+  const endSeasonNum = endSeason ? parseInt(endSeason, 10) : Infinity;
+  const inRangeMembers = members.filter((m) => {
+    const s = parseInt(m.season, 10);
+    return s >= startSeasonNum && s <= endSeasonNum;
+  });
+  if (inRangeMembers.length === 0) return emptyStats();
+
+  const leagueIds = inRangeMembers.map((m) => m.leagueId);
+  const leagueSeasonMap = new Map(inRangeMembers.map((m) => [m.leagueId, m.season]));
+
+  const [rosterRows, matchupRows, playerRow] = await Promise.all([
+    db
+      .select({
+        leagueId: schema.rosters.leagueId,
+        rosterId: schema.rosters.rosterId,
+      })
+      .from(schema.rosters)
+      .where(
+        and(
+          inArray(schema.rosters.leagueId, leagueIds),
+          eq(schema.rosters.ownerId, managerUserId),
+        ),
+      ),
+    db
+      .select({
+        leagueId: schema.matchups.leagueId,
+        week: schema.matchups.week,
+      })
+      .from(schema.matchups)
+      .where(inArray(schema.matchups.leagueId, leagueIds)),
+    db
+      .select({ gsisId: schema.players.gsisId })
+      .from(schema.players)
+      .where(eq(schema.players.id, playerId))
+      .limit(1),
+  ]);
+
+  const leagueRosterMap = new Map(rosterRows.map((r) => [r.leagueId, r.rosterId]));
+  if (leagueRosterMap.size === 0) return emptyStats();
+
+  const windowKeys = new Set<string>();
+  for (const m of matchupRows) {
+    const season = leagueSeasonMap.get(m.leagueId);
+    if (!season) continue;
+    if (!isInWindow(season, m.week, startSeason, startWeek, endSeason, endWeek)) {
+      continue;
+    }
+    windowKeys.add(`${season}|${m.week}`);
+  }
+
+  const gsisId = playerRow[0]?.gsisId ?? null;
+
+  const seasonsInWindow = [...new Set([...windowKeys].map((k) => parseInt(k.split("|")[0], 10)))];
+  const byeKeys = new Set<string>();
+  if (gsisId && seasonsInWindow.length > 0) {
+    const [statusRows, scheduleRows] = await Promise.all([
+      db
+        .select()
+        .from(schema.nflWeeklyRosterStatus)
+        .where(
+          and(
+            eq(schema.nflWeeklyRosterStatus.gsisId, gsisId),
+            inArray(schema.nflWeeklyRosterStatus.season, seasonsInWindow),
+          ),
+        ),
+      db
+        .select()
+        .from(schema.nflSchedule)
+        .where(inArray(schema.nflSchedule.season, seasonsInWindow)),
+    ]);
+
+    const playerTeamByWeek = new Map<string, string>();
+    for (const r of statusRows) {
+      if (r.team) playerTeamByWeek.set(`${r.season}|${r.week}`, r.team);
+    }
+
+    const teamPlayedWeeks = new Map<string, Set<number>>();
+    const seasonAllWeeks = new Map<number, Set<number>>();
+    const addTeamWeek = (season: number, team: string, week: number) => {
+      const key = `${season}|${team}`;
+      const set = teamPlayedWeeks.get(key) ?? new Set<number>();
+      set.add(week);
+      teamPlayedWeeks.set(key, set);
+    };
+    for (const g of scheduleRows) {
+      const allWeeksSet = seasonAllWeeks.get(g.season) ?? new Set<number>();
+      allWeeksSet.add(g.week);
+      seasonAllWeeks.set(g.season, allWeeksSet);
+      addTeamWeek(g.season, g.homeTeam, g.week);
+      addTeamWeek(g.season, g.awayTeam, g.week);
+    }
+
+    for (const key of windowKeys) {
+      const [seasonStr, weekStr] = key.split("|");
+      const seasonNum = parseInt(seasonStr, 10);
+      const weekNum = parseInt(weekStr, 10);
+      const allWeeks = seasonAllWeeks.get(seasonNum);
+      if (!allWeeks || !allWeeks.has(weekNum)) continue;
+
+      // Mid-season status rows occasionally drop; infer the player's team from
+      // the nearest week with data so we don't misclassify byes.
+      let team = playerTeamByWeek.get(key) ?? null;
+      if (!team) {
+        for (let delta = 1; delta <= 18 && !team; delta++) {
+          team =
+            playerTeamByWeek.get(`${seasonNum}|${weekNum - delta}`) ??
+            playerTeamByWeek.get(`${seasonNum}|${weekNum + delta}`) ??
+            null;
+        }
+      }
+      if (!team) continue;
+
+      const teamWeeks = teamPlayedWeeks.get(`${seasonNum}|${team}`);
+      if (teamWeeks && !teamWeeks.has(weekNum)) {
+        byeKeys.add(key);
+      }
+    }
+  }
+
+  const weeksInWindow = windowKeys.size - byeKeys.size;
+
+  const perLeaguePairs = [...leagueRosterMap.entries()].map(([lid, rid]) =>
+    and(
+      eq(schema.playerScores.leagueId, lid),
+      eq(schema.playerScores.rosterId, rid),
+    ),
+  );
+  const scoreRows = await db
+    .select({
+      leagueId: schema.playerScores.leagueId,
+      week: schema.playerScores.week,
+      points: schema.playerScores.points,
+      isStarter: schema.playerScores.isStarter,
+    })
+    .from(schema.playerScores)
+    .where(
+      and(
+        eq(schema.playerScores.playerId, playerId),
+        or(...perLeaguePairs)!,
+      ),
+    );
+
+  let weeksRostered = 0;
+  let starterWeeks = 0;
+  let totalPoints = 0;
+  let starterPoints = 0;
+  for (const s of scoreRows) {
+    const season = leagueSeasonMap.get(s.leagueId);
+    if (!season) continue;
+    const key = `${season}|${s.week}`;
+    if (!windowKeys.has(key)) continue;
+    if (byeKeys.has(key)) continue;
+    weeksRostered += 1;
+    const pts = s.points ?? 0;
+    totalPoints += pts;
+    if (s.isStarter) {
+      starterWeeks += 1;
+      starterPoints += pts;
+    }
+  }
+
+  return {
+    ppg: weeksRostered > 0 ? totalPoints / weeksRostered : null,
+    ppgStarting: starterWeeks > 0 ? starterPoints / starterWeeks : null,
+    startPct: weeksRostered > 0 ? starterWeeks / weeksRostered : null,
+    activePct: weeksInWindow > 0 ? weeksRostered / weeksInWindow : null,
+    weeksInWindow,
+    weeksRostered,
+    starterWeeks,
+    totalPoints,
+    starterPoints,
+    byeWeeksExcluded: byeKeys.size,
+  };
+}
+
+function emptyStats(): StintStats {
+  return {
+    ppg: null,
+    ppgStarting: null,
+    startPct: null,
+    activePct: null,
+    weeksInWindow: 0,
+    weeksRostered: 0,
+    starterWeeks: 0,
+    totalPoints: 0,
+    starterPoints: 0,
+    byeWeeksExcluded: 0,
+  };
+}
+
+function isInWindow(
+  season: string,
+  week: number,
+  startSeason: string,
+  startWeek: number,
+  endSeason: string | null | undefined,
+  endWeek: number | null | undefined,
+): boolean {
+  const s = parseInt(season, 10);
+  const ss = parseInt(startSeason, 10);
+  if (s < ss) return false;
+  if (s === ss && week < startWeek) return false;
+  if (endSeason == null) return true; // ongoing
+  const es = parseInt(endSeason, 10);
+  if (s > es) return false;
+  if (s === es && endWeek != null && week > endWeek) return false;
+  return true;
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -123,10 +123,15 @@ export default {
           from: { height: "var(--radix-accordion-content-height)" },
           to: { height: "0" },
         },
+        "tip-shimmer": {
+          "0%, 100%": { backgroundPosition: "200% 50%" },
+          "50%": { backgroundPosition: "-100% 50%" },
+        },
       },
       animation: {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
+        "tip-shimmer": "tip-shimmer 6s ease-in-out infinite",
       },
     },
   },


### PR DESCRIPTION
Closes #71.

## Summary
- Click a player tenure edge → drawer shows PPG, PPG-while-starting, Start %, and Active % for that exact stint window. Bye and inactive (NFL non-ACT) weeks are excluded from rate denominators so the numbers reflect actual scoring opportunities.
- ⌘/Ctrl/Shift-click another edge to add it to the selection — drawer flips into a side-by-side comparison grid. Each column has a × to remove. Plain click still replaces. URL is deep-linkable (`?selection=edge:id1,id2,id3`).
- Top value per metric row is highlighted in sage (border-primary/40, bg-primary/5, text-primary). Ties highlight all tied leaders.
- Tip text shimmers gently across the muted gradient (6s loop), respecting `prefers-reduced-motion`.
- Pick edges show metadata only (no metrics) in single view, "—/pick" placeholder columns in compare.

## Implementation
- `src/services/playerStintStats.ts` — resolves family → leagues, builds the stint window from `matchups`, detects byes via `nflWeeklyRosterStatus` + `nflSchedule`, computes `activeKeys` (window ∩ ACT status), aggregates from `playerScores`.
- `src/app/api/leagues/[familyId]/player/[playerId]/stint-stats/route.ts` — thin GET wrapper.
- `src/components/graph/GraphDetailDrawer.tsx` — `EdgeDetail` for single, `EdgeCompare` for 2+. Shared `buildStintStatsUrl` + per-edge fetch hook. Drawer widens to 40rem in compare mode.
- `src/components/graph/AssetGraph.tsx` — `onEdgeClick` reads modifier keys to toggle.
- `src/lib/assetGraph.ts` — `GraphSelection.edge` carries `edgeIds: string[]` (was singular `edgeId`). URL is back-compat.
- `tailwind.config.ts` + `src/app/globals.css` — `tip-shimmer` keyframe + utility class.

## Test plan
- [x] Closed stint (Jamaal Williams · mcmahorj 2021–2025): drawer numbers match `weekly-log` filtered to (manager, ACT, non-bye) — PPG 8.51 / PPG-starting 9.71 / 57 active / 32 starter / Active % 83%.
- [x] Ongoing stint (Saquon Barkley · jrygrande 2021W3 → ongoing): Active % 89% (74/83), reflecting his 9 NFL inactive games across 2021–2024.
- [x] Pick tenure edge: no stats block (single); "—/pick" placeholder columns (compare).
- [x] 2-stint and 3-stint compare via deep-link: leader cells light up in sage, remove × falls back cleanly to single-edge or null.
- [x] Mixed pick + player compare: pick column shows placeholder, player column shows metrics.
- [x] `npx tsc --noEmit` clean.
- [x] ESLint clean on changed files.
- [x] /simplify pass applied (parallelized DB queries, edgesById Map, dropped unstable useMemo, collapsed onClose into onSelectionChange, simplified COMPARE_METRIC_ROWS shape).
- [x] /security-review: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)