### PR TITLE
feat(waitlist): capture demand for unsupported leagues + Resend notifications (#83)

### DIFF
--- a/drizzle/0012_cute_shatterstar.sql
+++ b/drizzle/0012_cute_shatterstar.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "waitlist" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"email" text NOT NULL,
+	"league_id" text NOT NULL,
+	"status" text DEFAULT 'pending' NOT NULL,
+	"created_at" timestamp DEFAULT now() NOT NULL,
+	"notified_at" timestamp
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "waitlist_email_league_unique" ON "waitlist" USING btree ("email","league_id");--> statement-breakpoint
+CREATE INDEX "waitlist_league_id_idx" ON "waitlist" USING btree ("league_id");--> statement-breakpoint
+CREATE INDEX "waitlist_status_idx" ON "waitlist" USING btree ("status");

--- a/drizzle/meta/0012_snapshot.json
+++ b/drizzle/meta/0012_snapshot.json
@@ -1,0 +1,2668 @@
+{
+  "id": "b4c52b72-371f-490f-97e2-9f3473625c3e",
+  "prevId": "0e2959a9-3878-45be-944c-af3a0ac8312f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.algorithm_config": {
+      "name": "algorithm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "algorithm_config_active_idx": {
+          "name": "algorithm_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "algorithm_config_experiment_id_experiment_runs_id_fk": {
+          "name": "algorithm_config_experiment_id_experiment_runs_id_fk",
+          "tableFrom": "algorithm_config",
+          "tableTo": "experiment_runs",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_events": {
+      "name": "asset_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_kind": {
+          "name": "asset_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_season": {
+          "name": "pick_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_round": {
+          "name": "pick_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_original_roster_id": {
+          "name": "pick_original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_roster_id": {
+          "name": "from_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_roster_id": {
+          "name": "to_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "asset_events_player_idx": {
+          "name": "asset_events_player_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_tx_idx": {
+          "name": "asset_events_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_pick_idx": {
+          "name": "asset_events_pick_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_round",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_original_roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_grades": {
+      "name": "draft_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_value": {
+          "name": "benchmark_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_production": {
+          "name": "player_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_production": {
+          "name": "benchmark_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_size": {
+          "name": "benchmark_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_grades_draft_idx": {
+          "name": "draft_grades_draft_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_player_idx": {
+          "name": "draft_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_unique_idx": {
+          "name": "draft_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_grades_draft_id_drafts_id_fk": {
+          "name": "draft_grades_draft_id_drafts_id_fk",
+          "tableFrom": "draft_grades",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_slot": {
+          "name": "draft_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_keeper": {
+          "name": "is_keeper",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_draft_id_drafts_id_fk": {
+          "name": "draft_picks_draft_id_drafts_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "draft_picks_draft_id_pick_no_pk": {
+          "name": "draft_picks_draft_id_pick_no_pk",
+          "columns": [
+            "draft_id",
+            "pick_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_to_roster_id": {
+          "name": "slot_to_roster_id",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "drafts_league_id_leagues_id_fk": {
+          "name": "drafts_league_id_leagues_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_runs": {
+      "name": "experiment_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hypothesis": {
+          "name": "hypothesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_criteria": {
+          "name": "acceptance_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_reason": {
+          "name": "verdict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scorecard": {
+          "name": "scorecard",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiment_runs_name_idx": {
+          "name": "experiment_runs_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fantasy_calc_values": {
+      "name": "fantasy_calc_values",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_flex": {
+          "name": "is_super_flex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ppr": {
+          "name": "ppr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_rank": {
+          "name": "position_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "fantasy_calc_values_player_id_is_super_flex_ppr_pk": {
+          "name": "fantasy_calc_values_player_id_is_super_flex_ppr_pk",
+          "columns": [
+            "player_id",
+            "is_super_flex",
+            "ppr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_families": {
+      "name": "league_families",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_league_id": {
+          "name": "root_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "league_families_root_league_id_unique": {
+          "name": "league_families_root_league_id_unique",
+          "columns": [
+            {
+              "expression": "root_league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_family_members": {
+      "name": "league_family_members",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "league_family_members_league_id_idx": {
+          "name": "league_family_members_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "league_family_members_family_id_league_families_id_fk": {
+          "name": "league_family_members_family_id_league_families_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "league_families",
+          "columnsFrom": [
+            "family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_family_members_league_id_leagues_id_fk": {
+          "name": "league_family_members_league_id_leagues_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_family_members_family_id_league_id_pk": {
+          "name": "league_family_members_family_id_league_id_pk",
+          "columns": [
+            "family_id",
+            "league_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_users": {
+      "name": "league_users",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_users_league_id_leagues_id_fk": {
+          "name": "league_users_league_id_leagues_id_fk",
+          "tableFrom": "league_users",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_users_league_id_user_id_pk": {
+          "name": "league_users_league_id_user_id_pk",
+          "columns": [
+            "league_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_league_id": {
+          "name": "previous_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scoring_settings": {
+          "name": "scoring_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_positions": {
+          "name": "roster_positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_rosters": {
+          "name": "total_rosters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winners_bracket": {
+          "name": "winners_bracket",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manager_metrics": {
+      "name": "manager_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manager_metrics_unique_idx": {
+          "name": "manager_metrics_unique_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchups": {
+      "name": "matchups",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_points": {
+          "name": "starter_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_points": {
+          "name": "player_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchups_league_id_week_roster_id_pk": {
+          "name": "matchups_league_id_week_roster_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_injuries": {
+      "name": "nfl_injuries",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_type": {
+          "name": "game_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_primary_injury": {
+          "name": "report_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_secondary_injury": {
+          "name": "report_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_status": {
+          "name": "practice_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_primary_injury": {
+          "name": "practice_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_secondary_injury": {
+          "name": "practice_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_modified": {
+          "name": "date_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_injuries_gsis_idx": {
+          "name": "nfl_injuries_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_injuries_season_week_gsis_id_pk": {
+          "name": "nfl_injuries_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_schedule": {
+      "name": "nfl_schedule",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team": {
+          "name": "home_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team": {
+          "name": "away_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_date": {
+          "name": "game_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_schedule_season_week_home_team_pk": {
+          "name": "nfl_schedule_season_week_home_team_pk",
+          "columns": [
+            "season",
+            "week",
+            "home_team"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_state": {
+      "name": "nfl_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'nfl'"
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_type": {
+          "name": "season_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_weekly_roster_status": {
+      "name": "nfl_weekly_roster_status",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_abbr": {
+          "name": "status_abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_roster_status_gsis_idx": {
+          "name": "nfl_roster_status_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_weekly_roster_status_season_week_gsis_id_pk": {
+          "name": "nfl_weekly_roster_status_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_scores": {
+      "name": "player_scores",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_scores_league_id_week_roster_id_player_id_pk": {
+          "name": "player_scores_league_id_week_roster_id_player_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id",
+            "player_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injury_status": {
+          "name": "injury_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "years_exp": {
+          "name": "years_exp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rosters": {
+      "name": "rosters",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserve": {
+          "name": "reserve",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "ties": {
+          "name": "ties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts": {
+          "name": "fpts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts_against": {
+          "name": "fpts_against",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rosters_owner_idx": {
+          "name": "rosters_owner_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rosters_league_id_leagues_id_fk": {
+          "name": "rosters_league_id_leagues_id_fk",
+          "tableFrom": "rosters",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rosters_league_id_roster_id_pk": {
+          "name": "rosters_league_id_roster_id_pk",
+          "columns": [
+            "league_id",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_jobs": {
+      "name": "sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "done": {
+          "name": "done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_jobs_ref_status_idx": {
+          "name": "sync_jobs_ref_status_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_watermarks": {
+      "name": "sync_watermarks",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_week": {
+          "name": "last_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_watermarks_league_id_data_type_pk": {
+          "name": "sync_watermarks_league_id_data_type_pk",
+          "columns": [
+            "league_id",
+            "data_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trade_grades": {
+      "name": "trade_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fantasy_calc_value": {
+          "name": "fantasy_calc_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trade_grades_tx_idx": {
+          "name": "trade_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trade_grades_unique_idx": {
+          "name": "trade_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trade_grades_transaction_id_transactions_id_fk": {
+          "name": "trade_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "trade_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traded_picks": {
+      "name": "traded_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_roster_id": {
+          "name": "original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_owner_id": {
+          "name": "current_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_owner_id": {
+          "name": "previous_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "traded_picks_league_season_idx": {
+          "name": "traded_picks_league_season_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "traded_picks_league_id_leagues_id_fk": {
+          "name": "traded_picks_league_id_leagues_id_fk",
+          "tableFrom": "traded_picks",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_ids": {
+          "name": "roster_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adds": {
+          "name": "adds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drops": {
+          "name": "drops",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_picks": {
+          "name": "draft_picks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_league_week_idx": {
+          "name": "transactions_league_week_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_league_id_leagues_id_fk": {
+          "name": "transactions_league_id_leagues_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_email_league_unique": {
+          "name": "waitlist_email_league_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_league_id_idx": {
+          "name": "waitlist_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waiver_grades": {
+      "name": "waiver_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_player_id": {
+          "name": "dropped_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_value": {
+          "name": "dropped_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_bid": {
+          "name": "faab_bid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_efficiency": {
+          "name": "faab_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waiver_grades_tx_idx": {
+          "name": "waiver_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_player_idx": {
+          "name": "waiver_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_unique_idx": {
+          "name": "waiver_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "waiver_grades_transaction_id_transactions_id_fk": {
+          "name": "waiver_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "waiver_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1777734267813,
       "tag": "0011_many_the_initiative",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1777752556018,
+      "tag": "0012_cute_shatterstar",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "react-dom": "^18.3.1",
         "reactflow": "^11.11.4",
         "recharts": "^3.2.1",
+        "resend": "^6.12.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
         "zod": "^3.23.8"
@@ -3780,6 +3781,12 @@
         "@sinonjs/commons": "^3.0.1"
       }
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -7352,6 +7359,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
+    },
     "node_modules/fastq": {
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
@@ -10703,6 +10716,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.4.tgz",
+      "integrity": "sha512-0WdnFQYUrPGGTFu1uOqD2s7omwua8xaeYGdO6rb88oD5yJ/4pPHDA4sdWqfD8wQVfCny563n/HQS7zTFft+f/g==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -11170,6 +11189,27 @@
       "integrity": "sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==",
       "license": "MIT"
     },
+    "node_modules/resend": {
+      "version": "6.12.2",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.12.2.tgz",
+      "integrity": "sha512-xwgmU4b0OqoabJsIoK/x0Whk0Fcs3bpbK4i/DEWPiE5hYJHyHl0TbB6QbI3gIr+bLdLUJ1GYm/fe41aVFuHXgw==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.4",
+        "svix": "1.90.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -11592,6 +11632,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/stop-iteration-iterator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -11976,6 +12026,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/svix": {
+      "version": "1.90.0",
+      "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
+      "integrity": "sha512-ljkZuyy2+IBEoESkIpn8sLM+sxJHQcPxlZFxU+nVDhltNfUMisMBzWX/UR8SjEnzoI28ZjCzMbmYAPwSTucoMw==",
+      "license": "MIT",
+      "dependencies": {
+        "standardwebhooks": "1.0.0",
+        "uuid": "^10.0.0"
       }
     },
     "node_modules/synckit": {
@@ -12610,6 +12670,20 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "db:migrate": "drizzle-kit migrate",
     "db:push": "drizzle-kit push",
     "db:studio": "drizzle-kit studio",
+    "notify-waitlist": "tsx scripts/notify-waitlist.ts",
     "test": "jest"
   },
   "dependencies": {
@@ -37,6 +38,7 @@
     "react-dom": "^18.3.1",
     "reactflow": "^11.11.4",
     "recharts": "^3.2.1",
+    "resend": "^6.12.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
     "zod": "^3.23.8"

--- a/scripts/notify-waitlist.ts
+++ b/scripts/notify-waitlist.ts
@@ -104,7 +104,7 @@ async function main() {
   });
 
   console.log(
-    `notify-waitlist: ${summary.notified} sent, ${summary.skipped} skipped, ${summary.unsent.length} unsent`
+    `notify-waitlist: ${summary.notified} sent, ${summary.unsent.length} unsent`
   );
   if (summary.unsent.length > 0) {
     console.log("Unsent waitlist row IDs:");

--- a/scripts/notify-waitlist.ts
+++ b/scripts/notify-waitlist.ts
@@ -1,0 +1,118 @@
+/**
+ * CLI: notify all pending waitlist rows for a league family.
+ *
+ * Usage:
+ *   npm run notify-waitlist -- --family-id <UUID>
+ *   npx tsx scripts/notify-waitlist.ts --family-id <UUID>
+ *
+ * Behaviour:
+ *   - Resolves family_id → set of member league_ids
+ *   - Selects all `pending` waitlist rows whose league_id is in that set
+ *   - Sends notify email per row, with 100ms spacing
+ *   - On 429: exponential backoff (1s, 2s, 4s, 8s) up to 4 retries
+ *   - On daily-cap exhaustion: logs unsent IDs and exits 0 (re-runnable)
+ *   - On per-row send success: updates status='notified', notified_at=now()
+ *
+ * Idempotent: re-running skips already-notified rows.
+ */
+
+import "dotenv/config";
+import { neon } from "@neondatabase/serverless";
+import { drizzle } from "drizzle-orm/neon-http";
+import { and, eq, inArray } from "drizzle-orm";
+import * as schema from "../src/db/schema";
+import { notifyWaitlist } from "../src/lib/notifyWaitlist";
+
+function parseArgs(argv: string[]): { familyId: string | null } {
+  let familyId: string | null = null;
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    if (a === "--family-id" && i + 1 < argv.length) {
+      familyId = argv[i + 1];
+      i++;
+    } else if (a.startsWith("--family-id=")) {
+      familyId = a.slice("--family-id=".length);
+    }
+  }
+  return { familyId };
+}
+
+async function main() {
+  const { familyId } = parseArgs(process.argv.slice(2));
+  if (!familyId) {
+    console.error("Missing --family-id <UUID>");
+    process.exit(2);
+  }
+
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("DATABASE_URL is not set");
+    process.exit(2);
+  }
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error("RESEND_API_KEY is not set");
+    process.exit(2);
+  }
+
+  const db = drizzle(neon(url), { schema });
+
+  const summary = await notifyWaitlist({
+    familyId,
+    db: {
+      getMembers: async (fid) => {
+        const rows = await db
+          .select({
+            leagueId: schema.leagueFamilyMembers.leagueId,
+          })
+          .from(schema.leagueFamilyMembers)
+          .where(eq(schema.leagueFamilyMembers.familyId, fid));
+        return rows.map((r) => r.leagueId);
+      },
+      getPending: async (leagueIds) => {
+        if (leagueIds.length === 0) return [];
+        const rows = await db
+          .select({
+            id: schema.waitlist.id,
+            email: schema.waitlist.email,
+            leagueId: schema.waitlist.leagueId,
+          })
+          .from(schema.waitlist)
+          .where(
+            and(
+              eq(schema.waitlist.status, "pending"),
+              inArray(schema.waitlist.leagueId, leagueIds)
+            )
+          );
+        return rows;
+      },
+      getLeagueName: async (leagueId) => {
+        const rows = await db
+          .select({ name: schema.leagues.name })
+          .from(schema.leagues)
+          .where(eq(schema.leagues.id, leagueId))
+          .limit(1);
+        return rows[0]?.name ?? null;
+      },
+      markNotified: async (id) => {
+        await db
+          .update(schema.waitlist)
+          .set({ status: "notified", notifiedAt: new Date() })
+          .where(eq(schema.waitlist.id, id));
+      },
+    },
+  });
+
+  console.log(
+    `notify-waitlist: ${summary.notified} sent, ${summary.skipped} skipped, ${summary.unsent.length} unsent`
+  );
+  if (summary.unsent.length > 0) {
+    console.log("Unsent waitlist row IDs:");
+    for (const id of summary.unsent) console.log(`  ${id}`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/(public)/LandingWaitlist.tsx
+++ b/src/app/(public)/LandingWaitlist.tsx
@@ -1,9 +1,0 @@
-"use client";
-
-import { WaitlistProgress } from "@/components/WaitlistProgress";
-import { useWaitlistCount } from "@/lib/useWaitlistCount";
-
-export function LandingWaitlist() {
-  const { current } = useWaitlistCount();
-  return <WaitlistProgress current={current} target={100} />;
-}

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -8,8 +8,6 @@ import {
   BookOpen,
   FlaskConical,
 } from "lucide-react";
-import { LandingWaitlist } from "./LandingWaitlist";
-
 export default function LandingPage() {
   return (
     <div className="min-h-screen bg-gradient-to-b from-background to-secondary/20">
@@ -27,7 +25,6 @@ export default function LandingPage() {
         >
           Get started
         </Link>
-        <LandingWaitlist />
         <p className="text-xs text-muted-foreground mt-6 flex flex-wrap justify-center gap-x-2 gap-y-0.5">
           <span>Only for Sleeper leagues</span>
           <span>&middot; Player valuations by FantasyCalc &middot; NFL data from nflverse</span>

--- a/src/app/(public)/start/page.tsx
+++ b/src/app/(public)/start/page.tsx
@@ -34,6 +34,7 @@ interface FoundLeague {
   name: string;
   season: string;
   avatar: string | null;
+  waitlisted?: boolean;
 }
 
 interface FindLeaguesResponse {
@@ -455,7 +456,9 @@ function NotInDbList({
       </p>
       {leagues.map((l) => {
         const isJustAdded = justAdded.has(l.league_id);
-        const isPersisted = persisted.has(l.league_id) && !isJustAdded;
+        const isPersisted =
+          (persisted.has(l.league_id) || l.waitlisted === true) &&
+          !isJustAdded;
         const isOpen = openLeagueId === l.league_id;
         return (
           <div

--- a/src/app/(public)/start/page.tsx
+++ b/src/app/(public)/start/page.tsx
@@ -10,6 +10,8 @@ import {
   getStoredUsername,
   setStoredUsername,
 } from "@/lib/storedUsername";
+import { WaitlistProgress } from "@/components/WaitlistProgress";
+import { useWaitlistCount } from "@/lib/useWaitlistCount";
 import {
   addWaitlistedLeague,
   getWaitlistedLeagues,
@@ -306,6 +308,7 @@ function LeaguesList({
 }) {
   const inDb = leagues.filter((l) => l.family_id);
   const notInDb = leagues.filter((l) => !l.family_id);
+  const { current, bump } = useWaitlistCount();
 
   return (
     <div className="space-y-6">
@@ -354,7 +357,14 @@ function LeaguesList({
       )}
 
       {notInDb.length > 0 && (
-        <NotInDbList username={username} leagues={notInDb} />
+        <>
+          <WaitlistProgress current={current} target={100} />
+          <NotInDbList
+            username={username}
+            leagues={notInDb}
+            onWaitlistAdded={bump}
+          />
+        </>
       )}
 
       {notInDb.length > 0 && inDb.length === 0 && (
@@ -372,9 +382,11 @@ function LeaguesList({
 function NotInDbList({
   username,
   leagues,
+  onWaitlistAdded,
 }: {
   username: string;
   leagues: FoundLeague[];
+  onWaitlistAdded?: () => void;
 }) {
   const [openLeagueId, setOpenLeagueId] = useState<string | null>(null);
   const [email, setEmail] = useState("");
@@ -428,6 +440,7 @@ function NotInDbList({
         return next;
       });
       setOpenLeagueId(null);
+      onWaitlistAdded?.();
     } catch {
       setError("Network error. Try again.");
     } finally {

--- a/src/app/(public)/start/page.tsx
+++ b/src/app/(public)/start/page.tsx
@@ -456,7 +456,7 @@ function NotInDbList({
       </p>
       {leagues.map((l) => {
         const isJustAdded = justAdded.has(l.league_id);
-        const isPersisted =
+        const isOnWaitlist =
           (persisted.has(l.league_id) || l.waitlisted === true) &&
           !isJustAdded;
         const isOpen = openLeagueId === l.league_id;
@@ -472,11 +472,12 @@ function NotInDbList({
                   {l.season}
                 </p>
               </div>
-              {isPersisted ? (
+              {isOnWaitlist && (
                 <span className="text-sm text-primary font-medium flex-shrink-0">
                   ✓ On waitlist
                 </span>
-              ) : isJustAdded ? null : isOpen ? null : (
+              )}
+              {!isOnWaitlist && !isJustAdded && !isOpen && (
                 <button
                   type="button"
                   onClick={() => handleOpen(l.league_id)}
@@ -486,7 +487,7 @@ function NotInDbList({
                 </button>
               )}
             </div>
-            {isOpen && !isJustAdded && !isPersisted && (
+            {isOpen && !isJustAdded && !isOnWaitlist && (
               <form
                 className="space-y-2"
                 onSubmit={(e) => {

--- a/src/app/(public)/start/page.tsx
+++ b/src/app/(public)/start/page.tsx
@@ -10,6 +10,10 @@ import {
   getStoredUsername,
   setStoredUsername,
 } from "@/lib/storedUsername";
+import {
+  addWaitlistedLeague,
+  getWaitlistedLeagues,
+} from "@/lib/waitlistedLeagues";
 
 type ViewState =
   | "empty"
@@ -350,42 +354,179 @@ function LeaguesList({
       )}
 
       {notInDb.length > 0 && (
-        <div className="space-y-2">
-          <p className="text-xs uppercase tracking-wide text-muted-foreground font-mono">
-            Not yet supported
-          </p>
-          {notInDb.map((l) => (
-            <div
-              key={l.league_id}
-              className="flex items-center justify-between gap-4 p-4 rounded-md border bg-card"
-            >
+        <NotInDbList username={username} leagues={notInDb} />
+      )}
+
+      {notInDb.length > 0 && inDb.length === 0 && (
+        <p className="text-sm text-muted-foreground pt-2">
+          None of your leagues are supported yet.{" "}
+          <Link href="/demo" className="text-primary hover:underline">
+            Browse a demo league →
+          </Link>
+        </p>
+      )}
+    </div>
+  );
+}
+
+function NotInDbList({
+  username,
+  leagues,
+}: {
+  username: string;
+  leagues: FoundLeague[];
+}) {
+  const [openLeagueId, setOpenLeagueId] = useState<string | null>(null);
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [persisted, setPersisted] = useState<Set<string>>(() => new Set());
+  const [justAdded, setJustAdded] = useState<Set<string>>(() => new Set());
+
+  useEffect(() => {
+    if (!username) return;
+    const stored = getWaitlistedLeagues(username);
+    if (stored.length > 0) setPersisted(new Set(stored));
+  }, [username]);
+
+  function handleOpen(leagueId: string) {
+    setOpenLeagueId(leagueId);
+    setError(null);
+    track("waitlist_shown", { league_id: leagueId });
+  }
+
+  async function handleSubmit(league: FoundLeague) {
+    setError(null);
+    const trimmed = email.trim();
+    if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed)) {
+      setError("Enter a valid email address.");
+      return;
+    }
+    setSubmitting(true);
+    try {
+      const res = await fetch("/api/waitlist", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          email: trimmed,
+          league_id: league.league_id,
+          league_name: league.name,
+        }),
+      });
+      if (res.status === 429) {
+        setError("Too many requests. Try again in a minute.");
+        return;
+      }
+      if (!res.ok) {
+        setError("Something went wrong. Try again.");
+        return;
+      }
+      addWaitlistedLeague(username, league.league_id);
+      setJustAdded((prev) => {
+        const next = new Set(prev);
+        next.add(league.league_id);
+        return next;
+      });
+      setOpenLeagueId(null);
+    } catch {
+      setError("Network error. Try again.");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="space-y-2">
+      <p className="text-xs uppercase tracking-wide text-muted-foreground font-mono">
+        Not yet supported
+      </p>
+      {leagues.map((l) => {
+        const isJustAdded = justAdded.has(l.league_id);
+        const isPersisted = persisted.has(l.league_id) && !isJustAdded;
+        const isOpen = openLeagueId === l.league_id;
+        return (
+          <div
+            key={l.league_id}
+            className="p-4 rounded-md border bg-card space-y-3"
+          >
+            <div className="flex items-center justify-between gap-4">
               <div className="min-w-0">
                 <p className="font-medium truncate">{l.name}</p>
                 <p className="text-xs text-muted-foreground font-mono">
                   {l.season}
                 </p>
               </div>
-              <button
-                type="button"
-                onClick={() =>
-                  track("waitlist_shown", { league_id: l.league_id })
-                }
-                className="px-4 py-2 rounded-md border border-primary text-primary text-sm font-medium hover:bg-primary/10 transition-colors flex-shrink-0"
-              >
-                Join waitlist
-              </button>
+              {isPersisted ? (
+                <span className="text-sm text-primary font-medium flex-shrink-0">
+                  ✓ On waitlist
+                </span>
+              ) : isJustAdded ? null : isOpen ? null : (
+                <button
+                  type="button"
+                  onClick={() => handleOpen(l.league_id)}
+                  className="px-4 py-2 rounded-md border border-primary text-primary text-sm font-medium hover:bg-primary/10 transition-colors flex-shrink-0"
+                >
+                  Join waitlist
+                </button>
+              )}
             </div>
-          ))}
-          {inDb.length === 0 && (
-            <p className="text-sm text-muted-foreground pt-2">
-              None of your leagues are supported yet.{" "}
-              <Link href="/demo" className="text-primary hover:underline">
-                Browse a demo league →
-              </Link>
-            </p>
-          )}
-        </div>
-      )}
+            {isOpen && !isJustAdded && !isPersisted && (
+              <form
+                className="space-y-2"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  handleSubmit(l);
+                }}
+              >
+                <div className="flex gap-2">
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    disabled={submitting}
+                    placeholder="you@example.com"
+                    aria-label="Email address"
+                    autoComplete="email"
+                    required
+                    className="flex-1 px-3 py-2 rounded-md border border-input bg-background text-sm focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-60"
+                  />
+                  {/* Honeypot — hidden from users, bots fill it */}
+                  <input
+                    type="text"
+                    name="hp"
+                    tabIndex={-1}
+                    autoComplete="off"
+                    aria-hidden="true"
+                    style={{
+                      position: "absolute",
+                      left: "-10000px",
+                      width: "1px",
+                      height: "1px",
+                      opacity: 0,
+                    }}
+                  />
+                  <button
+                    type="submit"
+                    disabled={submitting || !email.trim()}
+                    className="px-4 py-2 rounded-md bg-primary text-primary-foreground text-sm font-medium hover:bg-primary/90 transition-colors disabled:opacity-50 flex-shrink-0"
+                  >
+                    {submitting ? "Submitting..." : "Submit"}
+                  </button>
+                </div>
+                {error && (
+                  <p className="text-xs text-grade-f">{error}</p>
+                )}
+              </form>
+            )}
+            {isJustAdded && (
+              <p className="text-sm text-primary font-medium">
+                ✓ Added to waitlist — we&apos;ll email you when {l.name} is
+                supported.
+              </p>
+            )}
+          </div>
+        );
+      })}
     </div>
   );
 }

--- a/src/app/api/start/find-leagues/route.ts
+++ b/src/app/api/start/find-leagues/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { and, eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { Sleeper } from "@/lib/sleeper";
+import { createIpRateLimiter, getClientIp } from "@/lib/ipRateLimit";
 
 interface FoundLeague {
   league_id: string;
@@ -19,51 +20,20 @@ interface FindLeaguesResponse {
   total_league_count: number;
 }
 
-const RATE_LIMIT_MAX = 10;
-const RATE_LIMIT_WINDOW_MS = 60_000;
 const RESPONSE_CACHE_TTL_MS = 60_000;
-const SWEEP_THRESHOLD = 1024;
 const DYNASTY_LEAGUE_TYPE = 2;
 
-const ipBuckets = new Map<string, { count: number; resetAt: number }>();
+const rateLimit = createIpRateLimiter({ max: 10, windowMs: 60_000 });
 const responseCache = new Map<
   string,
   { value: FindLeaguesResponse; expiresAt: number }
 >();
 
-function sweepExpired<T extends { resetAt?: number; expiresAt?: number }>(
-  map: Map<string, T>,
-  now: number
-) {
-  if (map.size < SWEEP_THRESHOLD) return;
-  for (const [k, v] of map) {
-    const exp = v.resetAt ?? v.expiresAt ?? 0;
-    if (exp < now) map.delete(k);
+function sweepCacheExpired(now: number) {
+  if (responseCache.size < 1024) return;
+  for (const [k, v] of responseCache) {
+    if (v.expiresAt < now) responseCache.delete(k);
   }
-}
-
-function getClientIp(req: NextRequest): string {
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) return forwarded.split(",")[0].trim();
-  return req.headers.get("x-real-ip") || "unknown";
-}
-
-function rateLimitCheck(ip: string): { allowed: boolean; retryAfterSec: number } {
-  const now = Date.now();
-  sweepExpired(ipBuckets, now);
-  const bucket = ipBuckets.get(ip);
-  if (!bucket || bucket.resetAt < now) {
-    ipBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return { allowed: true, retryAfterSec: 0 };
-  }
-  if (bucket.count >= RATE_LIMIT_MAX) {
-    return {
-      allowed: false,
-      retryAfterSec: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
-    };
-  }
-  bucket.count += 1;
-  return { allowed: true, retryAfterSec: 0 };
 }
 
 const SLEEPER_DOWN = NextResponse.json(
@@ -73,7 +43,7 @@ const SLEEPER_DOWN = NextResponse.json(
 
 export async function POST(req: NextRequest) {
   const ip = getClientIp(req);
-  const rl = rateLimitCheck(ip);
+  const rl = rateLimit(ip);
   if (!rl.allowed) {
     return NextResponse.json(
       { error: "Too many requests. Try again in a minute." },
@@ -98,7 +68,7 @@ export async function POST(req: NextRequest) {
   const username = rawUsername.toLowerCase();
 
   const now = Date.now();
-  sweepExpired(responseCache, now);
+  sweepCacheExpired(now);
   const cached = responseCache.get(username);
   if (cached && cached.expiresAt > now) {
     return NextResponse.json(cached.value);
@@ -143,29 +113,29 @@ export async function POST(req: NextRequest) {
     try {
       const db = getDb();
       const leagueIds = dynastyLeagues.map((l) => l.league_id);
-      const matched = await db
-        .select({
-          familyId: schema.leagueFamilyMembers.familyId,
-          leagueId: schema.leagueFamilyMembers.leagueId,
-        })
-        .from(schema.leagueFamilyMembers)
-        .where(inArray(schema.leagueFamilyMembers.leagueId, leagueIds));
-      for (const row of matched) {
-        familyMap.set(row.leagueId, row.familyId);
-      }
-
-      const notInDbIds = leagueIds.filter((id) => !familyMap.has(id));
-      if (notInDbIds.length > 0) {
-        const waitlisted = await db
+      const [matched, waitlisted] = await Promise.all([
+        db
+          .select({
+            familyId: schema.leagueFamilyMembers.familyId,
+            leagueId: schema.leagueFamilyMembers.leagueId,
+          })
+          .from(schema.leagueFamilyMembers)
+          .where(inArray(schema.leagueFamilyMembers.leagueId, leagueIds)),
+        db
           .select({ leagueId: schema.waitlist.leagueId })
           .from(schema.waitlist)
           .where(
             and(
               eq(schema.waitlist.status, "pending"),
-              inArray(schema.waitlist.leagueId, notInDbIds)
+              inArray(schema.waitlist.leagueId, leagueIds)
             )
-          );
-        for (const row of waitlisted) waitlistedSet.add(row.leagueId);
+          ),
+      ]);
+      for (const row of matched) {
+        familyMap.set(row.leagueId, row.familyId);
+      }
+      for (const row of waitlisted) {
+        if (!familyMap.has(row.leagueId)) waitlistedSet.add(row.leagueId);
       }
     } catch {
       return NextResponse.json(

--- a/src/app/api/start/find-leagues/route.ts
+++ b/src/app/api/start/find-leagues/route.ts
@@ -20,13 +20,27 @@ interface FindLeaguesResponse {
   total_league_count: number;
 }
 
+interface SleeperPayload {
+  user_id: string;
+  total_league_count: number;
+  dynastyLeagues: Array<{
+    league_id: string;
+    name: string;
+    season: string;
+    avatar: string | null;
+  }>;
+}
+
 const RESPONSE_CACHE_TTL_MS = 60_000;
 const DYNASTY_LEAGUE_TYPE = 2;
 
 const rateLimit = createIpRateLimiter({ max: 10, windowMs: 60_000 });
+// Caches only the Sleeper-derived shape — family + waitlist state are queried
+// fresh per request so writes (cleanup, new waitlist rows) become visible
+// immediately across all users, not after this username's TTL expires.
 const responseCache = new Map<
   string,
-  { value: FindLeaguesResponse; expiresAt: number }
+  { value: SleeperPayload; expiresAt: number }
 >();
 
 function sweepCacheExpired(now: number) {
@@ -70,49 +84,62 @@ export async function POST(req: NextRequest) {
   const now = Date.now();
   sweepCacheExpired(now);
   const cached = responseCache.get(username);
-  if (cached && cached.expiresAt > now) {
-    return NextResponse.json(cached.value);
-  }
+  let sleeperPayload: SleeperPayload | null =
+    cached && cached.expiresAt > now ? cached.value : null;
 
-  const [userRes, nflStateRes] = await Promise.allSettled([
-    Sleeper.getUserByUsername(username),
-    Sleeper.getNFLState(),
-  ]);
+  if (!sleeperPayload) {
+    const [userRes, nflStateRes] = await Promise.allSettled([
+      Sleeper.getUserByUsername(username),
+      Sleeper.getNFLState(),
+    ]);
 
-  if (userRes.status === "rejected") {
-    return SLEEPER_DOWN;
-  }
-  const user = userRes.value;
-  if (!user || !user.user_id) {
-    return NextResponse.json(
-      { error: `We couldn't find @${username} on Sleeper.` },
-      { status: 404 }
-    );
-  }
-  if (nflStateRes.status === "rejected") {
-    return SLEEPER_DOWN;
-  }
-  const currentSeason = String(nflStateRes.value.season);
+    if (userRes.status === "rejected") return SLEEPER_DOWN;
+    const user = userRes.value;
+    if (!user || !user.user_id) {
+      return NextResponse.json(
+        { error: `We couldn't find @${username} on Sleeper.` },
+        { status: 404 }
+      );
+    }
+    if (nflStateRes.status === "rejected") return SLEEPER_DOWN;
+    const currentSeason = String(nflStateRes.value.season);
 
-  let userLeagues;
-  try {
-    userLeagues = await Sleeper.getLeaguesByUser(user.user_id, currentSeason);
-  } catch {
-    return SLEEPER_DOWN;
-  }
-  const totalLeagueCount = userLeagues?.length ?? 0;
+    let userLeagues;
+    try {
+      userLeagues = await Sleeper.getLeaguesByUser(user.user_id, currentSeason);
+    } catch {
+      return SLEEPER_DOWN;
+    }
 
-  const dynastyLeagues = (userLeagues || []).filter((l) => {
-    const t = (l.settings as Record<string, unknown> | undefined)?.type;
-    return t === DYNASTY_LEAGUE_TYPE;
-  });
+    const dynastyLeagues = (userLeagues || [])
+      .filter((l) => {
+        const t = (l.settings as Record<string, unknown> | undefined)?.type;
+        return t === DYNASTY_LEAGUE_TYPE;
+      })
+      .map((l) => ({
+        league_id: l.league_id,
+        name: l.name,
+        season: l.season,
+        avatar: (l as unknown as { avatar?: string | null }).avatar ?? null,
+      }));
+
+    sleeperPayload = {
+      user_id: user.user_id,
+      total_league_count: userLeagues?.length ?? 0,
+      dynastyLeagues,
+    };
+    responseCache.set(username, {
+      value: sleeperPayload,
+      expiresAt: Date.now() + RESPONSE_CACHE_TTL_MS,
+    });
+  }
 
   const familyMap = new Map<string, string>();
   const waitlistedSet = new Set<string>();
-  if (dynastyLeagues.length > 0) {
+  if (sleeperPayload.dynastyLeagues.length > 0) {
     try {
       const db = getDb();
-      const leagueIds = dynastyLeagues.map((l) => l.league_id);
+      const leagueIds = sleeperPayload.dynastyLeagues.map((l) => l.league_id);
       const [matched, waitlisted] = await Promise.all([
         db
           .select({
@@ -147,23 +174,17 @@ export async function POST(req: NextRequest) {
 
   const response: FindLeaguesResponse = {
     username,
-    user_id: user.user_id,
-    leagues: dynastyLeagues.map((l) => ({
+    user_id: sleeperPayload.user_id,
+    leagues: sleeperPayload.dynastyLeagues.map((l) => ({
       league_id: l.league_id,
       family_id: familyMap.get(l.league_id) ?? null,
       name: l.name,
       season: l.season,
-      avatar:
-        (l as unknown as { avatar?: string | null }).avatar ?? null,
+      avatar: l.avatar,
       waitlisted: waitlistedSet.has(l.league_id),
     })),
-    total_league_count: totalLeagueCount,
+    total_league_count: sleeperPayload.total_league_count,
   };
-
-  responseCache.set(username, {
-    value: response,
-    expiresAt: Date.now() + RESPONSE_CACHE_TTL_MS,
-  });
 
   return NextResponse.json(response);
 }

--- a/src/app/api/start/find-leagues/route.ts
+++ b/src/app/api/start/find-leagues/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { inArray } from "drizzle-orm";
+import { and, eq, inArray } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { Sleeper } from "@/lib/sleeper";
 
@@ -9,6 +9,7 @@ interface FoundLeague {
   name: string;
   season: string;
   avatar: string | null;
+  waitlisted: boolean;
 }
 
 interface FindLeaguesResponse {
@@ -137,6 +138,7 @@ export async function POST(req: NextRequest) {
   });
 
   const familyMap = new Map<string, string>();
+  const waitlistedSet = new Set<string>();
   if (dynastyLeagues.length > 0) {
     try {
       const db = getDb();
@@ -150,6 +152,20 @@ export async function POST(req: NextRequest) {
         .where(inArray(schema.leagueFamilyMembers.leagueId, leagueIds));
       for (const row of matched) {
         familyMap.set(row.leagueId, row.familyId);
+      }
+
+      const notInDbIds = leagueIds.filter((id) => !familyMap.has(id));
+      if (notInDbIds.length > 0) {
+        const waitlisted = await db
+          .select({ leagueId: schema.waitlist.leagueId })
+          .from(schema.waitlist)
+          .where(
+            and(
+              eq(schema.waitlist.status, "pending"),
+              inArray(schema.waitlist.leagueId, notInDbIds)
+            )
+          );
+        for (const row of waitlisted) waitlistedSet.add(row.leagueId);
       }
     } catch {
       return NextResponse.json(
@@ -169,6 +185,7 @@ export async function POST(req: NextRequest) {
       season: l.season,
       avatar:
         (l as unknown as { avatar?: string | null }).avatar ?? null,
+      waitlisted: waitlistedSet.has(l.league_id),
     })),
     total_league_count: totalLeagueCount,
   };

--- a/src/app/api/waitlist/__tests__/route.test.ts
+++ b/src/app/api/waitlist/__tests__/route.test.ts
@@ -80,7 +80,8 @@ describe("POST /api/waitlist", () => {
     expect(sendConfirmationMock).toHaveBeenCalledWith({
       to: "user@example.com",
       leagueName: "Big & Bold Dynasty",
-      currentCapacity: 17,
+      // 17 from the count query + 20 vanity boost
+      currentCapacity: 37,
     });
   });
 
@@ -167,7 +168,8 @@ describe("POST /api/waitlist", () => {
     expect(sendConfirmationMock).toHaveBeenCalledWith({
       to: "user@example.com",
       leagueName: "<script>alert(1)</script>",
-      currentCapacity: 1,
+      // 1 from the count query + 20 vanity boost
+      currentCapacity: 21,
     });
   });
 });

--- a/src/app/api/waitlist/__tests__/route.test.ts
+++ b/src/app/api/waitlist/__tests__/route.test.ts
@@ -1,0 +1,173 @@
+/**
+ * @jest-environment node
+ *
+ * Tests POST /api/waitlist with the DB and Resend client mocked.
+ *
+ * Drizzle is mocked at the @/db boundary; the email module's sendConfirmation
+ * is mocked at the @/lib/email boundary. We exercise the route by calling
+ * its exported POST handler directly with synthesized NextRequest objects.
+ */
+
+type ExecuteRow = Record<string, unknown>;
+type ExecuteResult = { rows: ExecuteRow[] };
+
+const dbExecuteMock = jest.fn();
+const sendConfirmationMock = jest.fn();
+
+jest.mock("@/db", () => ({
+  getDb: () => ({
+    execute: (...args: unknown[]) => dbExecuteMock(...args),
+  }),
+  schema: {
+    waitlist: {},
+    leagueFamilyMembers: {},
+  },
+}));
+
+jest.mock("@/lib/email", () => ({
+  sendConfirmation: (...args: unknown[]) => sendConfirmationMock(...args),
+}));
+
+import { POST } from "../route";
+
+function makeRequest(
+  body: unknown,
+  ip = `1.1.1.${Math.floor(Math.random() * 250) + 1}`
+) {
+  return new Request("http://localhost/api/waitlist", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-forwarded-for": ip,
+    },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  }) as unknown as Parameters<typeof POST>[0];
+}
+
+function mockDbExecute({
+  inserted,
+  current,
+}: {
+  inserted: boolean;
+  current: number;
+}) {
+  // First call is upsert (returns inserted flag), second is count.
+  dbExecuteMock
+    .mockResolvedValueOnce({ rows: [{ inserted }] } as ExecuteResult)
+    .mockResolvedValueOnce({ rows: [{ current }] } as ExecuteResult);
+}
+
+beforeEach(() => {
+  dbExecuteMock.mockReset();
+  sendConfirmationMock.mockReset();
+});
+
+describe("POST /api/waitlist", () => {
+  const validBody = {
+    email: "user@example.com",
+    league_id: "123456789012345678",
+    league_name: "Big & Bold Dynasty",
+  };
+
+  it("inserts a new row, calls Resend once with the right payload, returns created", async () => {
+    mockDbExecute({ inserted: true, current: 17 });
+    sendConfirmationMock.mockResolvedValueOnce({ id: "msg_123" });
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, status: "created" });
+    expect(sendConfirmationMock).toHaveBeenCalledTimes(1);
+    expect(sendConfirmationMock).toHaveBeenCalledWith({
+      to: "user@example.com",
+      leagueName: "Big & Bold Dynasty",
+      currentCapacity: 17,
+    });
+  });
+
+  it("returns updated when ON CONFLICT path was taken", async () => {
+    mockDbExecute({ inserted: false, current: 17 });
+    sendConfirmationMock.mockResolvedValueOnce({});
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+    const json = await res.json();
+    expect(json).toEqual({ ok: true, status: "updated" });
+    expect(sendConfirmationMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("Resend failure is swallowed; row still committed; response still 200 created", async () => {
+    mockDbExecute({ inserted: true, current: 5 });
+    sendConfirmationMock.mockRejectedValueOnce(new Error("boom"));
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const res = await POST(makeRequest(validBody));
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json).toEqual({ ok: true, status: "created" });
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("honeypot-filled body returns 200 silently with no DB write and no Resend call", async () => {
+    const res = await POST(
+      makeRequest({ ...validBody, hp: "i am a bot" })
+    );
+    expect(res.status).toBe(200);
+    expect(dbExecuteMock).not.toHaveBeenCalled();
+    expect(sendConfirmationMock).not.toHaveBeenCalled();
+  });
+
+  it("invalid email returns 400 without DB write or Resend call", async () => {
+    const res = await POST(makeRequest({ ...validBody, email: "not-an-email" }));
+    expect(res.status).toBe(400);
+    expect(dbExecuteMock).not.toHaveBeenCalled();
+    expect(sendConfirmationMock).not.toHaveBeenCalled();
+  });
+
+  it("league_id of wrong shape returns 400", async () => {
+    const res = await POST(
+      makeRequest({ ...validBody, league_id: "12345" })
+    );
+    expect(res.status).toBe(400);
+    expect(dbExecuteMock).not.toHaveBeenCalled();
+    expect(sendConfirmationMock).not.toHaveBeenCalled();
+  });
+
+  it("missing league_name returns 400", async () => {
+    const res = await POST(
+      makeRequest({ ...validBody, league_name: "" })
+    );
+    expect(res.status).toBe(400);
+    expect(dbExecuteMock).not.toHaveBeenCalled();
+  });
+
+  it("rate limits the same IP after 5 successful posts in a window", async () => {
+    const ip = "9.9.9.9";
+    for (let i = 0; i < 5; i++) {
+      mockDbExecute({ inserted: true, current: i });
+      sendConfirmationMock.mockResolvedValueOnce({});
+      const res = await POST(makeRequest(validBody, ip));
+      expect(res.status).toBe(200);
+    }
+    const sixth = await POST(makeRequest(validBody, ip));
+    expect(sixth.status).toBe(429);
+    expect(sixth.headers.get("Retry-After")).toBeTruthy();
+  });
+
+  it("XSS-shaped league_name is stored and passed to email; escaping is the email module's job", async () => {
+    mockDbExecute({ inserted: true, current: 1 });
+    sendConfirmationMock.mockResolvedValueOnce({});
+    const res = await POST(
+      makeRequest({
+        ...validBody,
+        league_name: "<script>alert(1)</script>",
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(sendConfirmationMock).toHaveBeenCalledWith({
+      to: "user@example.com",
+      leagueName: "<script>alert(1)</script>",
+      currentCapacity: 1,
+    });
+  });
+});

--- a/src/app/api/waitlist/count/route.ts
+++ b/src/app/api/waitlist/count/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { sql } from "drizzle-orm";
+import { getDb, schema } from "@/db";
+
+export const revalidate = 60;
+
+export async function GET() {
+  try {
+    const db = getDb();
+    const result = await db.execute(sql`
+      SELECT (
+        (SELECT COUNT(DISTINCT league_id) FROM ${schema.leagueFamilyMembers})
+        +
+        (SELECT COUNT(DISTINCT league_id) FROM ${schema.waitlist}
+         WHERE status = 'pending'
+           AND league_id NOT IN (SELECT league_id FROM ${schema.leagueFamilyMembers}))
+      )::int AS current
+    `);
+    const current =
+      (result.rows?.[0] as { current?: number } | undefined)?.current ?? 0;
+    return NextResponse.json(
+      { current },
+      {
+        headers: {
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=120",
+        },
+      }
+    );
+  } catch (err) {
+    console.error("[waitlist/count] DB error", err);
+    return NextResponse.json({ current: 0 });
+  }
+}

--- a/src/app/api/waitlist/count/route.ts
+++ b/src/app/api/waitlist/count/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
 import { getDb, schema } from "@/db";
+import { WAITLIST_DISPLAY_BOOST } from "@/lib/waitlistDisplay";
 
 export const revalidate = 60;
 
@@ -16,8 +17,9 @@ export async function GET() {
            AND league_id NOT IN (SELECT league_id FROM ${schema.leagueFamilyMembers}))
       )::int AS current
     `);
-    const current =
+    const raw =
       (result.rows?.[0] as { current?: number } | undefined)?.current ?? 0;
+    const current = raw + WAITLIST_DISPLAY_BOOST;
     return NextResponse.json(
       { current },
       {

--- a/src/app/api/waitlist/count/route.ts
+++ b/src/app/api/waitlist/count/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
     const db = getDb();
     const result = await db.execute(sql`
       SELECT (
-        (SELECT COUNT(DISTINCT league_id) FROM ${schema.leagueFamilyMembers})
+        (SELECT COUNT(*) FROM ${schema.leagueFamilies})
         +
         (SELECT COUNT(DISTINCT league_id) FROM ${schema.waitlist}
          WHERE status = 'pending'

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -1,0 +1,137 @@
+import { NextRequest, NextResponse } from "next/server";
+import { sql } from "drizzle-orm";
+import { getDb, schema } from "@/db";
+import { sendConfirmation } from "@/lib/email";
+
+const RATE_LIMIT_MAX = 5;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+const SWEEP_THRESHOLD = 1024;
+
+const ipBuckets = new Map<string, { count: number; resetAt: number }>();
+
+function sweepExpired(map: Map<string, { resetAt: number }>, now: number) {
+  if (map.size < SWEEP_THRESHOLD) return;
+  for (const [k, v] of map) {
+    if (v.resetAt < now) map.delete(k);
+  }
+}
+
+function getClientIp(req: NextRequest): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return req.headers.get("x-real-ip") || "unknown";
+}
+
+function rateLimitCheck(ip: string): { allowed: boolean; retryAfterSec: number } {
+  const now = Date.now();
+  sweepExpired(ipBuckets, now);
+  const bucket = ipBuckets.get(ip);
+  if (!bucket || bucket.resetAt < now) {
+    ipBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
+    return { allowed: true, retryAfterSec: 0 };
+  }
+  if (bucket.count >= RATE_LIMIT_MAX) {
+    return {
+      allowed: false,
+      retryAfterSec: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+    };
+  }
+  bucket.count += 1;
+  return { allowed: true, retryAfterSec: 0 };
+}
+
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const LEAGUE_ID_REGEX = /^\d{18,20}$/;
+
+export async function POST(req: NextRequest) {
+  const ip = getClientIp(req);
+  const rl = rateLimitCheck(ip);
+  if (!rl.allowed) {
+    return NextResponse.json(
+      { error: "Too many requests. Try again in a minute." },
+      {
+        status: 429,
+        headers: { "Retry-After": String(rl.retryAfterSec) },
+      }
+    );
+  }
+
+  let body: {
+    email?: unknown;
+    league_id?: unknown;
+    league_name?: unknown;
+    hp?: unknown;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid request body" }, { status: 400 });
+  }
+
+  // Honeypot — silently accept and skip persistence + send.
+  if (typeof body.hp === "string" && body.hp.length > 0) {
+    return NextResponse.json({ ok: true, status: "created" });
+  }
+
+  const email =
+    typeof body.email === "string" ? body.email.trim().toLowerCase() : "";
+  if (!email || email.length > 254 || !EMAIL_REGEX.test(email)) {
+    return NextResponse.json({ error: "Invalid email" }, { status: 400 });
+  }
+
+  const leagueId = typeof body.league_id === "string" ? body.league_id : "";
+  if (!LEAGUE_ID_REGEX.test(leagueId)) {
+    return NextResponse.json({ error: "Invalid league_id" }, { status: 400 });
+  }
+
+  const leagueName =
+    typeof body.league_name === "string" ? body.league_name.trim() : "";
+  if (!leagueName || leagueName.length > 100) {
+    return NextResponse.json({ error: "Invalid league_name" }, { status: 400 });
+  }
+
+  let status: "created" | "updated";
+  let currentCapacity = 0;
+  try {
+    const db = getDb();
+    // xmax = 0 on a row means it was just inserted (no prior tuple version).
+    // Non-zero xmax means the ON CONFLICT update path was taken.
+    const upsertResult = await db.execute(sql`
+      INSERT INTO ${schema.waitlist} (email, league_id)
+      VALUES (${email}, ${leagueId})
+      ON CONFLICT (email, league_id) DO UPDATE SET created_at = now()
+      RETURNING (xmax = 0) AS inserted
+    `);
+    const inserted = (upsertResult.rows?.[0] as { inserted?: boolean } | undefined)
+      ?.inserted;
+    status = inserted ? "created" : "updated";
+
+    const countRow = await db.execute(sql`
+      SELECT (
+        (SELECT COUNT(DISTINCT league_id) FROM ${schema.leagueFamilyMembers})
+        +
+        (SELECT COUNT(DISTINCT league_id) FROM ${schema.waitlist}
+         WHERE status = 'pending'
+           AND league_id NOT IN (SELECT league_id FROM ${schema.leagueFamilyMembers}))
+      )::int AS current
+    `);
+    const currentValue = (countRow.rows?.[0] as { current?: number } | undefined)
+      ?.current;
+    currentCapacity = typeof currentValue === "number" ? currentValue : 0;
+  } catch (err) {
+    console.error("[waitlist] DB error", err);
+    return NextResponse.json(
+      { error: "Something went wrong on our end. Try refreshing." },
+      { status: 500 }
+    );
+  }
+
+  try {
+    await sendConfirmation({ to: email, leagueName, currentCapacity });
+  } catch (err) {
+    console.error("[waitlist] Resend send failed", err);
+    // Swallow — row is stored; CLI notify is the eventual source of truth.
+  }
+
+  return NextResponse.json({ ok: true, status });
+}

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -2,50 +2,16 @@ import { NextRequest, NextResponse } from "next/server";
 import { sql } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { sendConfirmation } from "@/lib/email";
+import { createIpRateLimiter, getClientIp } from "@/lib/ipRateLimit";
 
-const RATE_LIMIT_MAX = 5;
-const RATE_LIMIT_WINDOW_MS = 60_000;
-const SWEEP_THRESHOLD = 1024;
-
-const ipBuckets = new Map<string, { count: number; resetAt: number }>();
-
-function sweepExpired(map: Map<string, { resetAt: number }>, now: number) {
-  if (map.size < SWEEP_THRESHOLD) return;
-  for (const [k, v] of map) {
-    if (v.resetAt < now) map.delete(k);
-  }
-}
-
-function getClientIp(req: NextRequest): string {
-  const forwarded = req.headers.get("x-forwarded-for");
-  if (forwarded) return forwarded.split(",")[0].trim();
-  return req.headers.get("x-real-ip") || "unknown";
-}
-
-function rateLimitCheck(ip: string): { allowed: boolean; retryAfterSec: number } {
-  const now = Date.now();
-  sweepExpired(ipBuckets, now);
-  const bucket = ipBuckets.get(ip);
-  if (!bucket || bucket.resetAt < now) {
-    ipBuckets.set(ip, { count: 1, resetAt: now + RATE_LIMIT_WINDOW_MS });
-    return { allowed: true, retryAfterSec: 0 };
-  }
-  if (bucket.count >= RATE_LIMIT_MAX) {
-    return {
-      allowed: false,
-      retryAfterSec: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
-    };
-  }
-  bucket.count += 1;
-  return { allowed: true, retryAfterSec: 0 };
-}
+const rateLimit = createIpRateLimiter({ max: 5, windowMs: 60_000 });
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
 const LEAGUE_ID_REGEX = /^\d{18,20}$/;
 
 export async function POST(req: NextRequest) {
   const ip = getClientIp(req);
-  const rl = rateLimitCheck(ip);
+  const rl = rateLimit(ip);
   if (!rl.allowed) {
     return NextResponse.json(
       { error: "Too many requests. Try again in a minute." },

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -74,7 +74,7 @@ export async function POST(req: NextRequest) {
 
     const countRow = await db.execute(sql`
       SELECT (
-        (SELECT COUNT(DISTINCT league_id) FROM ${schema.leagueFamilyMembers})
+        (SELECT COUNT(*) FROM ${schema.leagueFamilies})
         +
         (SELECT COUNT(DISTINCT league_id) FROM ${schema.waitlist}
          WHERE status = 'pending'

--- a/src/app/api/waitlist/route.ts
+++ b/src/app/api/waitlist/route.ts
@@ -3,6 +3,7 @@ import { sql } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { sendConfirmation } from "@/lib/email";
 import { createIpRateLimiter, getClientIp } from "@/lib/ipRateLimit";
+import { WAITLIST_DISPLAY_BOOST } from "@/lib/waitlistDisplay";
 
 const rateLimit = createIpRateLimiter({ max: 5, windowMs: 60_000 });
 
@@ -83,7 +84,9 @@ export async function POST(req: NextRequest) {
     `);
     const currentValue = (countRow.rows?.[0] as { current?: number } | undefined)
       ?.current;
-    currentCapacity = typeof currentValue === "number" ? currentValue : 0;
+    currentCapacity =
+      (typeof currentValue === "number" ? currentValue : 0) +
+      WAITLIST_DISPLAY_BOOST;
   } catch (err) {
     console.error("[waitlist] DB error", err);
     return NextResponse.json(

--- a/src/components/WaitlistProgress.tsx
+++ b/src/components/WaitlistProgress.tsx
@@ -6,8 +6,6 @@ interface WaitlistProgressProps {
 }
 
 export function WaitlistProgress({ current, target }: WaitlistProgressProps) {
-  if (current < 10) return null;
-
   const goalReached = current >= target;
   const copy = goalReached
     ? "Goal reached — bringing leagues online."

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -538,6 +538,30 @@ export const syncJobs = pgTable(
 );
 
 // ============================================================
+// Waitlist
+// ============================================================
+
+export const waitlist = pgTable(
+  "waitlist",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    email: text("email").notNull(),
+    leagueId: text("league_id").notNull(), // Sleeper league_id, not family_id
+    status: text("status").notNull().default("pending"), // pending | notified
+    createdAt: timestamp("created_at", { mode: "date" }).defaultNow().notNull(),
+    notifiedAt: timestamp("notified_at", { mode: "date" }),
+  },
+  (w) => ({
+    emailLeagueUnique: uniqueIndex("waitlist_email_league_unique").on(
+      w.email,
+      w.leagueId
+    ),
+    leagueIdIdx: index("waitlist_league_id_idx").on(w.leagueId),
+    statusIdx: index("waitlist_status_idx").on(w.status),
+  })
+);
+
+// ============================================================
 // Experiments
 // ============================================================
 

--- a/src/lib/__tests__/email.test.ts
+++ b/src/lib/__tests__/email.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { renderConfirmation, renderNotify, __test__ } from "../email";
+
+describe("renderConfirmation", () => {
+  it("subject matches the spec", () => {
+    const r = renderConfirmation({
+      leagueName: "Big & Bold Dynasty",
+      currentCapacity: 42,
+    });
+    expect(r.subject).toBe("Waitlist confirmed: Big & Bold Dynasty");
+  });
+
+  it("plain text body contains the league name, position, and milestone", () => {
+    const r = renderConfirmation({ leagueName: "My League", currentCapacity: 7 });
+    expect(r.text).toContain("My League");
+    expect(r.text).toContain("Your league is 7 on the waitlist");
+    expect(r.text).toContain("once it reaches 100");
+    expect(r.text).toContain("— Dynasty DNA");
+  });
+
+  it("HTML body escapes dangerous characters in the league name", () => {
+    const r = renderConfirmation({
+      leagueName: "<script>alert(1)</script>",
+      currentCapacity: 1,
+    });
+    expect(r.html).not.toContain("<script>alert(1)</script>");
+    expect(r.html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+  });
+
+  it("HTML body escapes ampersand and quotes", () => {
+    const r = renderConfirmation({
+      leagueName: 'Big & "Bold"',
+      currentCapacity: 1,
+    });
+    expect(r.html).toContain("Big &amp; &quot;Bold&quot;");
+  });
+
+  it("HTML and text bodies stay structurally in sync", () => {
+    const r = renderConfirmation({ leagueName: "X", currentCapacity: 1 });
+    // Both bodies must include the same key sentences (waitlist position
+    // sentence and sign-off).
+    expect(r.text).toContain("Your league is 1 on the waitlist");
+    expect(r.html).toContain("Your league is");
+    expect(r.html).toContain("on the waitlist");
+    expect(r.text).toContain("— Dynasty DNA");
+    expect(r.html).toContain("— Dynasty DNA");
+  });
+});
+
+describe("renderNotify", () => {
+  it("subject matches the spec", () => {
+    const r = renderNotify({
+      leagueName: "My Dynasty",
+      familyId: "abc-123",
+    });
+    expect(r.subject).toBe("Your league is live: My Dynasty");
+  });
+
+  it("text body contains the absolute URL", () => {
+    const r = renderNotify({ leagueName: "X", familyId: "fam-7" });
+    expect(r.text).toContain("/league/fam-7");
+    expect(r.text).toMatch(/https?:\/\//);
+  });
+
+  it("HTML body escapes the league name", () => {
+    const r = renderNotify({
+      leagueName: "<img src=x onerror=alert(1)>",
+      familyId: "fam-1",
+    });
+    expect(r.html).not.toContain("<img src=x onerror=alert(1)>");
+    expect(r.html).toContain("&lt;img");
+  });
+
+  it("HTML body links to the league family URL", () => {
+    const r = renderNotify({ leagueName: "X", familyId: "fam-9" });
+    expect(r.html).toContain("/league/fam-9");
+  });
+});
+
+describe("escapeHtml", () => {
+  it("escapes &, <, >, \", '", () => {
+    expect(__test__.escapeHtml("a & b")).toBe("a &amp; b");
+    expect(__test__.escapeHtml("<x>")).toBe("&lt;x&gt;");
+    expect(__test__.escapeHtml('"q"')).toBe("&quot;q&quot;");
+    expect(__test__.escapeHtml("'q'")).toBe("&#39;q&#39;");
+  });
+});

--- a/src/lib/__tests__/notifyWaitlist.test.ts
+++ b/src/lib/__tests__/notifyWaitlist.test.ts
@@ -57,11 +57,7 @@ describe("notifyWaitlist", () => {
       familyId: "fam-1",
     });
     expect(marked).toEqual(["r1", "r2"]);
-    expect(summary).toEqual({
-      notified: 2,
-      skipped: 0,
-      unsent: [],
-    });
+    expect(summary).toEqual({ notified: 2, unsent: [] });
   });
 
   it("skips already-notified rows because getPending only returns pending", async () => {
@@ -187,7 +183,7 @@ describe("notifyWaitlist", () => {
       sleep: async () => {},
     });
     expect(sendCalls).toBe(0);
-    expect(summary).toEqual({ notified: 0, skipped: 0, unsent: [] });
+    expect(summary).toEqual({ notified: 0, unsent: [] });
   });
 
   it("partial failure: rows sent before a failure stay marked", async () => {

--- a/src/lib/__tests__/notifyWaitlist.test.ts
+++ b/src/lib/__tests__/notifyWaitlist.test.ts
@@ -1,0 +1,221 @@
+/**
+ * @jest-environment node
+ */
+import { notifyWaitlist, type NotifyDb } from "../notifyWaitlist";
+
+interface TestRow {
+  id: string;
+  email: string;
+  leagueId: string;
+}
+
+function makeDb(opts: {
+  members: string[];
+  pending: TestRow[];
+  leagueNames?: Record<string, string>;
+  markNotified?: (id: string) => Promise<void>;
+}): NotifyDb {
+  return {
+    getMembers: async () => opts.members,
+    getPending: async () => opts.pending,
+    getLeagueName: async (lid) => opts.leagueNames?.[lid] ?? null,
+    markNotified: opts.markNotified ?? (async () => {}),
+  };
+}
+
+describe("notifyWaitlist", () => {
+  it("resolves family_id to member league_ids and notifies all matching pending rows", async () => {
+    const sent: Array<{ to: string; leagueName: string; familyId: string }> = [];
+    const marked: string[] = [];
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({
+        members: ["L1", "L2"],
+        pending: [
+          { id: "r1", email: "a@x.com", leagueId: "L1" },
+          { id: "r2", email: "b@x.com", leagueId: "L2" },
+        ],
+        leagueNames: { L1: "Alpha", L2: "Beta" },
+        markNotified: async (id) => {
+          marked.push(id);
+        },
+      }),
+      send: async (p) => {
+        sent.push(p);
+      },
+      sleep: async () => {},
+    });
+    expect(sent).toHaveLength(2);
+    expect(sent[0]).toEqual({
+      to: "a@x.com",
+      leagueName: "Alpha",
+      familyId: "fam-1",
+    });
+    expect(sent[1]).toEqual({
+      to: "b@x.com",
+      leagueName: "Beta",
+      familyId: "fam-1",
+    });
+    expect(marked).toEqual(["r1", "r2"]);
+    expect(summary).toEqual({
+      notified: 2,
+      skipped: 0,
+      unsent: [],
+    });
+  });
+
+  it("skips already-notified rows because getPending only returns pending", async () => {
+    const sent: Array<{ to: string }> = [];
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({
+        members: ["L1"],
+        pending: [], // notified rows excluded by query
+      }),
+      send: async (p) => {
+        sent.push({ to: p.to });
+      },
+      sleep: async () => {},
+    });
+    expect(sent).toHaveLength(0);
+    expect(summary.notified).toBe(0);
+  });
+
+  it("retries with exponential backoff on rate-limit errors", async () => {
+    const sleeps: number[] = [];
+    let attempts = 0;
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({
+        members: ["L1"],
+        pending: [{ id: "r1", email: "a@x.com", leagueId: "L1" }],
+        leagueNames: { L1: "Alpha" },
+      }),
+      send: async () => {
+        attempts++;
+        if (attempts < 3) {
+          throw new Error("Too many requests (429)");
+        }
+        // Succeeds on attempt 3
+      },
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    expect(attempts).toBe(3);
+    expect(sleeps.slice(0, 2)).toEqual([1000, 2000]);
+    expect(summary.notified).toBe(1);
+  });
+
+  it("after exhausting backoff, marks the row as unsent and continues", async () => {
+    let attempts = 0;
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({
+        members: ["L1"],
+        pending: [
+          { id: "r1", email: "a@x.com", leagueId: "L1" },
+          { id: "r2", email: "b@x.com", leagueId: "L1" },
+        ],
+        leagueNames: { L1: "Alpha" },
+      }),
+      send: async (p) => {
+        if (p.to === "a@x.com") {
+          attempts++;
+          throw new Error("429 Too Many Requests");
+        }
+      },
+      sleep: async () => {},
+    });
+    // 1 initial + 4 backoff retries = 5 attempts
+    expect(attempts).toBe(5);
+    expect(summary.notified).toBe(1);
+    expect(summary.unsent).toEqual(["r1"]);
+  });
+
+  it("on daily-cap exhaustion logs unsent IDs and exits cleanly", async () => {
+    let calls = 0;
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({
+        members: ["L1"],
+        pending: [
+          { id: "r1", email: "a@x.com", leagueId: "L1" },
+          { id: "r2", email: "b@x.com", leagueId: "L1" },
+          { id: "r3", email: "c@x.com", leagueId: "L1" },
+        ],
+        leagueNames: { L1: "Alpha" },
+      }),
+      send: async () => {
+        calls++;
+        throw new Error("Daily cap exceeded — quota reached");
+      },
+      sleep: async () => {},
+    });
+    expect(calls).toBe(1);
+    expect(summary.notified).toBe(0);
+    expect(summary.unsent).toEqual(["r1", "r2", "r3"]);
+  });
+
+  it("re-running with same family_id only processes still-pending rows", async () => {
+    const sent: string[] = [];
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({
+        members: ["L1", "L2"],
+        // Only r2 is pending; r1 was already notified so excluded by query.
+        pending: [{ id: "r2", email: "b@x.com", leagueId: "L2" }],
+        leagueNames: { L1: "Alpha", L2: "Beta" },
+      }),
+      send: async (p) => {
+        sent.push(p.to);
+      },
+      sleep: async () => {},
+    });
+    expect(sent).toEqual(["b@x.com"]);
+    expect(summary.notified).toBe(1);
+  });
+
+  it("returns early when family has no member leagues", async () => {
+    let sendCalls = 0;
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({ members: [], pending: [] }),
+      send: async () => {
+        sendCalls++;
+      },
+      sleep: async () => {},
+    });
+    expect(sendCalls).toBe(0);
+    expect(summary).toEqual({ notified: 0, skipped: 0, unsent: [] });
+  });
+
+  it("partial failure: rows sent before a failure stay marked", async () => {
+    const marked: string[] = [];
+    const summary = await notifyWaitlist({
+      familyId: "fam-1",
+      db: makeDb({
+        members: ["L1"],
+        pending: [
+          { id: "r1", email: "a@x.com", leagueId: "L1" },
+          { id: "r2", email: "b@x.com", leagueId: "L1" },
+          { id: "r3", email: "c@x.com", leagueId: "L1" },
+        ],
+        leagueNames: { L1: "Alpha" },
+        markNotified: async (id) => {
+          marked.push(id);
+        },
+      }),
+      send: async (p) => {
+        if (p.to === "b@x.com") {
+          throw new Error("Daily quota cap hit");
+        }
+      },
+      sleep: async () => {},
+    });
+    // r1 sent + marked. r2 hits daily cap → exit cleanly, r2/r3 unsent.
+    expect(marked).toEqual(["r1"]);
+    expect(summary.notified).toBe(1);
+    expect(summary.unsent).toEqual(["r2", "r3"]);
+  });
+});

--- a/src/lib/email.ts
+++ b/src/lib/email.ts
@@ -1,0 +1,120 @@
+import { Resend } from "resend";
+
+const FROM_ADDRESS = "Dynasty DNA <onboarding@resend.dev>";
+
+function getSiteUrl(): string {
+  if (process.env.NEXT_PUBLIC_SITE_URL) {
+    return process.env.NEXT_PUBLIC_SITE_URL.replace(/\/+$/, "");
+  }
+  if (process.env.VERCEL_URL) {
+    return `https://${process.env.VERCEL_URL.replace(/\/+$/, "")}`;
+  }
+  return "https://dynasty-dna.app";
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+interface ConfirmationParams {
+  to: string;
+  leagueName: string;
+  currentCapacity: number;
+}
+
+interface NotifyParams {
+  to: string;
+  leagueName: string;
+  familyId: string;
+}
+
+interface RenderedEmail {
+  subject: string;
+  text: string;
+  html: string;
+}
+
+const WAITLIST_MILESTONE = 100;
+
+export function renderConfirmation({
+  leagueName,
+  currentCapacity,
+}: Omit<ConfirmationParams, "to">): RenderedEmail {
+  const safeLeague = escapeHtml(leagueName);
+  const safePosition = escapeHtml(String(currentCapacity));
+  const safeMilestone = escapeHtml(String(WAITLIST_MILESTONE));
+  const subject = `Waitlist confirmed: ${leagueName}`;
+  const text = `We've added ${leagueName} to the waitlist for Dynasty DNA. We'll email you the moment your league data is loaded and all features are available.
+
+We are scaling up capacity to meet demand. Your league is ${currentCapacity} on the waitlist — once it reaches ${WAITLIST_MILESTONE}, we'll invest in supporting this cohort, thanks!
+
+— Dynasty DNA`;
+  const html = `<!doctype html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1a1a1a; line-height: 1.5;">
+<p>We've added <strong>${safeLeague}</strong> to the waitlist for Dynasty DNA. We'll email you the moment your league data is loaded and all features are available.</p>
+<p>We are scaling up capacity to meet demand. Your league is <strong>${safePosition}</strong> on the waitlist — once it reaches <strong>${safeMilestone}</strong>, we'll invest in supporting this cohort, thanks!</p>
+<p>— Dynasty DNA</p>
+</body></html>`;
+  return { subject, text, html };
+}
+
+export function renderNotify({
+  leagueName,
+  familyId,
+}: Omit<NotifyParams, "to">): RenderedEmail {
+  const safeLeague = escapeHtml(leagueName);
+  const url = `${getSiteUrl()}/league/${encodeURIComponent(familyId)}`;
+  const safeUrl = escapeHtml(url);
+  const subject = `Your league is live: ${leagueName}`;
+  const text = `Good news — ${leagueName} is now ingested in Dynasty DNA.
+
+Open it here: ${url}
+
+— Dynasty DNA`;
+  const html = `<!doctype html>
+<html><body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; color: #1a1a1a; line-height: 1.5;">
+<p>Good news — <strong>${safeLeague}</strong> is now ingested in Dynasty DNA.</p>
+<p>Open it here: <a href="${safeUrl}">${safeUrl}</a></p>
+<p>— Dynasty DNA</p>
+</body></html>`;
+  return { subject, text, html };
+}
+
+function getClient(): Resend {
+  const key = process.env.RESEND_API_KEY;
+  if (!key) {
+    throw new Error("RESEND_API_KEY is not set");
+  }
+  return new Resend(key);
+}
+
+export async function sendConfirmation(params: ConfirmationParams) {
+  const rendered = renderConfirmation(params);
+  const client = getClient();
+  return client.emails.send({
+    from: FROM_ADDRESS,
+    to: params.to,
+    subject: rendered.subject,
+    text: rendered.text,
+    html: rendered.html,
+  });
+}
+
+export async function sendNotify(params: NotifyParams) {
+  const rendered = renderNotify(params);
+  const client = getClient();
+  return client.emails.send({
+    from: FROM_ADDRESS,
+    to: params.to,
+    subject: rendered.subject,
+    text: rendered.text,
+    html: rendered.html,
+  });
+}
+
+export const __test__ = { escapeHtml, FROM_ADDRESS, getSiteUrl };

--- a/src/lib/ipRateLimit.ts
+++ b/src/lib/ipRateLimit.ts
@@ -1,0 +1,42 @@
+import type { NextRequest } from "next/server";
+
+const SWEEP_THRESHOLD = 1024;
+
+export function getClientIp(req: NextRequest): string {
+  const forwarded = req.headers.get("x-forwarded-for");
+  if (forwarded) return forwarded.split(",")[0].trim();
+  return req.headers.get("x-real-ip") || "unknown";
+}
+
+export interface RateLimitOptions {
+  max: number;
+  windowMs: number;
+}
+
+export interface RateLimitResult {
+  allowed: boolean;
+  retryAfterSec: number;
+}
+
+export function createIpRateLimiter({ max, windowMs }: RateLimitOptions) {
+  const buckets = new Map<string, { count: number; resetAt: number }>();
+  return function check(ip: string): RateLimitResult {
+    const now = Date.now();
+    if (buckets.size >= SWEEP_THRESHOLD) {
+      for (const [k, v] of buckets) if (v.resetAt < now) buckets.delete(k);
+    }
+    const bucket = buckets.get(ip);
+    if (!bucket || bucket.resetAt < now) {
+      buckets.set(ip, { count: 1, resetAt: now + windowMs });
+      return { allowed: true, retryAfterSec: 0 };
+    }
+    if (bucket.count >= max) {
+      return {
+        allowed: false,
+        retryAfterSec: Math.max(1, Math.ceil((bucket.resetAt - now) / 1000)),
+      };
+    }
+    bucket.count += 1;
+    return { allowed: true, retryAfterSec: 0 };
+  };
+}

--- a/src/lib/notifyWaitlist.ts
+++ b/src/lib/notifyWaitlist.ts
@@ -1,0 +1,170 @@
+import { sendNotify } from "@/lib/email";
+
+interface PendingRow {
+  id: string;
+  email: string;
+  leagueId: string;
+}
+
+export interface NotifyDb {
+  getMembers: (familyId: string) => Promise<string[]>;
+  getPending: (leagueIds: string[]) => Promise<PendingRow[]>;
+  getLeagueName: (leagueId: string) => Promise<string | null>;
+  markNotified: (id: string) => Promise<void>;
+}
+
+export interface NotifyOptions {
+  familyId: string;
+  db: NotifyDb;
+  // Injected for testability — defaults to real Resend send and a real
+  // setTimeout-based sleep.
+  send?: (params: {
+    to: string;
+    leagueName: string;
+    familyId: string;
+  }) => Promise<unknown>;
+  sleep?: (ms: number) => Promise<void>;
+  perRowDelayMs?: number;
+}
+
+export interface NotifySummary {
+  notified: number;
+  skipped: number;
+  unsent: string[];
+}
+
+const BACKOFF_MS = [1000, 2000, 4000, 8000];
+
+function isRateLimitError(err: unknown): boolean {
+  const msg = errorMessage(err).toLowerCase();
+  return (
+    msg.includes("rate") ||
+    msg.includes("429") ||
+    msg.includes("too many")
+  );
+}
+
+function isDailyCapError(err: unknown): boolean {
+  const msg = errorMessage(err).toLowerCase();
+  return (
+    msg.includes("daily") &&
+    (msg.includes("cap") || msg.includes("limit") || msg.includes("quota"))
+  );
+}
+
+function errorMessage(err: unknown): string {
+  if (err && typeof err === "object" && "message" in err) {
+    const m = (err as { message?: unknown }).message;
+    if (typeof m === "string") return m;
+  }
+  return String(err);
+}
+
+export async function notifyWaitlist({
+  familyId,
+  db,
+  send,
+  sleep,
+  perRowDelayMs = 100,
+}: NotifyOptions): Promise<NotifySummary> {
+  const doSend =
+    send ??
+    (async (p) => {
+      return sendNotify({
+        to: p.to,
+        leagueName: p.leagueName,
+        familyId: p.familyId,
+      });
+    });
+  const doSleep =
+    sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  const memberLeagueIds = await db.getMembers(familyId);
+  if (memberLeagueIds.length === 0) {
+    return { notified: 0, skipped: 0, unsent: [] };
+  }
+  const pending = await db.getPending(memberLeagueIds);
+  if (pending.length === 0) {
+    return { notified: 0, skipped: 0, unsent: [] };
+  }
+
+  // Cache league name resolution per leagueId — multiple rows often share one
+  // leagueId.
+  const nameCache = new Map<string, string>();
+  async function resolveName(leagueId: string): Promise<string> {
+    if (nameCache.has(leagueId)) return nameCache.get(leagueId) as string;
+    const name = (await db.getLeagueName(leagueId)) ?? leagueId;
+    nameCache.set(leagueId, name);
+    return name;
+  }
+
+  let notified = 0;
+  const skipped = 0;
+  const unsent: string[] = [];
+
+  for (let i = 0; i < pending.length; i++) {
+    const row = pending[i];
+    const leagueName = await resolveName(row.leagueId);
+
+    let sent = false;
+    let dailyCapHit = false;
+    for (let attempt = 0; attempt <= BACKOFF_MS.length; attempt++) {
+      try {
+        await doSend({
+          to: row.email,
+          leagueName,
+          familyId,
+        });
+        sent = true;
+        break;
+      } catch (err) {
+        if (isDailyCapError(err)) {
+          dailyCapHit = true;
+          break;
+        }
+        if (isRateLimitError(err) && attempt < BACKOFF_MS.length) {
+          await doSleep(BACKOFF_MS[attempt]);
+          continue;
+        }
+        // Non-retryable error: log and move on.
+        console.error(
+          `[notify-waitlist] send failed for row ${row.id}:`,
+          errorMessage(err)
+        );
+        break;
+      }
+    }
+
+    if (sent) {
+      try {
+        await db.markNotified(row.id);
+        notified++;
+      } catch (err) {
+        console.error(
+          `[notify-waitlist] mark-notified failed for row ${row.id}:`,
+          errorMessage(err)
+        );
+        unsent.push(row.id);
+      }
+    } else {
+      unsent.push(row.id);
+    }
+
+    if (dailyCapHit) {
+      // Log all remaining IDs as unsent and exit cleanly.
+      for (let j = i + 1; j < pending.length; j++) {
+        unsent.push(pending[j].id);
+      }
+      console.warn(
+        "[notify-waitlist] daily cap hit — exiting cleanly. Re-run tomorrow."
+      );
+      break;
+    }
+
+    if (i < pending.length - 1) {
+      await doSleep(perRowDelayMs);
+    }
+  }
+
+  return { notified, skipped, unsent };
+}

--- a/src/lib/notifyWaitlist.ts
+++ b/src/lib/notifyWaitlist.ts
@@ -29,7 +29,6 @@ export interface NotifyOptions {
 
 export interface NotifySummary {
   notified: number;
-  skipped: number;
   unsent: string[];
 }
 
@@ -81,11 +80,11 @@ export async function notifyWaitlist({
 
   const memberLeagueIds = await db.getMembers(familyId);
   if (memberLeagueIds.length === 0) {
-    return { notified: 0, skipped: 0, unsent: [] };
+    return { notified: 0, unsent: [] };
   }
   const pending = await db.getPending(memberLeagueIds);
   if (pending.length === 0) {
-    return { notified: 0, skipped: 0, unsent: [] };
+    return { notified: 0, unsent: [] };
   }
 
   // Cache league name resolution per leagueId — multiple rows often share one
@@ -99,7 +98,6 @@ export async function notifyWaitlist({
   }
 
   let notified = 0;
-  const skipped = 0;
   const unsent: string[] = [];
 
   for (let i = 0; i < pending.length; i++) {
@@ -126,7 +124,6 @@ export async function notifyWaitlist({
           await doSleep(BACKOFF_MS[attempt]);
           continue;
         }
-        // Non-retryable error: log and move on.
         console.error(
           `[notify-waitlist] send failed for row ${row.id}:`,
           errorMessage(err)
@@ -151,7 +148,6 @@ export async function notifyWaitlist({
     }
 
     if (dailyCapHit) {
-      // Log all remaining IDs as unsent and exit cleanly.
       for (let j = i + 1; j < pending.length; j++) {
         unsent.push(pending[j].id);
       }
@@ -166,5 +162,5 @@ export async function notifyWaitlist({
     }
   }
 
-  return { notified, skipped, unsent };
+  return { notified, unsent };
 }

--- a/src/lib/storedUsername.ts
+++ b/src/lib/storedUsername.ts
@@ -2,7 +2,7 @@
 
 export const STORED_USERNAME_KEY = "dd_username";
 
-function safeStorage(): Storage | null {
+export function safeStorage(): Storage | null {
   try {
     return window.localStorage;
   } catch {

--- a/src/lib/useWaitlistCount.ts
+++ b/src/lib/useWaitlistCount.ts
@@ -1,8 +1,11 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
-export function useWaitlistCount(): { current: number } {
+export function useWaitlistCount(): {
+  current: number;
+  bump: () => void;
+} {
   const [current, setCurrent] = useState(0);
 
   useEffect(() => {
@@ -22,5 +25,7 @@ export function useWaitlistCount(): { current: number } {
     };
   }, []);
 
-  return { current };
+  const bump = useCallback(() => setCurrent((n) => n + 1), []);
+
+  return { current, bump };
 }

--- a/src/lib/useWaitlistCount.ts
+++ b/src/lib/useWaitlistCount.ts
@@ -1,6 +1,26 @@
 "use client";
 
-// TODO #83: query waitlist table for actual count
+import { useEffect, useState } from "react";
+
 export function useWaitlistCount(): { current: number } {
-  return { current: 0 };
+  const [current, setCurrent] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/waitlist/count")
+      .then((res) => (res.ok ? res.json() : { current: 0 }))
+      .then((data: { current?: unknown }) => {
+        if (cancelled) return;
+        if (typeof data.current === "number") setCurrent(data.current);
+      })
+      .catch(() => {
+        // Network/parse error: stay at 0; <WaitlistProgress /> hides itself
+        // when current < 10 anyway.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return { current };
 }

--- a/src/lib/waitlistDisplay.ts
+++ b/src/lib/waitlistDisplay.ts
@@ -1,0 +1,5 @@
+// Vanity boost added to the publicly-displayed waitlist count so the early
+// days don't look like an empty room. Applied uniformly across the counter
+// API, the WaitlistProgress bar, and the confirmation email's position
+// number — keeping all three in sync.
+export const WAITLIST_DISPLAY_BOOST = 20;

--- a/src/lib/waitlistedLeagues.ts
+++ b/src/lib/waitlistedLeagues.ts
@@ -1,0 +1,40 @@
+"use client";
+
+const PREFIX = "dd_waitlisted_leagues_";
+
+function safeStorage(): Storage | null {
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function key(username: string): string {
+  return `${PREFIX}${username.toLowerCase()}`;
+}
+
+export function getWaitlistedLeagues(username: string): string[] {
+  const ls = safeStorage();
+  if (!ls || !username) return [];
+  const raw = ls.getItem(key(username));
+  if (!raw) return [];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      return parsed.filter((v): v is string => typeof v === "string");
+    }
+  } catch {
+    // Corrupt entry — ignore, treat as empty.
+  }
+  return [];
+}
+
+export function addWaitlistedLeague(username: string, leagueId: string): void {
+  const ls = safeStorage();
+  if (!ls || !username || !leagueId) return;
+  const current = getWaitlistedLeagues(username);
+  if (current.includes(leagueId)) return;
+  current.push(leagueId);
+  ls.setItem(key(username), JSON.stringify(current));
+}

--- a/src/lib/waitlistedLeagues.ts
+++ b/src/lib/waitlistedLeagues.ts
@@ -1,14 +1,8 @@
 "use client";
 
-const PREFIX = "dd_waitlisted_leagues_";
+import { safeStorage } from "@/lib/storedUsername";
 
-function safeStorage(): Storage | null {
-  try {
-    return window.localStorage;
-  } catch {
-    return null;
-  }
-}
+const PREFIX = "dd_waitlisted_leagues_";
 
 function key(username: string): string {
   return `${PREFIX}${username.toLowerCase()}`;


### PR DESCRIPTION
Closes #83.

## Summary
- New `waitlist` table (`email`, `league_id`, `status`, timestamps) with `(email, league_id)` unique index plus `league_id` and `status` indexes.
- `POST /api/waitlist`: per-IP token bucket (5/min), email + league_id shape validation, honeypot, UPSERT via `xmax = 0` create/update detection, Resend send with failure swallow.
- `GET /api/waitlist/count`: counter formula `families + waitlisted_unique_leagues_not_in_DB`, with a `+20` vanity boost (`src/lib/waitlistDisplay.ts`) so the early days don't render an empty room.
- `src/lib/email.ts`: Resend wrapper, per-request client. HTML escapes the user-provided `league_name`. Confirmation copy: "We are scaling up capacity to meet demand. Your league is {N} on the waitlist — once it reaches 100, we'll invest in supporting this cohort, thanks!"
- `/start` inline expansion: one-row-at-a-time waitlist form, email persists in component state, success collapses to "✓ Added to waitlist" message, refresh shows "✓ On waitlist" via per-username localStorage. **Globally deduped** via `find-leagues` returning `waitlisted: boolean` per league — the second user discovering an already-waitlisted league sees the badge, not the form.
- `WaitlistProgress` moved from landing to `/start`, above the not-yet-supported list. Counter bumps optimistically (+1) on successful submit. Always renders.
- `scripts/notify-waitlist.ts` (`npm run notify-waitlist -- --family-id <UUID>`): family_id → member league_ids → sequenced notify sends with 100ms spacing, exp-backoff (1/2/4/8s) on rate-limit, clean exit on daily-cap exhaustion. Idempotent re-runs.
- Shared utilities: `src/lib/ipRateLimit.ts` (used by both this route and find-leagues), `safeStorage()` promoted from `storedUsername.ts` for reuse by `waitlistedLeagues.ts`.
- `find-leagues` cache restructured to hold only Sleeper-derived data; family + waitlist state are queried fresh per request so writes become visible immediately across all users.

## Test plan
- [x] `npm run build` clean
- [x] `npm run lint` — only pre-existing warnings
- [x] `npm test` — 45 passing (27 new: email rendering with XSS escape, POST /api/waitlist with Drizzle + Resend mocked, notify CLI core)
- [x] Browser smoke on `/start`:
  - [x] Username with not-in-DB league → "Join waitlist" → form expands inline
  - [x] Invalid email → inline error "Enter a valid email address."
  - [x] Valid email → POST returns 200, row collapses to "✓ Added to waitlist…"
  - [x] Refresh → "✓ On waitlist" rendered (localStorage round-trip)
  - [x] Different user discovering same league → "✓ On waitlist" (server-side dedup)
- [x] Curl rate-limit: 6th rapid POST returns 429 with `Retry-After`
- [x] `GET /api/waitlist/count` returns `{ current }` matching the family + waitlist-unique formula (boosted by 20)
- [x] Manual smoke: confirmation email arrives at `john.ryan.grande@gmail.com` with the right league name and copy

## Pre-merge notes
- The Resend test sender (`onboarding@resend.dev`) only delivers to the Resend account email. When a real domain is verified, swap the `FROM_ADDRESS` constant in `src/lib/email.ts` and arbitrary recipients work — one-line change, out of scope here.
- Notify path is currently a manual CLI. Auto-trigger on sync + allow non-creator subscribe are tracked in #95 as the Phase 7 follow-up.
- The +20 vanity boost lives in `src/lib/waitlistDisplay.ts`. Drop or set to 0 once real demand catches up.

## Changelog hint
Phase 7B — Demand capture. Inline waitlist on /start for unsupported leagues, with Resend confirmation, public counter, and a notify CLI for when capacity opens. (#83)

🤖 Generated with [Claude Code](https://claude.com/claude-code)