### PR TITLE
fix(tracer): filter orphan player IDs from asset picker

### DIFF
--- a/src/app/api/leagues/[familyId]/assets/route.ts
+++ b/src/app/api/leagues/[familyId]/assets/route.ts
@@ -84,14 +84,8 @@ export async function GET(
           .where(inArray(schema.players.id, playerIds))
       : [];
 
-  // Fall back to displaying the player ID for asset-event players that have no
-  // metadata row yet — matches the graph builder's `player?.name ?? playerId`
-  // behavior so the picker never silently hides a valid asset.
-  const metaIds = new Set(playerMeta.map((p) => p.id));
-  const fallback = playerIds
-    .filter((id) => !metaIds.has(id))
-    .map((id) => ({ id, name: id, position: null, team: null }));
-  const players = [...playerMeta, ...fallback]
+  // Only include players we can identify; orphan IDs are filtered out — see issue #105.
+  const players = playerMeta
     .map((p) => ({ id: p.id, name: p.name, position: p.position, team: p.team }))
     .sort((a, b) => a.name.localeCompare(b.name));
 


### PR DESCRIPTION
## Summary
- Drop the orphan-player fallback in `/api/leagues/[familyId]/assets` so the Lineage Tracer's seed picker no longer surfaces entries whose name is just a raw Sleeper player ID.
- Players list is now built solely from rows that have hydrated metadata in the `players` table; picks logic is untouched.
- Graph node fallback (`player?.name ?? playerId`) elsewhere is preserved.

## Test plan
- [x] `npm run lint` clean (pre-existing `react-hooks/exhaustive-deps` warnings only).
- [x] `npx tsc --noEmit` passes.
- [x] Confirmed `fallback`/`metaIds` references removed from `src/app/api/leagues/[familyId]/assets/route.ts`.
- [x] Confirmed no existing test exists for this route (no `assets/route.test.ts` under `src/app/api/leagues/`).

Closes #105

https://claude.ai/code/session_017PXxzMeujQYhJ8UGvoLkzT

---
_Generated by [Claude Code](https://claude.ai/code/session_017PXxzMeujQYhJ8UGvoLkzT)_