### PR TITLE
chore(manager-api): force fresh Vercel build to pick up rename

### DIFF
--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -170,7 +170,8 @@ export async function GET(
       }
     }
 
-    // Manager Process Score (MPS) — composite all-time score
+    // Manager Process Score (MPS) — composite all-time score.
+    // Stored as `manager_process_score` per #41 (sibling to *_score columns).
     const mpsMetric = myMetrics.find(
       (r) => r.metric === "manager_process_score" && r.scope === "all_time",
     );


### PR DESCRIPTION
## Summary
Trivial comment in the manager route handler to force a fresh Vercel function compile.

## Why
After PR #109 merged the \`overall_score\` → \`manager_process_score\` rename, the deployed prod function on \`dynasty-dna.vercel.app\` has been returning \`mps: null\` for managers who unambiguously have the row in the DB. A debug-instrumented preview deployment built from main returns the correct value, proving the source + DB are right. \`vercel --prod --force\` and \`vercel deploy --prebuilt --prod\` both failed to refresh the prod artifact.

Touching the file in source forces a fresh function compile through Vercel's normal git-driven build pipeline.

## Test plan
- [ ] After merge: smoke \`/api/leagues/{familyId}/manager/{userId}\` — \`mps\` should be populated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)