### PR TITLE
chore: gitignore .claude/ agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ data/*.sqlite*
 
 # Generated calibration output
 docs/trade-grade-calibration.md
+
+# Claude Code agent worktrees + local config
+.claude/


### PR DESCRIPTION
## Summary
- Adds `.claude/` to `.gitignore` so per-session Claude Code state and isolation worktrees stop polluting `git status`.

## Why
The harness writes worktrees under `.claude/worktrees/...` and other local config to that path. It's been showing up as untracked across recent sessions and nearly got staged when running `git add -A`.

## Test plan
- [x] `git status` no longer lists `.claude/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)