### PR TITLE
cleanup: revert manager API URL workarounds now that Data Cache is opted out

### DIFF
--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -54,7 +54,7 @@ export default function ManagerPage() {
     async function loadData() {
       setLoading(true);
       try {
-        const res = await fetch(`/api/leagues/${familyId}/manager-grades/${userId}`);
+        const res = await fetch(`/api/leagues/${familyId}/manager/${userId}`);
         if (res.ok) {
           setData(await res.json());
         }

--- a/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
+++ b/src/app/api/leagues/[familyId]/manager/[userId]/route.ts
@@ -6,11 +6,6 @@ import { percentileToGrade } from "@/services/gradingCore";
 import { getDemoSwapForRequest } from "@/lib/demoServer";
 import { lookupSwap } from "@/lib/demoAnonymize";
 
-// Cache-busting marker — Vercel was serving a stale compiled bundle for
-// this route after the overall_score → manager_process_score rename
-// (#41) shipped. Substantial source touch forces a fresh function hash.
-export const dynamic = "force-dynamic";
-
 export async function GET(
   req: NextRequest,
   { params }: { params: Promise<{ familyId: string; userId: string }> },
@@ -177,22 +172,22 @@ export async function GET(
 
     // Manager Process Score (MPS) — composite all-time score.
     // Stored as `manager_process_score` per #41 (sibling to *_score columns).
-    const MPS_METRIC = "manager_process_score" as const;
-    const ALL_TIME = "all_time" as const;
-    const mpsRow = myMetrics.find(
-      (r) => r.metric === MPS_METRIC && r.scope === ALL_TIME,
+    const mpsMetric = myMetrics.find(
+      (r) => r.metric === "manager_process_score" && r.scope === "all_time",
     );
-    const mpsPercentile = mpsRow
-      ? globalPercentile(MPS_METRIC, ALL_TIME, mpsRow.value)
+    const mps = mpsMetric
+      ? {
+          value: mpsMetric.value,
+          grade: percentileToGrade(
+            globalPercentile("manager_process_score", "all_time", mpsMetric.value),
+          ),
+          percentile: globalPercentile(
+            "manager_process_score",
+            "all_time",
+            mpsMetric.value,
+          ),
+        }
       : null;
-    const mps =
-      mpsRow && mpsPercentile !== null
-        ? {
-            value: mpsRow.value,
-            grade: percentileToGrade(mpsPercentile),
-            percentile: mpsPercentile,
-          }
-        : null;
 
     // Season history — group season-scoped metrics by season
     const seasonMetrics = myMetrics.filter((r) =>


### PR DESCRIPTION
## Summary
PR #114 fixed the actual root cause of the prod MPS staleness (drizzle/neon-http fetch responses being cached indefinitely by Next.js's Data Cache on Production). The intermediate workarounds across PRs #110-113 are no longer needed.

## Reverts
- Move route file back to canonical \`/manager/[userId]\` (was \`/manager-grades/[userId]\` per PR #113)
- Drop the \`(routes)\` route group (PR #112)
- Drop \`export const dynamic = "force-dynamic"\` (PR #111)
- Restore simpler inline-string MPS lookup (was hoisted to \`MPS_METRIC\`/\`ALL_TIME\` constants for cache-busting in PR #111)
- Update the page consumer back to \`/manager/\${userId}\`

Net code removal. Canonical URL restored.

## Test plan
- [x] \`npm test\` — 75 pass
- [x] \`npm run lint\` — pre-existing warnings only
- [x] \`npm run build\` — clean
- [x] \`grep manager-grades src/\` returns nothing
- [ ] After merge: prod \`/api/leagues/.../manager/{userId}\` returns populated mps (will work because the Data Cache opt-out from #114 is now the universal default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)