### PR TITLE
fix(manager-api): force fresh bundle to bypass Vercel cache after MPS rename

### DIFF
--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -6,6 +6,11 @@ import { percentileToGrade } from "@/services/gradingCore";
 import { getDemoSwapForRequest } from "@/lib/demoServer";
 import { lookupSwap } from "@/lib/demoAnonymize";
 
+// Cache-busting marker — Vercel was serving a stale compiled bundle for
+// this route after the overall_score → manager_process_score rename
+// (#41) shipped. Substantial source touch forces a fresh function hash.
+export const dynamic = "force-dynamic";
+
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ familyId: string; userId: string }> },
@@ -172,22 +177,22 @@ export async function GET(
 
     // Manager Process Score (MPS) — composite all-time score.
     // Stored as `manager_process_score` per #41 (sibling to *_score columns).
-    const mpsMetric = myMetrics.find(
-      (r) => r.metric === "manager_process_score" && r.scope === "all_time",
+    const MPS_METRIC = "manager_process_score" as const;
+    const ALL_TIME = "all_time" as const;
+    const mpsRow = myMetrics.find(
+      (r) => r.metric === MPS_METRIC && r.scope === ALL_TIME,
     );
-    const mps = mpsMetric
-      ? {
-          value: mpsMetric.value,
-          grade: percentileToGrade(
-            globalPercentile("manager_process_score", "all_time", mpsMetric.value),
-          ),
-          percentile: globalPercentile(
-            "manager_process_score",
-            "all_time",
-            mpsMetric.value,
-          ),
-        }
+    const mpsPercentile = mpsRow
+      ? globalPercentile(MPS_METRIC, ALL_TIME, mpsRow.value)
       : null;
+    const mps =
+      mpsRow && mpsPercentile !== null
+        ? {
+            value: mpsRow.value,
+            grade: percentileToGrade(mpsPercentile),
+            percentile: mpsPercentile,
+          }
+        : null;
 
     // Season history — group season-scoped metrics by season
     const seasonMetrics = myMetrics.filter((r) =>


### PR DESCRIPTION
## Summary
Substantively restructures the manager API's MPS lookup to force Vercel to compile a different function bundle hash. Behavior is unchanged.

## Why
After PR #109 renamed the metric \`overall_score\` → \`manager_process_score\`, the deployed production bundle for \`/api/leagues/[familyId]/manager/[userId]\` kept returning \`mps:null\` even though:

- Source on main queries the new metric name correctly (verified via \`git show\`)
- Local builds produce bundles with the correct string (\`manager_process_score: 4\`, \`"mps": 0\`)
- The DB has the row (verified by direct query and a debug-instrumented preview deployment)
- A new route at \`/api/debug-mps-check\` deployed in the **same Vercel deployment** queries \`manager_process_score\` and returns 12 rows correctly

That last point is the smoking gun: the same prod deployment, same DB connection, same drizzle, same metric string — but the **specific route path** \`/manager/[userId]\` serves a stale function bundle. The new route path doesn't, because it bypasses whatever Vercel cached. We tried \`--force\`, \`--prebuilt\`, full nuke + clean install, and a trivial comment touch (PR #110) — none invalidated.

## What this PR changes (behavior-equivalent)
- Extract \`MPS_METRIC\` and \`ALL_TIME\` as inline \`as const\` literals and hoist the percentile calculation into its own variable
- Add \`export const dynamic = "force-dynamic"\` (the route always touched the DB anyway; this just makes it explicit)
- Restructured ternary changes the bundle's minified shape, hopefully enough to force a fresh Vercel function hash

The compiled output now has different variable names, different statement ordering, and different export metadata — should produce a different content hash than the cached version.

## Test plan
- [x] \`npm test\` — 75 pass
- [x] \`npm run lint\` — pre-existing warnings only
- [x] \`npm run build\` — clean
- [x] Built bundle still grep-shows \`manager_process_score\`
- [ ] After merge + auto-deploy: prod manager API returns \`mps\` populated. If it still doesn't, the cache bust didn't work and we'll need a more drastic intervention (route URL change or Vercel project rebuild).

🤖 Generated with [Claude Code](https://claude.com/claude-code)