### PR TITLE
fix(manager-page): use current season's user record for header (#99)

### DIFF
--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -35,6 +35,10 @@ export async function GET(
     }
 
     const leagueIds = members.map((m) => m.leagueId);
+    const leagueToSeason = new Map(members.map((m) => [m.leagueId, m.season]));
+    const seasonsNewestFirst = [...members].sort(
+      (a, b) => Number(b.season) - Number(a.season),
+    );
 
     // Load user info, metrics, transactions, and rosters in parallel
     const [users, allMetrics, recentTx, rosters] = await Promise.all([
@@ -88,7 +92,12 @@ export async function GET(
         ),
     ]);
 
-    const user = users[0];
+    // Walk seasons newest-first; first matching row wins. Avoids leaking a
+    // stale teamName from an older season when the user has no current-season
+    // row (e.g. left the league after season rollover).
+    const user = seasonsNewestFirst
+      .map((m) => users.find((u) => u.leagueId === m.leagueId))
+      .find(Boolean);
     if (!user) {
       return NextResponse.json(
         { error: "Manager not found" },
@@ -180,9 +189,6 @@ export async function GET(
       : null;
 
     // Season history — group season-scoped metrics by season
-    const leagueToSeason = new Map(
-      members.map((m) => [m.leagueId, m.season]),
-    );
     const seasonMetrics = myMetrics.filter((r) =>
       r.scope.startsWith("season:"),
     );


### PR DESCRIPTION
## Summary

- The manager API was returning an arbitrary `league_users` row across the family's seasons, so the header rendered stale team names — or fell back to just the display name when an older season's row had no `teamName`.
- Walk family members newest-first and pick the first row that matches the manager. Current season wins; falls back to the most recent season the manager actually participated in (not a random pre-rollover record).
- Closes #99.

## Before / after — Dynasty Domination (`afc3acf8-2d18-47c9-80c1-998252c9a06a`)

Five managers verified against `/api/leagues/[familyId]` (2026 season):

| User           | Before (`users[0]`) | After (current season) | Source of truth |
| -------------- | ------------------- | ---------------------- | --------------- |
| tendererbrick  | stale team name     | `White Dudes 4 Goddess ` | matches overview |
| kingjustin713  | stale team name     | `God Squad 🏆🏆🏆🏆`   | matches overview |
| andrewduke23   | stale team name     | `I Bucky'd the McBride` | matches overview |
| mcmahorj       | display name only   | `Allenhu Akbar`        | matches overview |
| agiotis        | display name only   | `null` (genuine null in 2026) | matches overview; UI fallback handles |

Demo regression — same family with `dd_demo_seed` cookie still returns pseudonyms (e.g. tendererbrick → `Marv Levy / Miami Sharks`).

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` no new warnings
- [x] `npm test` (67 passed)
- [x] curl all five managers returns current-season `displayName` + `teamName`
- [x] curl with demo cookie still returns coach pseudonyms
- [ ] Browser: manager page header matches league overview standings for all five managers

🤖 Generated with [Claude Code](https://claude.com/claude-code)