### PR TITLE
feat(tracer): pick numbers on draft cards + always-visible dates (#92)

### DIFF
--- a/src/app/api/leagues/[familyId]/graph/route.ts
+++ b/src/app/api/leagues/[familyId]/graph/route.ts
@@ -215,20 +215,13 @@ export async function GET(
     for (const ev of draftSelectedEvents) {
       if (!ev.playerId || ev.pickSeason === null) continue;
       const draftInfo = draftByLeagueSeason.get(`${ev.leagueId}:${ev.pickSeason}`);
-      if (!draftInfo?.slotToRosterId) continue;
-
-      const slot = draftSlotLookup.get(`${draftInfo.id}:${ev.playerId}`);
-      if (slot == null) continue;
-
-      const trueOriginal = draftInfo.slotToRosterId[String(slot)];
-      if (trueOriginal != null && trueOriginal !== ev.pickOriginalRosterId) {
-        ev.pickOriginalRosterId = trueOriginal;
-      }
+      if (!draftInfo) continue;
 
       // Surface pickInRound on the event so the card header can render
-      // "2024  3.04". Stored in details (jsonb) since it's derived metadata,
-      // not a column. Wrap-around arithmetic handles snake drafts the same
-      // as linear since pick ordering is by global pickNo regardless.
+      // "2024  3.04". Independent of the slot-remap below since pick
+      // ordering is by global pickNo — derives correctly even when
+      // draft_slot is null on the draft_picks row (and therefore the slot
+      // remap is skipped).
       const details = (ev.details ?? {}) as Record<string, unknown>;
       const pickNo = typeof details.pickNo === "number" ? details.pickNo : null;
       if (pickNo !== null && draftInfo.draftSize > 0) {
@@ -236,6 +229,16 @@ export async function GET(
           ...details,
           pickInRound: ((pickNo - 1) % draftInfo.draftSize) + 1,
         };
+      }
+
+      // Slot remap (Sleeper's draft_selected uses the drafter's roster, not
+      // the original owner — fix it for traded picks).
+      if (!draftInfo.slotToRosterId) continue;
+      const slot = draftSlotLookup.get(`${draftInfo.id}:${ev.playerId}`);
+      if (slot == null) continue;
+      const trueOriginal = draftInfo.slotToRosterId[String(slot)];
+      if (trueOriginal != null && trueOriginal !== ev.pickOriginalRosterId) {
+        ev.pickOriginalRosterId = trueOriginal;
       }
     }
   }

--- a/src/app/api/leagues/[familyId]/graph/route.ts
+++ b/src/app/api/leagues/[familyId]/graph/route.ts
@@ -177,12 +177,17 @@ export async function GET(
       .from(schema.drafts)
       .where(inArray(schema.drafts.leagueId, allLeagueIds));
 
-    // leagueId:season → draft info
-    const draftByLeagueSeason = new Map<string, { id: string; slotToRosterId: Record<string, number> | null }>();
+    // leagueId:season → draft info (size precomputed once for pickInRound math)
+    const draftByLeagueSeason = new Map<
+      string,
+      { id: string; slotToRosterId: Record<string, number> | null; draftSize: number }
+    >();
     for (const d of draftRows) {
+      const slotToRosterId = d.slotToRosterId as Record<string, number> | null;
       draftByLeagueSeason.set(`${d.leagueId}:${d.season}`, {
         id: d.id,
-        slotToRosterId: d.slotToRosterId as Record<string, number> | null,
+        slotToRosterId,
+        draftSize: slotToRosterId ? Object.keys(slotToRosterId).length : 0,
       });
     }
 
@@ -218,6 +223,19 @@ export async function GET(
       const trueOriginal = draftInfo.slotToRosterId[String(slot)];
       if (trueOriginal != null && trueOriginal !== ev.pickOriginalRosterId) {
         ev.pickOriginalRosterId = trueOriginal;
+      }
+
+      // Surface pickInRound on the event so the card header can render
+      // "2024  3.04". Stored in details (jsonb) since it's derived metadata,
+      // not a column. Wrap-around arithmetic handles snake drafts the same
+      // as linear since pick ordering is by global pickNo regardless.
+      const details = (ev.details ?? {}) as Record<string, unknown>;
+      const pickNo = typeof details.pickNo === "number" ? details.pickNo : null;
+      if (pickNo !== null && draftInfo.draftSize > 0) {
+        ev.details = {
+          ...details,
+          pickInRound: ((pickNo - 1) % draftInfo.draftSize) + 1,
+        };
       }
     }
   }

--- a/src/components/graph/TransactionCardChrome.tsx
+++ b/src/components/graph/TransactionCardChrome.tsx
@@ -265,10 +265,20 @@ export function TransactionCardChrome({
               {data.header.title}
             </span>
             <span
-              className="font-mono text-[11px] text-muted-foreground truncate"
-              title={data.header.subtitle}
+              className="font-mono text-[11px] text-muted-foreground flex items-baseline gap-1 min-w-0"
+              title={
+                data.header.subtitleLead
+                  ? `${data.header.subtitleLead} · ${data.header.subtitle}`
+                  : data.header.subtitle
+              }
             >
-              {data.header.subtitle}
+              {data.header.subtitleLead ? (
+                <>
+                  <span className="truncate min-w-0">{data.header.subtitleLead}</span>
+                  <span aria-hidden className="shrink-0">·</span>
+                </>
+              ) : null}
+              <span className="shrink-0 whitespace-nowrap">{data.header.subtitle}</span>
             </span>
           </div>
           <span

--- a/src/components/graph/__tests__/transactionHeader.test.ts
+++ b/src/components/graph/__tests__/transactionHeader.test.ts
@@ -1,0 +1,139 @@
+/**
+ * @jest-environment node
+ *
+ * buildTransactionHeader contract: title formatting (especially the new
+ * "{season}  {round}.{pickInRound}" draft format from #92) and the
+ * subtitle split that lets dates render in full while long manager names
+ * truncate.
+ */
+
+import type { TransactionNode } from "@/lib/assetGraph";
+import { buildTransactionHeader } from "../transactionHeader";
+
+declare const describe: (name: string, fn: () => void) => void;
+declare const it: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toBeUndefined: () => void;
+};
+
+// 2025-03-05 12:00 UTC — picked so en-US short formatting is stable across
+// host timezones near the boundary. Formats as "Mar 5, 25" in en-US.
+const SAMPLE_CREATED_AT = Date.UTC(2025, 2, 5, 12, 0, 0);
+
+function draftNode(
+  draftPick: TransactionNode["draftPick"],
+): TransactionNode {
+  return {
+    id: "draft:e1",
+    kind: "transaction",
+    txKind: "draft",
+    transactionId: null,
+    leagueId: "L",
+    season: "2024",
+    week: 0,
+    createdAt: SAMPLE_CREATED_AT,
+    managers: [{ userId: "u1", displayName: "jrygrande" }],
+    assets: [],
+    draftPick,
+  };
+}
+
+describe("buildTransactionHeader — draft", () => {
+  it("formats title as '{season}  {round}.{pickInRound}' with zero-padded pick", () => {
+    const node = draftNode({
+      season: "2024",
+      round: 3,
+      originalRosterId: 1,
+      pickInRound: 4,
+    });
+    const header = buildTransactionHeader(node);
+    expect(header.title).toBe("2024  3.04");
+  });
+
+  it("splits subtitle into manager lead + date so dates never truncate", () => {
+    const node = draftNode({
+      season: "2024",
+      round: 3,
+      originalRosterId: 1,
+      pickInRound: 4,
+    });
+    const header = buildTransactionHeader(node);
+    expect(header.subtitleLead).toBe("jrygrande");
+    expect(header.subtitle).toBe("Mar 5, 25");
+  });
+
+  it("falls back to 'Draft' when draftPick is missing", () => {
+    const node = draftNode(undefined);
+    const header = buildTransactionHeader(node);
+    expect(header.title).toBe("Draft");
+  });
+
+  it("falls back to 'Draft' when pickInRound is null (older event)", () => {
+    const node = draftNode({
+      season: "2024",
+      round: 3,
+      originalRosterId: 1,
+      pickInRound: null,
+    });
+    const header = buildTransactionHeader(node);
+    expect(header.title).toBe("Draft");
+  });
+
+  it("zero-pads single-digit pickInRound but does not pad rounds", () => {
+    const node = draftNode({
+      season: "2025",
+      round: 1,
+      originalRosterId: 1,
+      pickInRound: 1,
+    });
+    const header = buildTransactionHeader(node);
+    expect(header.title).toBe("2025  1.01");
+  });
+});
+
+describe("buildTransactionHeader — non-draft (regression guard)", () => {
+  function txNode(
+    overrides: Partial<TransactionNode>,
+  ): TransactionNode {
+    return {
+      id: "tx:1",
+      kind: "transaction",
+      txKind: "trade",
+      transactionId: "1",
+      leagueId: "L",
+      season: "2024",
+      week: 1,
+      createdAt: SAMPLE_CREATED_AT,
+      managers: [
+        { userId: "u1", displayName: "Andrew" },
+        { userId: "u2", displayName: "Brian" },
+      ],
+      assets: [],
+      ...overrides,
+    };
+  }
+
+  it("trade title joins both managers; subtitle is just the date", () => {
+    const header = buildTransactionHeader(txNode({ txKind: "trade" }));
+    expect(header.title).toBe("Andrew ↔ Brian");
+    expect(header.subtitle).toBe("Mar 5, 25");
+    expect(header.subtitleLead).toBeUndefined();
+  });
+
+  it("waiver subtitle has no lead segment", () => {
+    const header = buildTransactionHeader(
+      txNode({ txKind: "waiver", managers: [{ userId: "u1", displayName: "Andrew" }] }),
+    );
+    expect(header.title).toBe("Waiver claim by Andrew");
+    expect(header.subtitleLead).toBeUndefined();
+  });
+
+  it("free-agent subtitle has no lead segment", () => {
+    const header = buildTransactionHeader(
+      txNode({ txKind: "free_agent", managers: [{ userId: "u1", displayName: "Andrew" }] }),
+    );
+    expect(header.title).toBe("Free-agent signing by Andrew");
+    expect(header.subtitleLead).toBeUndefined();
+  });
+});

--- a/src/components/graph/transactionHeader.ts
+++ b/src/components/graph/transactionHeader.ts
@@ -1,8 +1,12 @@
 import { assetKey, type GraphNode, type TransactionNode } from "@/lib/assetGraph";
-import { getRoundSuffix } from "@/lib/utils";
 
 export interface TransactionHeader {
   title: string;
+  /** Optional left segment of the subtitle (e.g. manager name on draft
+   *  cards). Truncates with ellipsis when the card is narrow. */
+  subtitleLead?: string;
+  /** Trailing subtitle segment — typically the formatted date. Pinned at
+   *  the end of the subtitle row so it always renders in full. */
   subtitle: string;
 }
 
@@ -80,13 +84,16 @@ export function buildTransactionHeader(node: TransactionNode): TransactionHeader
     }
     case "draft": {
       // Pick details live on `draftPick` (populated from the draft_selected
-      // event), not in `assets` (which holds the player drafted). Falls
-      // back to "Draft" if pick info is somehow missing.
+      // event), not in `assets` (which holds the player drafted). Title
+      // format is "{season}  {round}.{pickInRound zero-padded to 2}" — note
+      // the double-space separator. Falls back to "Draft" when pick info
+      // (or pickInRound) is missing.
       const pick = node.draftPick;
-      const title = pick
-        ? `${pick.round}${getRoundSuffix(pick.round)} round, ${pick.season}`
-        : "Draft";
-      return { title, subtitle: `${managerName} · ${date}` };
+      const title =
+        pick && pick.pickInRound !== null
+          ? `${pick.season}  ${pick.round}.${String(pick.pickInRound).padStart(2, "0")}`
+          : "Draft";
+      return { title, subtitleLead: managerName, subtitle: date };
     }
     case "waiver":
       return { title: `Waiver claim by ${managerName}`, subtitle: date };

--- a/src/lib/assetGraph.ts
+++ b/src/lib/assetGraph.ts
@@ -122,11 +122,15 @@ export interface TransactionNode {
   assets: TransactionAssetRef[];
   /** For draft nodes, the pick that was consumed to draft the player. The
    * pick lives on the incoming edge rather than in `assets` (which holds
-   * the player drafted), so we surface it here for header display. */
+   * the player drafted), so we surface it here for header display.
+   *
+   * `pickInRound` is the 1-based position within the round, used to
+   * render "2024  3.04" titles. Null when source data is missing. */
   draftPick?: {
     season: string;
     round: number;
     originalRosterId: number;
+    pickInRound: number | null;
   };
   layout?: LayoutPos;
 }
@@ -388,10 +392,14 @@ export function buildGraphFromEvents(input: BuildGraphInput): Graph {
       ev.pickOriginalRosterId !== null &&
       !node.draftPick
     ) {
+      const details = (ev.details ?? {}) as Record<string, unknown>;
+      const pickInRound =
+        typeof details.pickInRound === "number" ? details.pickInRound : null;
       node.draftPick = {
         season: ev.pickSeason,
         round: ev.pickRound,
         originalRosterId: ev.pickOriginalRosterId,
+        pickInRound,
       };
     }
 


### PR DESCRIPTION
## Summary
- Draft cards now title as `2024  3.04` (season, round, pick-in-round) — no more "3rd round, 2024" noise.
- Subtitle splits into `{managerName} · {date}`; the date is `shrink-0 whitespace-nowrap` so long manager names truncate but dates always render in full.
- Plumbing: graph route precomputes `draftSize` per draft and writes `pickInRound` into `assetEvents.details` (jsonb) so the asset-graph builder can read it without a schema change.

Closes #92.

## Why this format
Previously the title leaked the round and dropped the pick number entirely; the legacy timeline rendered "Pick #N, Round R" and that detail was the most-cited gap when promoting the Tracer to the primary CTA. The new format keeps cards scannable (one line, mono-friendly) while restoring round + pick.

## Test plan
- [x] `npm test` — 75 tests pass, including 8 new for `buildTransactionHeader` (draft title format, manager+date split, null-fallback to "Draft", regression guards on trade/waiver/free-agent subtitles).
- [x] `npm run lint` — only pre-existing warnings.
- [x] `npm run build` — clean.
- [x] Manual: `/league/afc3acf8-2d18-47c9-80c1-998252c9a06a/graph?seedPlayerId=5859` — draft card renders title `2021  2.06`, subtitle `andrewduke23 · Aug 9, 21` with the date pinned shrink-0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)