### PR TITLE
fix(db): opt neon-http out of Next.js Data Cache (root cause of MPS staleness)

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -20,7 +20,13 @@ const globalForDb = globalThis as unknown as {
 
 export function getDb() {
   if (!globalForDb.dbInstance) {
-    const sql = neon(getDbUrl());
+    // `cache: "no-store"` opts every neon-http request out of Next.js's
+    // Data Cache. Without this, fetch() responses from neon's HTTP
+    // endpoint get cached indefinitely on Production deployments
+    // (preview deployments don't enable the Data Cache, which is why
+    // they showed fresh DB rows while production served stale ones —
+    // see #41 / Vercel debugging session, May 2026).
+    const sql = neon(getDbUrl(), { fetchOptions: { cache: "no-store" } });
     globalForDb.dbInstance = drizzle(sql, { schema });
   }
   return globalForDb.dbInstance;


### PR DESCRIPTION
## Summary
Adds \`cache: "no-store"\` to the neon-http driver config in \`src/db/index.ts\` so every DB query bypasses Next.js's Data Cache. **This is the root cause of the prod manager-page MPS bug.**

## Diagnosis
Production deployments were serving stale DB query results because:

1. \`@neondatabase/serverless\`'s \`neon()\` function uses \`fetch()\` to call Neon's HTTP query endpoint.
2. Next.js's Data Cache **automatically caches fetch() responses indefinitely** on Production deployments.
3. Preview deployments don't enable the Data Cache (Vercel's default), which is why preview always worked while prod was broken.
4. The cached snapshot pre-dated the \`overall_score\` → \`manager_process_score\` migration. So drizzle queries returned the OLD row state for as long as the cache lived, regardless of how many times we redeployed the function code.

Confirmed earlier today by deploying instrumented code as both Preview and Production targets:

| | Preview | Production |
|---|---|---|
| codeMarker | \`v2-inspect-runtime-2026-05-03\` | \`v2-inspect-runtime-2026-05-03\` (same code) |
| myMetricsAllTime metric values | \`manager_process_score\` ✓ | \`overall_score\` ✗ (pre-migration!) |
| mpsRowFound | true | false |
| mps in response | \`{value: 63.6, ...}\` | null |

The deployed function on prod was running the latest code, querying for \`manager_process_score\`, but receiving rows where \`metric='overall_score'\` from the cached fetch — because the Data Cache snapshot was taken before the migration.

## Why this fix
For a data-fetching app where rows can change at any time and we have no per-query cache invalidation, \`cache: "no-store"\` is the right default. Specific routes that benefit from caching can opt back in via \`unstable_cache()\` wrappers when we have the invalidation story sorted out.

## Test plan
- [x] \`npm test\` — 75 pass
- [x] \`npm run lint\` — pre-existing warnings only
- [x] \`npm run build\` — clean
- [ ] After merge: prod \`/api/leagues/.../manager/{userId}\` (or the \`-grades\` rename) returns populated \`mps\`
- [ ] Manager page renders MPS card

## Cleanup follow-ups (separate)
- Revert the \`/manager-grades\` URL rename (PR #113) — that was a workaround that's no longer needed, can move back to \`/manager/[userId]\` once the cache fix is live and verified
- Drop the \`force-dynamic\` export from the manager route — was added to bust suspected route cache, no longer needed
- Drop the \`(routes)\` route group — not needed for cache-busting

🤖 Generated with [Claude Code](https://claude.com/claude-code)