### PR TITLE
refactor(manager-grades): rename overall_score → manager_process_score (MPS) (#41)

### DIFF
--- a/drizzle/0014_rename_overall_score_to_manager_process_score.sql
+++ b/drizzle/0014_rename_overall_score_to_manager_process_score.sql
@@ -1,0 +1,14 @@
+-- Rename the composite manager metric from "overall_score" to
+-- "manager_process_score" (MPS). MPS is the process/algorithm quality
+-- score, distinct from MOS (Manager Outcome Score) which is computed
+-- in src/services/outcomeScore.ts and not stored in this column.
+--
+-- Long form keeps the metric value consistent with its siblings
+-- (draft_score, trade_score, waiver_score, lineup_score) — each row
+-- in this column reads as "<x>_score". UI surfaces still display "MPS".
+--
+-- Idempotent: re-running is a no-op once all rows are renamed.
+
+UPDATE "manager_metrics"
+SET "metric" = 'manager_process_score'
+WHERE "metric" = 'overall_score';

--- a/drizzle/0014_rename_overall_score_to_mps.sql
+++ b/drizzle/0014_rename_overall_score_to_mps.sql
@@ -1,0 +1,9 @@
+-- Rename the composite manager metric from "overall_score" to "mps"
+-- (Manager Process Score). MPS is the process/algorithm quality score,
+-- distinct from MOS (Manager Outcome Score).
+--
+-- Idempotent: re-running is a no-op once all rows are renamed.
+
+UPDATE "manager_metrics"
+SET "metric" = 'mps'
+WHERE "metric" = 'overall_score';

--- a/drizzle/0014_rename_overall_score_to_mps.sql
+++ b/drizzle/0014_rename_overall_score_to_mps.sql
@@ -1,9 +1,0 @@
--- Rename the composite manager metric from "overall_score" to "mps"
--- (Manager Process Score). MPS is the process/algorithm quality score,
--- distinct from MOS (Manager Outcome Score).
---
--- Idempotent: re-running is a no-op once all rows are renamed.
-
-UPDATE "manager_metrics"
-SET "metric" = 'mps'
-WHERE "metric" = 'overall_score';

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,2675 @@
+{
+  "id": "9d199902-c41f-4e3a-acc2-a42513620e6b",
+  "prevId": "1f7f6c30-f411-4d3b-a3c5-00aaf5b9d0e6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.algorithm_config": {
+      "name": "algorithm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "algorithm_config_active_idx": {
+          "name": "algorithm_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "algorithm_config_experiment_id_experiment_runs_id_fk": {
+          "name": "algorithm_config_experiment_id_experiment_runs_id_fk",
+          "tableFrom": "algorithm_config",
+          "tableTo": "experiment_runs",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_events": {
+      "name": "asset_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_kind": {
+          "name": "asset_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_season": {
+          "name": "pick_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_round": {
+          "name": "pick_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_original_roster_id": {
+          "name": "pick_original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_roster_id": {
+          "name": "from_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_roster_id": {
+          "name": "to_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "asset_events_player_idx": {
+          "name": "asset_events_player_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_tx_idx": {
+          "name": "asset_events_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_pick_idx": {
+          "name": "asset_events_pick_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_round",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_original_roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_grades": {
+      "name": "draft_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_value": {
+          "name": "benchmark_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_production": {
+          "name": "player_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_production": {
+          "name": "benchmark_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_size": {
+          "name": "benchmark_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_grades_draft_idx": {
+          "name": "draft_grades_draft_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_player_idx": {
+          "name": "draft_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_unique_idx": {
+          "name": "draft_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_grades_draft_id_drafts_id_fk": {
+          "name": "draft_grades_draft_id_drafts_id_fk",
+          "tableFrom": "draft_grades",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_slot": {
+          "name": "draft_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_keeper": {
+          "name": "is_keeper",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_draft_id_drafts_id_fk": {
+          "name": "draft_picks_draft_id_drafts_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "draft_picks_draft_id_pick_no_pk": {
+          "name": "draft_picks_draft_id_pick_no_pk",
+          "columns": [
+            "draft_id",
+            "pick_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_to_roster_id": {
+          "name": "slot_to_roster_id",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "drafts_league_id_leagues_id_fk": {
+          "name": "drafts_league_id_leagues_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_runs": {
+      "name": "experiment_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hypothesis": {
+          "name": "hypothesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_criteria": {
+          "name": "acceptance_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_reason": {
+          "name": "verdict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scorecard": {
+          "name": "scorecard",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiment_runs_name_idx": {
+          "name": "experiment_runs_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fantasy_calc_values": {
+      "name": "fantasy_calc_values",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_flex": {
+          "name": "is_super_flex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ppr": {
+          "name": "ppr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_rank": {
+          "name": "position_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "fantasy_calc_values_player_id_is_super_flex_ppr_pk": {
+          "name": "fantasy_calc_values_player_id_is_super_flex_ppr_pk",
+          "columns": [
+            "player_id",
+            "is_super_flex",
+            "ppr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_families": {
+      "name": "league_families",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_league_id": {
+          "name": "root_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo_eligible": {
+          "name": "demo_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "league_families_root_league_id_unique": {
+          "name": "league_families_root_league_id_unique",
+          "columns": [
+            {
+              "expression": "root_league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_family_members": {
+      "name": "league_family_members",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "league_family_members_league_id_idx": {
+          "name": "league_family_members_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "league_family_members_family_id_league_families_id_fk": {
+          "name": "league_family_members_family_id_league_families_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "league_families",
+          "columnsFrom": [
+            "family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_family_members_league_id_leagues_id_fk": {
+          "name": "league_family_members_league_id_leagues_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_family_members_family_id_league_id_pk": {
+          "name": "league_family_members_family_id_league_id_pk",
+          "columns": [
+            "family_id",
+            "league_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_users": {
+      "name": "league_users",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_users_league_id_leagues_id_fk": {
+          "name": "league_users_league_id_leagues_id_fk",
+          "tableFrom": "league_users",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_users_league_id_user_id_pk": {
+          "name": "league_users_league_id_user_id_pk",
+          "columns": [
+            "league_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_league_id": {
+          "name": "previous_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scoring_settings": {
+          "name": "scoring_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_positions": {
+          "name": "roster_positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_rosters": {
+          "name": "total_rosters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winners_bracket": {
+          "name": "winners_bracket",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manager_metrics": {
+      "name": "manager_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manager_metrics_unique_idx": {
+          "name": "manager_metrics_unique_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchups": {
+      "name": "matchups",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_points": {
+          "name": "starter_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_points": {
+          "name": "player_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchups_league_id_week_roster_id_pk": {
+          "name": "matchups_league_id_week_roster_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_injuries": {
+      "name": "nfl_injuries",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_type": {
+          "name": "game_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_primary_injury": {
+          "name": "report_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_secondary_injury": {
+          "name": "report_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_status": {
+          "name": "practice_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_primary_injury": {
+          "name": "practice_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_secondary_injury": {
+          "name": "practice_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_modified": {
+          "name": "date_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_injuries_gsis_idx": {
+          "name": "nfl_injuries_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_injuries_season_week_gsis_id_pk": {
+          "name": "nfl_injuries_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_schedule": {
+      "name": "nfl_schedule",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team": {
+          "name": "home_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team": {
+          "name": "away_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_date": {
+          "name": "game_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_schedule_season_week_home_team_pk": {
+          "name": "nfl_schedule_season_week_home_team_pk",
+          "columns": [
+            "season",
+            "week",
+            "home_team"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_state": {
+      "name": "nfl_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'nfl'"
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_type": {
+          "name": "season_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_weekly_roster_status": {
+      "name": "nfl_weekly_roster_status",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_abbr": {
+          "name": "status_abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_roster_status_gsis_idx": {
+          "name": "nfl_roster_status_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_weekly_roster_status_season_week_gsis_id_pk": {
+          "name": "nfl_weekly_roster_status_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_scores": {
+      "name": "player_scores",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_scores_league_id_week_roster_id_player_id_pk": {
+          "name": "player_scores_league_id_week_roster_id_player_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id",
+            "player_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injury_status": {
+          "name": "injury_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "years_exp": {
+          "name": "years_exp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rosters": {
+      "name": "rosters",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserve": {
+          "name": "reserve",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "ties": {
+          "name": "ties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts": {
+          "name": "fpts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts_against": {
+          "name": "fpts_against",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rosters_owner_idx": {
+          "name": "rosters_owner_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rosters_league_id_leagues_id_fk": {
+          "name": "rosters_league_id_leagues_id_fk",
+          "tableFrom": "rosters",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rosters_league_id_roster_id_pk": {
+          "name": "rosters_league_id_roster_id_pk",
+          "columns": [
+            "league_id",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_jobs": {
+      "name": "sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "done": {
+          "name": "done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_jobs_ref_status_idx": {
+          "name": "sync_jobs_ref_status_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_watermarks": {
+      "name": "sync_watermarks",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_week": {
+          "name": "last_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_watermarks_league_id_data_type_pk": {
+          "name": "sync_watermarks_league_id_data_type_pk",
+          "columns": [
+            "league_id",
+            "data_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trade_grades": {
+      "name": "trade_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fantasy_calc_value": {
+          "name": "fantasy_calc_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trade_grades_tx_idx": {
+          "name": "trade_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trade_grades_unique_idx": {
+          "name": "trade_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trade_grades_transaction_id_transactions_id_fk": {
+          "name": "trade_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "trade_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traded_picks": {
+      "name": "traded_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_roster_id": {
+          "name": "original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_owner_id": {
+          "name": "current_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_owner_id": {
+          "name": "previous_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "traded_picks_league_season_idx": {
+          "name": "traded_picks_league_season_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "traded_picks_league_id_leagues_id_fk": {
+          "name": "traded_picks_league_id_leagues_id_fk",
+          "tableFrom": "traded_picks",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_ids": {
+          "name": "roster_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adds": {
+          "name": "adds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drops": {
+          "name": "drops",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_picks": {
+          "name": "draft_picks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_league_week_idx": {
+          "name": "transactions_league_week_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_league_id_leagues_id_fk": {
+          "name": "transactions_league_id_leagues_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_email_league_unique": {
+          "name": "waitlist_email_league_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_league_id_idx": {
+          "name": "waitlist_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waiver_grades": {
+      "name": "waiver_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_player_id": {
+          "name": "dropped_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_value": {
+          "name": "dropped_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_bid": {
+          "name": "faab_bid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_efficiency": {
+          "name": "faab_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waiver_grades_tx_idx": {
+          "name": "waiver_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_player_idx": {
+          "name": "waiver_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_unique_idx": {
+          "name": "waiver_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "waiver_grades_transaction_id_transactions_id_fk": {
+          "name": "waiver_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "waiver_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1777758087053,
       "tag": "0013_harsh_havok",
       "breakpoints": true
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1777809025774,
+      "tag": "0014_rename_overall_score_to_mps",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -104,7 +104,7 @@
       "idx": 14,
       "version": "7",
       "when": 1777809025774,
-      "tag": "0014_rename_overall_score_to_mps",
+      "tag": "0014_rename_overall_score_to_manager_process_score",
       "breakpoints": true
     }
   ]

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -35,7 +35,7 @@ interface ManagerData {
     teamName: string | null;
     avatar: string | null;
   };
-  overallScore: { value: number; grade: string; percentile: number } | null;
+  mps: { value: number; grade: string; percentile: number } | null;
   pillarScores: Record<string, { value: number; grade: string; percentile: number } | null>;
   seasonHistory: SeasonRow[];
   recentTransactions: Transaction[];
@@ -85,7 +85,7 @@ export default function ManagerPage() {
     );
   }
 
-  const { manager, overallScore, pillarScores, seasonHistory, recentTransactions } = data;
+  const { manager, mps, pillarScores, seasonHistory, recentTransactions } = data;
 
   return (
     <div>
@@ -123,7 +123,7 @@ export default function ManagerPage() {
         {/* Top section: Grade card + Radar chart */}
         <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
           <ManagerGradeCard
-            overallScore={overallScore}
+            mps={mps}
             pillarScores={pillarScores}
           />
           <div className="border rounded-lg p-4">

--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -172,16 +172,16 @@ export async function GET(
 
     // Manager Process Score (MPS) — composite all-time score
     const mpsMetric = myMetrics.find(
-      (r) => r.metric === "mps" && r.scope === "all_time",
+      (r) => r.metric === "manager_process_score" && r.scope === "all_time",
     );
     const mps = mpsMetric
       ? {
           value: mpsMetric.value,
           grade: percentileToGrade(
-            globalPercentile("mps", "all_time", mpsMetric.value),
+            globalPercentile("manager_process_score", "all_time", mpsMetric.value),
           ),
           percentile: globalPercentile(
-            "mps",
+            "manager_process_score",
             "all_time",
             mpsMetric.value,
           ),

--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -170,20 +170,20 @@ export async function GET(
       }
     }
 
-    // Overall score
-    const overallMetric = myMetrics.find(
-      (r) => r.metric === "overall_score" && r.scope === "all_time",
+    // Manager Process Score (MPS) — composite all-time score
+    const mpsMetric = myMetrics.find(
+      (r) => r.metric === "mps" && r.scope === "all_time",
     );
-    const overallScore = overallMetric
+    const mps = mpsMetric
       ? {
-          value: overallMetric.value,
+          value: mpsMetric.value,
           grade: percentileToGrade(
-            globalPercentile("overall_score", "all_time", overallMetric.value),
+            globalPercentile("mps", "all_time", mpsMetric.value),
           ),
           percentile: globalPercentile(
-            "overall_score",
+            "mps",
             "all_time",
-            overallMetric.value,
+            mpsMetric.value,
           ),
         }
       : null;
@@ -313,7 +313,7 @@ export async function GET(
         teamName: swap?.teamName ?? user.teamName,
         avatar: swap ? null : user.avatar,
       },
-      overallScore,
+      mps,
       pillarScores,
       seasonHistory,
       recentTransactions: enrichedTx,

--- a/src/components/ManagerGradeCard.tsx
+++ b/src/components/ManagerGradeCard.tsx
@@ -8,7 +8,7 @@ function ordinal(n: number): string {
 }
 
 interface ManagerGradeCardProps {
-  overallScore: {
+  mps: {
     value: number;
     grade: string;
     percentile: number;
@@ -20,13 +20,13 @@ interface ManagerGradeCardProps {
 }
 
 export function ManagerGradeCard({
-  overallScore,
+  mps,
   pillarScores,
 }: ManagerGradeCardProps) {
-  if (!overallScore) {
+  if (!mps) {
     return (
       <div className="border rounded-lg p-6 text-center text-muted-foreground text-sm">
-        No overall score yet — sync league data to generate grades
+        No MPS yet — sync league data to generate grades
       </div>
     );
   }
@@ -34,11 +34,11 @@ export function ManagerGradeCard({
   return (
     <div className="border rounded-lg p-6">
       <div className="flex items-center gap-4 mb-6">
-        <div className="text-5xl font-bold">{ordinal(Math.round(overallScore.percentile))}</div>
+        <div className="text-5xl font-bold">{ordinal(Math.round(mps.percentile))}</div>
         <div>
-          <GradeBadge grade={overallScore.grade} size="sm" />
+          <GradeBadge grade={mps.grade} size="sm" />
           <div className="text-xs text-muted-foreground mt-1">
-            Score: {overallScore.value}
+            MPS: {mps.value}
           </div>
         </div>
       </div>

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -479,7 +479,7 @@ export const managerMetrics = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     leagueId: text("league_id").notNull(),
     managerId: text("manager_id").notNull(), // Sleeper user_id
-    metric: text("metric").notNull(), // draft_score, trade_score, waiver_score, lineup_score, mps (Manager Process Score)
+    metric: text("metric").notNull(), // draft_score, trade_score, waiver_score, lineup_score, manager_process_score (MPS)
     scope: text("scope").notNull(), // all_time, season:2024, etc
     value: real("value").notNull(),
     percentile: real("percentile"), // 0-100 within league

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -479,7 +479,7 @@ export const managerMetrics = pgTable(
     id: uuid("id").primaryKey().defaultRandom(),
     leagueId: text("league_id").notNull(),
     managerId: text("manager_id").notNull(), // Sleeper user_id
-    metric: text("metric").notNull(), // draft_score, trade_score, waiver_score, lineup_score, overall_score
+    metric: text("metric").notNull(), // draft_score, trade_score, waiver_score, lineup_score, mps (Manager Process Score)
     scope: text("scope").notNull(), // all_time, season:2024, etc
     value: real("value").notNull(),
     percentile: real("percentile"), // 0-100 within league

--- a/src/lib/demoAnonymize.ts
+++ b/src/lib/demoAnonymize.ts
@@ -137,7 +137,7 @@ export function initialsFromName(name: string): string {
 
 export interface ManagerInput {
   userId: string;
-  // overall_score / all_time. null = missing for this manager.
+  // mps / all_time. null = missing for this manager.
   score: number | null;
 }
 

--- a/src/lib/demoAnonymize.ts
+++ b/src/lib/demoAnonymize.ts
@@ -137,7 +137,7 @@ export function initialsFromName(name: string): string {
 
 export interface ManagerInput {
   userId: string;
-  // mps / all_time. null = missing for this manager.
+  // manager_process_score / all_time. null = missing for this manager.
   score: number | null;
 }
 

--- a/src/lib/demoServer.ts
+++ b/src/lib/demoServer.ts
@@ -82,7 +82,7 @@ async function loadDemoInputs(familyId: string): Promise<DemoInputs> {
       .where(
         and(
           inArray(schema.managerMetrics.leagueId, allLeagueIds),
-          eq(schema.managerMetrics.metric, "mps"),
+          eq(schema.managerMetrics.metric, "manager_process_score"),
           eq(schema.managerMetrics.scope, "all_time")
         )
       )

--- a/src/lib/demoServer.ts
+++ b/src/lib/demoServer.ts
@@ -82,7 +82,7 @@ async function loadDemoInputs(familyId: string): Promise<DemoInputs> {
       .where(
         and(
           inArray(schema.managerMetrics.leagueId, allLeagueIds),
-          eq(schema.managerMetrics.metric, "overall_score"),
+          eq(schema.managerMetrics.metric, "mps"),
           eq(schema.managerMetrics.scope, "all_time")
         )
       )

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -47,7 +47,7 @@ export const FLAGS = {
   MANAGER_DNA_PROFILE: {
     id: "manager-dna-profile",
     title: "Manager DNA Profile",
-    description: "Composite DNA score combining draft, trade, and lineup grades",
+    description: "Manager Process Score (MPS) combining draft, trade, waiver, and lineup grades",
     status: "disabled",
     hypothesis:
       "A single composite score increases engagement with individual analytics features by giving managers a 'headline number' to improve",

--- a/src/services/algorithmConfig.ts
+++ b/src/services/algorithmConfig.ts
@@ -56,7 +56,7 @@ export interface AlgorithmConfig {
   // Trade grading config
   defaultRoundAverages: Record<number, number>;
 
-  // Overall score pillar weights
+  // MPS pillar weights
   pillarWeights: {
     trade_score: number;
     draft_score: number;

--- a/src/services/managerGrades.ts
+++ b/src/services/managerGrades.ts
@@ -292,7 +292,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     mpsValues.push({
       leagueId: recentLeagueId,
       managerId,
-      metric: "mps",
+      metric: "manager_process_score",
       scope: "all_time",
       value: mps,
       percentile: 0,
@@ -319,7 +319,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
       .where(
         and(
           eq(schema.managerMetrics.managerId, entry.managerId),
-          eq(schema.managerMetrics.metric, "mps"),
+          eq(schema.managerMetrics.metric, "manager_process_score"),
           eq(schema.managerMetrics.scope, "all_time"),
         ),
       );

--- a/src/services/managerGrades.ts
+++ b/src/services/managerGrades.ts
@@ -57,13 +57,13 @@ function computePercentile(entry: { score: number }, sortedAsc: { score: number 
 
 
 // ============================================================
-// Rollup: all_time per-metric + overall_score
+// Rollup: all_time per-metric + MPS (Manager Process Score)
 // ============================================================
 
 /**
  * Aggregate all season-scoped manager metrics in a league family into
  * `all_time` scores with exponential time-decay weighting, then compute
- * an `overall_score` blending all available metric types.
+ * an `mps` (Manager Process Score) blending all available metric types.
  *
  * Call this after all per-metric grading (lineup, trade, draft, etc.)
  * has written its season-scoped rows.
@@ -216,7 +216,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     for (const entry of sorted) {
       const percentile = computePercentile(entry, sorted);
 
-      // Store percentile in managerAllTime for overall_score computation
+      // Store percentile in managerAllTime for MPS computation
       const mgrMetric = managerAllTime.get(entry.managerId)?.get(metric);
       if (mgrMetric) mgrMetric.percentile = percentile;
 
@@ -241,7 +241,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     }
   }
 
-  // 6. Compute overall_score per manager
+  // 6. Compute MPS per manager
   const managerRecentLeague = new Map<string, string>();
   for (const [key, entries] of grouped) {
     const managerId = key.split("::")[0];
@@ -252,8 +252,8 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     }
   }
 
-  const overallValues: Array<typeof schema.managerMetrics.$inferInsert> = [];
-  const overallScores: Array<{ managerId: string; score: number }> = [];
+  const mpsValues: Array<typeof schema.managerMetrics.$inferInsert> = [];
+  const mpsScores: Array<{ managerId: string; score: number }> = [];
   const mostRecentLeagueId = [...members].sort(
     (a, b) => parseInt(b.season, 10) - parseInt(a.season, 10),
   )[0].leagueId;
@@ -264,7 +264,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     const values = Array.from(metrics.entries());
     if (values.length === 0) continue;
 
-    // Weighted overall_score from pillar percentiles (not raw scores)
+    // Weighted MPS from pillar percentiles (not raw scores)
     // This ensures pillars on different scales contribute equally
     let weightedSum = 0;
     let totalWeight = 0;
@@ -273,7 +273,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
       weightedSum += data.percentile * weight;
       totalWeight += weight;
     }
-    const overallScore =
+    const mps =
       Math.round(
         (totalWeight > 0 ? weightedSum / totalWeight : 0) * 10,
       ) / 10;
@@ -287,17 +287,17 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
       ]),
     );
 
-    overallScores.push({ managerId, score: overallScore });
+    mpsScores.push({ managerId, score: mps });
 
-    overallValues.push({
+    mpsValues.push({
       leagueId: recentLeagueId,
       managerId,
-      metric: "overall_score",
+      metric: "mps",
       scope: "all_time",
-      value: overallScore,
+      value: mps,
       percentile: 0,
       meta: {
-        grade: scoreToGrade(overallScore),
+        grade: scoreToGrade(mps),
         metricBreakdown,
         decayHalflife: DECAY_HALFLIFE_YEARS,
       },
@@ -305,13 +305,13 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
     });
   }
 
-  // Batch upsert overall scores
-  await batchUpsertManagerMetrics(overallValues);
+  // Batch upsert MPS scores
+  await batchUpsertManagerMetrics(mpsValues);
 
-  // 7. Update overall_score percentiles
-  const sortedOverall = [...overallScores].sort((a, b) => a.score - b.score);
-  for (const entry of sortedOverall) {
-    const percentile = computePercentile(entry, sortedOverall);
+  // 7. Update MPS percentiles
+  const sortedMps = [...mpsScores].sort((a, b) => a.score - b.score);
+  for (const entry of sortedMps) {
+    const percentile = computePercentile(entry, sortedMps);
 
     await db
       .update(schema.managerMetrics)
@@ -319,7 +319,7 @@ export async function rollupManagerGrades(familyId: string): Promise<void> {
       .where(
         and(
           eq(schema.managerMetrics.managerId, entry.managerId),
-          eq(schema.managerMetrics.metric, "overall_score"),
+          eq(schema.managerMetrics.metric, "mps"),
           eq(schema.managerMetrics.scope, "all_time"),
         ),
       );

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -570,7 +570,7 @@ export async function syncLeagueFamily(
     });
   }
 
-  // Roll up all_time + overall_score after all per-league grading is done
+  // Roll up all_time + MPS after all per-league grading is done
   if (familyId) {
     onProgress?.({
       step: "manager_grades",


### PR DESCRIPTION
## Summary
- Renames the composite manager metric from `overall_score` to `manager_process_score` in the `manager_metrics` table.
- Closes #41. Unblocks #101 (manager page redesign) which depends on the field name.

## Why this name (not `mps`)
`manager_process_score` keeps the metric value consistent with its siblings — `draft_score`, `trade_score`, `waiver_score`, `lineup_score`. The UI badge still reads "MPS" (it's a label, not a key); JS variables stay short (`mps`, response field `mps`). Storage names and display names are independent decisions.

MOS (Manager Outcome Score) lives in `src/services/outcomeScore.ts` and is computed for experiment validation — it's not stored in this column, so the MPS/MOS abbreviation pairing argument doesn't apply at the storage layer.

## Diff at a glance
- `drizzle/0014_rename_overall_score_to_manager_process_score.sql` — idempotent `UPDATE` of the existing 12 rows
- `drizzle/meta/0014_snapshot.json` + journal entry
- `src/db/schema.ts` — column comment updated
- `src/services/managerGrades.ts` — metric literals + variable names + comments
- `src/services/sync.ts`, `src/services/algorithmConfig.ts` — comment updates
- `src/app/api/leagues/[familyId]/manager/[userId]/route.ts` — query string + response field rename (`overallScore` → `mps`)
- `src/app/(app)/league/[familyId]/manager/[userId]/page.tsx` — destructure + prop rename
- `src/components/ManagerGradeCard.tsx` — prop rename + UI: `"Score:"` → `"MPS:"`, `"No overall score yet"` → `"No MPS yet"`
- `src/lib/demoServer.ts` — query rename
- `src/lib/demoAnonymize.ts`, `src/lib/featureFlags.ts` — comment/description updates

## Production migration
**Heads up**: 0014 was applied to prod earlier in this session by mistake (12 rows already renamed; drizzle journal id=15 records it as applied). This PR brings the code in line with that already-migrated state. After merge + auto-deploy, prod will read `manager_process_score` correctly.

## Test plan
- [x] `npm test` — 75 tests pass.
- [x] `npm run lint` — only pre-existing warnings.
- [x] `npm run build` — clean.
- [x] No remaining `overall_score`/`overallScore` references in `src/` or `drizzle/`.
- [ ] After deploy: manager page MPS card renders for the 12 affected managers.

Closes #41.

🤖 Generated with [Claude Code](https://claude.com/claude-code)