### PR TITLE
polish(landing+nav): rename feature cards, swap arrow glyphs for icons, tighten attribution line

### DIFF
--- a/src/app/(app)/league/[familyId]/drafts/page.tsx
+++ b/src/app/(app)/league/[familyId]/drafts/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 
 interface PickGrade {
   grade: string;
@@ -96,9 +97,10 @@ export default function DraftsPage() {
           <div className="container mx-auto px-6 py-3 flex items-center gap-4">
             <Link
               href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-foreground"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
             >
-              &larr; League
+              <ArrowLeft className="h-4 w-4" />
+              League
             </Link>
             <h1 className="text-lg font-semibold">Draft History</h1>
           </div>

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import { GradeBadge } from "@/components/GradeBadge";
 import { ManagerRadarChart } from "@/components/ManagerRadarChart";
 import { ManagerGradeCard } from "@/components/ManagerGradeCard";
@@ -93,9 +94,10 @@ export default function ManagerPage() {
           <div className="flex items-center gap-3">
             <Link
               href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-primary transition-colors"
+              className="text-sm text-muted-foreground hover:text-primary transition-colors inline-flex items-center gap-1.5"
             >
-              &larr; League
+              <ArrowLeft className="h-4 w-4" />
+              League
             </Link>
             <span className="text-muted-foreground">/</span>
             <h1 className="text-lg font-semibold">

--- a/src/app/(app)/league/[familyId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { Network } from "lucide-react";
+import { ArrowLeft, Network } from "lucide-react";
 import {
   LineupEfficiencyCard,
   type RosterGrade,
@@ -129,9 +129,10 @@ export default function LeagueOverviewPage() {
             <div className="flex items-center gap-4">
               <Link
                 href="/start"
-                className="text-sm text-muted-foreground hover:text-foreground"
+                className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
               >
-                &larr; My leagues
+                <ArrowLeft className="h-4 w-4" />
+                My leagues
               </Link>
               <h1 className="text-lg font-semibold">{data.league.name}</h1>
               <span className="text-sm text-muted-foreground">

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import { useFlag } from "@/lib/useFlag";
 
 interface Manager {
@@ -194,16 +194,18 @@ export default function PlayerDetailPage() {
             <div className="flex items-center gap-4 ml-auto">
               <Link
                 href={`/league/${familyId}/timeline?playerId=${playerId}`}
-                className="text-sm text-muted-foreground hover:text-foreground"
+                className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
               >
-                Timeline &rarr;
+                Timeline
+                <ArrowRight className="h-4 w-4" />
               </Link>
               {graphEnabled && (
                 <Link
                   href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
-                  className="text-sm text-muted-foreground hover:text-foreground"
+                  className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
                 >
-                  Trace lineage &rarr;
+                  Trace lineage
+                  <ArrowRight className="h-4 w-4" />
                 </Link>
               )}
             </div>

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import { useFlag } from "@/lib/useFlag";
 
 interface Manager {
@@ -179,9 +180,10 @@ export default function PlayerDetailPage() {
           <div className="container mx-auto px-6 py-3 flex items-center gap-4">
             <Link
               href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-foreground"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
             >
-              &larr; League
+              <ArrowLeft className="h-4 w-4" />
+              League
             </Link>
             <div className="flex-1">
               <h1 className="text-lg font-semibold">{player.name}</h1>

--- a/src/app/(app)/league/[familyId]/timeline/page.tsx
+++ b/src/app/(app)/league/[familyId]/timeline/page.tsx
@@ -3,6 +3,7 @@
 import { useParams, useSearchParams } from "next/navigation";
 import { useCallback, useRef, useState, useEffect } from "react";
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import { AssetTimeline, AssetIdentifier } from "@/components/AssetTimeline";
 
 function assetKey(asset: AssetIdentifier): string {
@@ -121,9 +122,10 @@ export default function TimelinePage() {
         <div className="container mx-auto px-6 py-3 flex items-center gap-4">
           <Link
             href={`/league/${familyId}`}
-            className="text-sm text-muted-foreground hover:text-foreground"
+            className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
           >
-            &larr; League
+            <ArrowLeft className="h-4 w-4" />
+            League
           </Link>
           <h1 className="text-lg font-semibold">Asset Timeline</h1>
         </div>

--- a/src/app/(app)/league/[familyId]/transactions/page.tsx
+++ b/src/app/(app)/league/[familyId]/transactions/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { ArrowLeft } from "lucide-react";
 import {
   TransactionCard,
   type TransactionData,
@@ -66,9 +67,10 @@ export default function TransactionsPage() {
           <div className="container mx-auto px-6 py-3 flex items-center gap-4">
             <Link
               href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-foreground"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
             >
-              &larr; League
+              <ArrowLeft className="h-4 w-4" />
+              League
             </Link>
             <h1 className="text-lg font-semibold">Transactions</h1>
             {graphEnabled && (

--- a/src/app/(app)/league/[familyId]/transactions/page.tsx
+++ b/src/app/(app)/league/[familyId]/transactions/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
 import {
   TransactionCard,
   type TransactionData,
@@ -76,9 +76,10 @@ export default function TransactionsPage() {
             {graphEnabled && (
               <Link
                 href={`/league/${familyId}/graph?from=transactions`}
-                className="text-sm text-muted-foreground hover:text-foreground ml-auto"
+                className="text-sm text-muted-foreground hover:text-foreground ml-auto inline-flex items-center gap-1.5"
               >
-                View as network &rarr;
+                View as network
+                <ArrowRight className="h-4 w-4" />
               </Link>
             )}
           </div>

--- a/src/app/(public)/changelog/page.tsx
+++ b/src/app/(public)/changelog/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ArrowRight } from "lucide-react";
 import { StatusBadge } from "@/components/StatusBadge";
 import { formatDate } from "@/lib/utils";
 import type { RoadmapIssue } from "@/app/api/roadmap/route";
@@ -158,9 +159,10 @@ export default function ChangelogPage() {
               href="https://github.com/jrygrande/dynasty-dna"
               target="_blank"
               rel="noopener noreferrer"
-              className="text-primary hover:underline"
+              className="text-primary hover:underline inline-flex items-center gap-1.5"
             >
-              View source on GitHub →
+              View source on GitHub
+              <ArrowRight className="h-4 w-4" />
             </a>
           </div>
         </footer>

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -25,9 +25,8 @@ export default function LandingPage() {
         >
           Get started
         </Link>
-        <p className="text-xs text-muted-foreground mt-6 flex flex-wrap justify-center gap-x-2 gap-y-0.5">
-          <span>Only for Sleeper leagues</span>
-          <span>&middot; Player valuations by FantasyCalc &middot; NFL data from nflverse</span>
+        <p className="text-xs text-muted-foreground mt-6">
+          Only for Sleeper leagues &middot; Player valuations by FantasyCalc &middot; NFL data from nflverse
         </p>
       </section>
 
@@ -35,24 +34,24 @@ export default function LandingPage() {
       <section className="container mx-auto px-6 pb-20 max-w-5xl">
         <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
           <FeatureCard
-            icon={<ArrowRightLeft className="h-6 w-6 text-primary" />}
-            title="Know if you won the trade"
-            description="Every trade scored with surplus value so you can see who came out ahead — and why."
+            icon={<Dna className="h-6 w-6 text-primary" />}
+            title="Lineage Tracer"
+            description="Find the origin of every asset and higher order outcomes of each trade."
           />
           <FeatureCard
             icon={<ClipboardList className="h-6 w-6 text-primary" />}
-            title="Grade every pick"
-            description="Pick-by-pick draft grades comparing capital spent vs. production gained."
+            title="Transaction Grading"
+            description="Every trade, draft pick, and move graded on realized production and future value."
+          />
+          <FeatureCard
+            icon={<ArrowRightLeft className="h-6 w-6 text-primary" />}
+            title="Trade Finder"
+            description="Find the manager in your league who wants to acquire your sell-high piece."
           />
           <FeatureCard
             icon={<BarChart3 className="h-6 w-6 text-primary" />}
-            title="Never leave points on your bench"
-            description="Weekly lineup analysis showing exactly where you left points on the table."
-          />
-          <FeatureCard
-            icon={<Dna className="h-6 w-6 text-primary" />}
-            title="Discover your manager style"
-            description="A profile across trades, drafts, and waivers that reveals how you build rosters."
+            title="Manager Process Score"
+            description="See how you stack up against dynasty managers across leagues."
           />
         </div>
       </section>

--- a/src/app/(public)/roadmap/page.tsx
+++ b/src/app/(public)/roadmap/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { ArrowRight } from "lucide-react";
 import { RoadmapCard } from "@/components/RoadmapCard";
 import type { RoadmapIssue } from "@/app/api/roadmap/route";
 import { type FeatureFlag, getActiveExperiments } from "@/lib/featureFlags";
@@ -174,7 +175,7 @@ export default function RoadmapPage() {
               rel="noopener noreferrer"
               className="text-sm text-primary hover:underline"
             >
-              View roadmap on GitHub →
+              <span className="inline-flex items-center gap-1.5">View roadmap on GitHub<ArrowRight className="h-4 w-4" /></span>
             </a>
           </div>
         )}
@@ -264,7 +265,7 @@ export default function RoadmapPage() {
               rel="noopener noreferrer"
               className="text-primary hover:underline"
             >
-              Submit a feature request →
+              <span className="inline-flex items-center gap-1.5">Submit a feature request<ArrowRight className="h-4 w-4" /></span>
             </a>
           </div>
         </footer>

--- a/src/app/(public)/start/page.tsx
+++ b/src/app/(public)/start/page.tsx
@@ -371,8 +371,9 @@ function LeaguesList({
       {notInDb.length > 0 && inDb.length === 0 && (
         <p className="text-sm text-muted-foreground pt-2">
           None of your leagues are supported yet.{" "}
-          <Link href="/demo" className="text-primary hover:underline">
-            Browse a demo league →
+          <Link href="/demo" className="text-primary hover:underline inline-flex items-center gap-1.5">
+            Browse a demo league
+            <ArrowRight className="h-4 w-4" />
           </Link>
         </p>
       )}

--- a/src/app/(public)/trade-finder/page.tsx
+++ b/src/app/(public)/trade-finder/page.tsx
@@ -7,7 +7,7 @@ export default function TradeFinderPage() {
       <p className="text-muted-foreground text-lg mb-2">In development.</p>
       <p className="text-muted-foreground max-w-md mx-auto">
         Find trade partners who might be interested in the assets you want to
-        move by exploring their exposure across their portfolios.
+        move by exploring exposure across their portfolios.
       </p>
     </main>
   );

--- a/src/app/(public)/trade-finder/page.tsx
+++ b/src/app/(public)/trade-finder/page.tsx
@@ -6,8 +6,8 @@ export default function TradeFinderPage() {
       </h1>
       <p className="text-muted-foreground text-lg mb-2">In development.</p>
       <p className="text-muted-foreground max-w-md mx-auto">
-        A working surface for proposing dynasty trades that account for league
-        context, manager tendencies, and roster fit. Coming as part of Phase 7.
+        Find trade partners who might be interested in the assets you want to
+        move by exploring their exposure across their portfolios.
       </p>
     </main>
   );

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -189,8 +189,8 @@ export default function DesignSystemPage() {
               <CardHeader>
                 <CardTitle>Grade badges</CardTitle>
                 <CardDescription>
-                  Earned colors: A sage → B dusty blue → C ochre → D
-                  terracotta → F muted red.
+                  Earned colors: A sage, B dusty blue, C ochre, D
+                  terracotta, F muted red.
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-wrap gap-2">

--- a/src/components/AssetTimeline.tsx
+++ b/src/components/AssetTimeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { ArrowRight } from "lucide-react";
 import { TransactionCard, TransactionData } from "./TransactionCard";
 import { StintCard, StintData } from "./StintCard";
 
@@ -256,8 +257,10 @@ export function AssetTimeline({
                 {event.transaction && event.eventType !== "trade" && (
                   <div className="text-sm text-muted-foreground mt-1">
                     {event.transaction.adds.map((a) => (
-                      <p key={a.playerId} className="text-primary">
-                        + {a.playerName} → {a.managerName}
+                      <p key={a.playerId} className="text-primary inline-flex items-center gap-1 align-middle">
+                        <span>+ {a.playerName}</span>
+                        <ArrowRight className="h-3 w-3" />
+                        <span>{a.managerName}</span>
                       </p>
                     ))}
                     {event.transaction.drops.map((d) => (

--- a/src/components/RoadmapCard.tsx
+++ b/src/components/RoadmapCard.tsx
@@ -1,3 +1,4 @@
+import { ArrowRight } from "lucide-react";
 import { StatusBadge } from "./StatusBadge";
 import { formatDate } from "@/lib/utils";
 import type { RoadmapIssue } from "@/app/api/roadmap/route";
@@ -83,8 +84,9 @@ export function RoadmapCard({ issue }: { issue: RoadmapIssue }) {
         {issue.tags.length > 0 && (
           <span>{issue.tags.join(" · ")}</span>
         )}
-        <span className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity">
-          View on GitHub →
+        <span className="ml-auto opacity-0 group-hover:opacity-100 transition-opacity inline-flex items-center gap-1.5">
+          View on GitHub
+          <ArrowRight className="h-3.5 w-3.5" />
         </span>
       </div>
     </a>

--- a/src/components/StintCard.tsx
+++ b/src/components/StintCard.tsx
@@ -34,7 +34,7 @@ interface StintCardProps {
 function formatStintRange(stint: StintData): string {
   const start = `${stint.startSeason} W${stint.startWeek}`;
   const end = stint.endSeason === "now" ? "Present" : `${stint.endSeason} W${stint.endWeek}`;
-  return `${start} → ${end}`;
+  return `${start} – ${end}`;
 }
 
 export function StintCard({ stint, assetKind, defaultExpanded = false }: StintCardProps) {

--- a/src/components/TransactionCard.tsx
+++ b/src/components/TransactionCard.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link";
+import { ArrowRight } from "lucide-react";
 import type { AssetIdentifier } from "./AssetTimeline";
 import { GradeBadge } from "./GradeBadge";
 import { getRoundSuffix } from "@/lib/utils";
@@ -226,8 +227,9 @@ function TradeCard({ tx, familyId, onAssetClick }: { tx: TransactionData; family
                       </span>
                     )}
                     {p.resolvedPlayerName && (
-                      <span className="text-xs text-muted-foreground ml-1">
-                        &rarr; <PlayerLink playerId={p.resolvedPlayerId!} playerName={p.resolvedPlayerName} familyId={familyId} className="text-xs text-muted-foreground" />
+                      <span className="text-xs text-muted-foreground ml-1 inline-flex items-center gap-1 align-middle">
+                        <ArrowRight className="h-3 w-3" />
+                        <PlayerLink playerId={p.resolvedPlayerId!} playerName={p.resolvedPlayerName} familyId={familyId} className="text-xs text-muted-foreground" />
                       </span>
                     )}
                     {onAssetClick && (
@@ -264,8 +266,9 @@ function TradeCard({ tx, familyId, onAssetClick }: { tx: TransactionData; family
                       </span>
                     )}
                     {p.resolvedPlayerName && (
-                      <span className="text-xs text-muted-foreground ml-1">
-                        &rarr; <PlayerLink playerId={p.resolvedPlayerId!} playerName={p.resolvedPlayerName} familyId={familyId} className="text-xs text-muted-foreground" />
+                      <span className="text-xs text-muted-foreground ml-1 inline-flex items-center gap-1 align-middle">
+                        <ArrowRight className="h-3 w-3" />
+                        <PlayerLink playerId={p.resolvedPlayerId!} playerName={p.resolvedPlayerName} familyId={familyId} className="text-xs text-muted-foreground" />
                       </span>
                     )}
                     {onAssetClick && (
@@ -311,8 +314,9 @@ function SimpleTransactionCard({ tx, familyId }: { tx: TransactionData; familyId
             <span className="text-primary font-medium">
               + <PlayerLink playerId={a.playerId} playerName={a.playerName} familyId={familyId} />
             </span>
-            <span className="text-muted-foreground ml-2">
-              &rarr; {a.managerName}
+            <span className="text-muted-foreground ml-2 inline-flex items-center gap-1 align-middle">
+              <ArrowRight className="h-3 w-3" />
+              {a.managerName}
             </span>
           </p>
         ))}

--- a/src/components/graph/AssetPicker.tsx
+++ b/src/components/graph/AssetPicker.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { ArrowRight } from "lucide-react";
 import type { AssetsListResponse } from "@/app/api/leagues/[familyId]/assets/route";
 import type { GraphFocus } from "@/lib/assetGraph";
 import { getRoundSuffix } from "@/lib/utils";
@@ -227,9 +228,14 @@ function PickList({
               {p.season} · {p.round}
               {getRoundSuffix(p.round)} round
             </span>
-            <span className="text-xs text-muted-foreground">
+            <span className="text-xs text-muted-foreground inline-flex items-center gap-1 align-middle">
               {p.originalOwnerName ?? "Unknown owner"}
-              {p.resolvedPlayerName ? ` → ${p.resolvedPlayerName}` : ""}
+              {p.resolvedPlayerName && (
+                <>
+                  <ArrowRight className="h-3 w-3" />
+                  {p.resolvedPlayerName}
+                </>
+              )}
             </span>
           </button>
         </li>

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -301,7 +301,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
         <PlayerStintStats familyId={familyId} edge={edge} />
       )}
       <p className="text-xs text-muted-foreground">
-        {edge.startSeason} W{edge.startWeek} → {endLabel}
+        {edge.startSeason} W{edge.startWeek} – {endLabel}
       </p>
       {edge.assetKind === "player" && edge.playerId && (
         <p className="text-[11px] tip-shimmer pt-1 border-t border-border/40">
@@ -633,7 +633,7 @@ function CompareColumnHeader({
       )}
       <p className="text-muted-foreground truncate">{edge.managerName}</p>
       <p className="font-mono text-[10px] text-muted-foreground">
-        {edge.startSeason} W{edge.startWeek} → {endLabel}
+        {edge.startSeason} W{edge.startWeek} – {endLabel}
       </p>
     </div>
   );

--- a/src/components/graph/MobileTimeline.tsx
+++ b/src/components/graph/MobileTimeline.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo } from "react";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { ArrowDown, ArrowLeft } from "lucide-react";
 
 import type {
   GraphEdge,
@@ -362,8 +362,9 @@ function Connector({
           ))}
         </div>
       ) : (
-        <div className="px-2 py-1 text-[10px] italic text-muted-foreground">
-          &darr; thread continues
+        <div className="px-2 py-1 text-[10px] italic text-muted-foreground inline-flex items-center gap-1">
+          <ArrowDown className="h-3 w-3" />
+          thread continues
         </div>
       )}
       <div className="h-3 w-px bg-border" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- Replace the 4 feature cards with the new lineup: **Lineage Tracer**, **Transaction Grading**, **Trade Finder**, **Manager Process Score**.
- Collapse the attribution line into a single span — the previous flex gap-x-2 between the two spans (plus the leading middot in the second) read as an extra space after "Only for Sleeper leagues."

## Test plan
- [ ] `/` renders 4 cards in the new order/copy
- [ ] No double-space between "Only for Sleeper leagues" and the first middot

🤖 Generated with [Claude Code](https://claude.com/claude-code)