### PR TITLE
Player page: header redesign + collapsible season×manager game log (#91, #90)

### DIFF
--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -3,7 +3,7 @@
 import { Fragment, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
+import { ArrowLeft, ChevronDown, GitBranch } from "lucide-react";
 import {
   ManagerName,
   ManagerAvatar,
@@ -162,30 +162,91 @@ export default function PlayerDetailPage() {
     if (filteredWeeks.length === 0) return null;
     const totalWeeks = filteredWeeks.length;
     const starterWeeks = filteredWeeks.filter((w) => w.fantasyStatus === "starter").length;
-    const benchWeeks = totalWeeks - starterWeeks;
     const totalPoints = filteredWeeks.reduce((sum, w) => sum + w.points, 0);
-    const starterPoints = filteredWeeks
-      .filter((w) => w.fantasyStatus === "starter")
-      .reduce((sum, w) => sum + w.points, 0);
     const ppgAll = totalPoints / totalWeeks;
-    const ppgStarter = starterWeeks > 0 ? starterPoints / starterWeeks : 0;
-
-    return { totalWeeks, starterWeeks, benchWeeks, totalPoints, ppgAll, ppgStarter };
+    return { totalWeeks, starterWeeks, ppgAll };
   }, [filteredWeeks]);
 
-  // Group weeks by season for dividers
-  const groupedWeeks = useMemo(() => {
-    const groups: { season: string; weeks: WeekEntry[] }[] = [];
-    let currentSeason = "";
+  // Group filtered weeks by (season, manager). Each stint is the unit of
+  // analysis on a player page: "what did this player do for THIS manager in
+  // THIS season". Multi-manager seasons (mid-season trades) get one row per
+  // manager.
+  const seasonGroups = useMemo(() => {
+    type Stint = {
+      key: string;
+      season: string;
+      managerUserId: string | null;
+      managerDisplayName: string | null;
+      managerRosterId: number | null;
+      weeks: WeekEntry[];
+      totalWeeks: number;
+      starterWeeks: number;
+      totalPoints: number;
+      ppgAll: number;
+      ppgStarter: number;
+    };
+    const map = new Map<string, Map<string, Stint>>();
     for (const w of filteredWeeks) {
-      if (w.season !== currentSeason) {
-        currentSeason = w.season;
-        groups.push({ season: currentSeason, weeks: [] });
+      const userKey = w.manager?.userId ?? "__unrostered";
+      if (!map.has(w.season)) map.set(w.season, new Map());
+      const seasonMap = map.get(w.season)!;
+      if (!seasonMap.has(userKey)) {
+        seasonMap.set(userKey, {
+          key: `${w.season}|${userKey}`,
+          season: w.season,
+          managerUserId: w.manager?.userId ?? null,
+          managerDisplayName: w.manager?.displayName ?? null,
+          managerRosterId: w.manager?.rosterId ?? null,
+          weeks: [],
+          totalWeeks: 0,
+          starterWeeks: 0,
+          totalPoints: 0,
+          ppgAll: 0,
+          ppgStarter: 0,
+        });
       }
-      groups[groups.length - 1].weeks.push(w);
+      seasonMap.get(userKey)!.weeks.push(w);
     }
-    return groups;
+    for (const seasonMap of map.values()) {
+      for (const stint of seasonMap.values()) {
+        stint.totalWeeks = stint.weeks.length;
+        stint.starterWeeks = stint.weeks.filter(
+          (w) => w.fantasyStatus === "starter"
+        ).length;
+        stint.totalPoints = stint.weeks.reduce((s, w) => s + w.points, 0);
+        stint.ppgAll = stint.totalWeeks
+          ? stint.totalPoints / stint.totalWeeks
+          : 0;
+        const starterPoints = stint.weeks
+          .filter((w) => w.fantasyStatus === "starter")
+          .reduce((s, w) => s + w.points, 0);
+        stint.ppgStarter = stint.starterWeeks
+          ? starterPoints / stint.starterWeeks
+          : 0;
+      }
+    }
+    return [...map.entries()]
+      .sort(([a], [b]) => parseInt(b, 10) - parseInt(a, 10))
+      .map(([season, stintMap]) => ({
+        season,
+        stints: [...stintMap.values()].sort(
+          (a, b) => b.totalPoints - a.totalPoints
+        ),
+      }));
   }, [filteredWeeks]);
+
+  const allStintKeys = useMemo(
+    () => seasonGroups.flatMap((g) => g.stints.map((s) => s.key)),
+    [seasonGroups]
+  );
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
+  const toggleStint = (key: string) =>
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
 
   if (loading) {
     return (
@@ -218,7 +279,7 @@ export default function PlayerDetailPage() {
   return (
       <div>
         <div className="border-b">
-          <div className="container mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-4">
+          <div className="container mx-auto px-4 sm:px-6 py-3">
             <Link
               href={`/league/${familyId}`}
               className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
@@ -226,15 +287,6 @@ export default function PlayerDetailPage() {
               <ArrowLeft className="h-4 w-4" />
               League
             </Link>
-            {graphEnabled && (
-              <Link
-                href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
-                className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
-              >
-                Trace lineage
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            )}
           </div>
         </div>
 
@@ -262,6 +314,15 @@ export default function PlayerDetailPage() {
                   </>
                 )}
               </div>
+              {graphEnabled && (
+                <Link
+                  href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
+                  className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-full bg-primary/10 text-primary hover:bg-primary/15 transition-colors"
+                >
+                  <GitBranch className="h-3.5 w-3.5" />
+                  Trace lineage
+                </Link>
+              )}
             </div>
 
             <CurrentManagerBlock
@@ -274,13 +335,10 @@ export default function PlayerDetailPage() {
         <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
         {/* Summary Stats */}
         {stats && (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
+          <div className="grid grid-cols-3 gap-3 sm:gap-4 mb-8">
             <StatCard label="Weeks Rostered" value={stats.totalWeeks} />
             <StatCard label="Weeks Started" value={stats.starterWeeks} />
-            <StatCard label="Weeks Benched" value={stats.benchWeeks} />
-            <StatCard label="Total Points" value={stats.totalPoints.toFixed(1)} />
-            <StatCard label="PPG (Started)" value={stats.ppgStarter.toFixed(1)} />
-            <StatCard label="PPG (All)" value={stats.ppgAll.toFixed(1)} />
+            <StatCard label="PPG" value={stats.ppgAll.toFixed(1)} />
           </div>
         )}
 
@@ -355,86 +413,136 @@ export default function PlayerDetailPage() {
           </div>
         </div>
 
-        {/* Weekly Log Table */}
+        {/* Weekly Log: collapsible (season, manager) groups */}
         {filteredWeeks.length === 0 ? (
           <p className="text-muted-foreground text-center py-8">
             No weekly data found for this player
           </p>
         ) : (
-          <div className="border rounded-lg overflow-x-auto">
-            <table className="w-full min-w-[480px]">
-              <thead className="bg-muted/50">
-                <tr className="text-left text-sm">
-                  <th className="px-4 py-3 font-medium">Week</th>
-                  <th className="px-4 py-3 font-medium">Manager</th>
-                  <th className="px-4 py-3 font-medium">Lineup</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium text-right">Points</th>
-                </tr>
-              </thead>
-              <tbody>
-                {groupedWeeks.map((group) => (
-                  <Fragment key={`group-${group.season}`}>
-                    {/* Season divider */}
-                    {data.availableSeasons.length > 1 && (
-                      <tr>
-                        <td
-                          colSpan={5}
-                          className="px-4 py-2 bg-muted/30 text-xs font-semibold text-muted-foreground uppercase tracking-wider"
-                        >
-                          {group.season} Season
-                        </td>
-                      </tr>
-                    )}
-                    {group.weeks.map((w) => {
-                      const badge = fantasyStatusBadge(w);
+          <>
+            <div className="flex items-center justify-end gap-3 mb-3 text-xs">
+              <button
+                type="button"
+                onClick={() => setExpandedKeys(new Set(allStintKeys))}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Expand all
+              </button>
+              <span aria-hidden className="text-muted-foreground/40">|</span>
+              <button
+                type="button"
+                onClick={() => setExpandedKeys(new Set())}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+              >
+                Collapse all
+              </button>
+            </div>
+
+            <div className="space-y-5">
+              {seasonGroups.map((group) => (
+                <section key={group.season}>
+                  <h3 className="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-2 px-1">
+                    {group.season} Season
+                  </h3>
+                  <div className="border rounded-lg overflow-hidden bg-card">
+                    {group.stints.map((stint, idx) => {
+                      const expanded = expandedKeys.has(stint.key);
                       return (
-                        <tr
-                          key={`${w.leagueId}-${w.season}-${w.week}`}
-                          className="border-t hover:bg-muted/30 transition-colors"
-                        >
-                          <td className="px-4 py-3 text-sm font-mono">
-                            W{w.week}
-                          </td>
-                          <td className="px-4 py-3 text-sm">
-                            {w.manager ? (
-                              <ManagerName
-                                userId={w.manager.userId}
-                                rosterId={w.manager.rosterId}
-                                displayName={w.manager.displayName}
-                                variant="display-only"
-                                fallback="—"
-                              />
-                            ) : (
-                              "—"
-                            )}
-                          </td>
-                          <td className="px-4 py-3">
-                            <span
-                              className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${badge.className}`}
-                            >
-                              {badge.label}
-                            </span>
-                          </td>
-                          <td className="px-4 py-3">
-                            <span className={`text-sm ${nflStatusColor(w.nflStatus, w.isByeWeek)}`}>
-                              {nflStatusLabel(w.nflStatus, w.isByeWeek)}
-                            </span>
-                          </td>
-                          <td className="px-4 py-3 text-right font-mono text-sm">
-                            {w.points.toFixed(1)}
-                          </td>
-                        </tr>
+                        <Fragment key={stint.key}>
+                          <button
+                            type="button"
+                            onClick={() => toggleStint(stint.key)}
+                            className={`w-full px-3 sm:px-4 py-3 flex items-center gap-3 text-left hover:bg-muted/30 transition-colors ${
+                              idx > 0 ? "border-t" : ""
+                            }`}
+                            aria-expanded={expanded}
+                          >
+                            <ChevronDown
+                              className={`h-4 w-4 text-muted-foreground transition-transform shrink-0 ${
+                                expanded ? "" : "-rotate-90"
+                              }`}
+                            />
+                            <div className="flex-1 min-w-0">
+                              <div className="font-medium truncate">
+                                {stint.managerDisplayName ?? "Unrostered"}
+                              </div>
+                              <div className="mt-0.5 text-xs text-muted-foreground font-mono flex flex-wrap gap-x-3 gap-y-0.5">
+                                <span>{stint.totalWeeks} wks</span>
+                                <span>{stint.starterWeeks} started</span>
+                                <span>{stint.totalPoints.toFixed(1)} pts</span>
+                                <span>{stint.ppgAll.toFixed(1)} ppg</span>
+                              </div>
+                            </div>
+                          </button>
+                          {expanded && <WeeklyDetail weeks={stint.weeks} />}
+                        </Fragment>
                       );
                     })}
-                  </Fragment>
-                ))}
-              </tbody>
-            </table>
-          </div>
+                  </div>
+                </section>
+              ))}
+            </div>
+          </>
         )}
       </main>
       </div>
+  );
+}
+
+function WeeklyDetail({ weeks }: { weeks: WeekEntry[] }) {
+  return (
+    <div className="border-t bg-muted/10 overflow-x-auto">
+      <table className="w-full text-sm border-collapse">
+        <thead className="bg-muted/30 text-left">
+          <tr>
+            <th className="sticky left-0 z-10 bg-muted/30 px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide shadow-[1px_0_0_0_var(--border)]">
+              Week
+            </th>
+            <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide">
+              Lineup
+            </th>
+            <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide">
+              Status
+            </th>
+            <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide text-right">
+              Points
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {weeks.map((w) => {
+            const badge = fantasyStatusBadge(w);
+            return (
+              <tr
+                key={`${w.leagueId}-${w.season}-${w.week}`}
+                className="border-t border-border/60"
+              >
+                <td className="sticky left-0 z-10 bg-card px-3 py-2 font-mono shadow-[1px_0_0_0_var(--border)]">
+                  W{w.week}
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${badge.className}`}
+                  >
+                    {badge.label}
+                  </span>
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`${nflStatusColor(w.nflStatus, w.isByeWeek)}`}
+                  >
+                    {nflStatusLabel(w.nflStatus, w.isByeWeek)}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right font-mono">
+                  {w.points.toFixed(1)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
   );
 }
 

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -4,7 +4,11 @@ import { Fragment, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, ArrowRight } from "lucide-react";
-import { ManagerName } from "@/components/ManagerName";
+import {
+  ManagerName,
+  ManagerAvatar,
+  ManagerSecondaryName,
+} from "@/components/ManagerName";
 import { useFlag } from "@/lib/useFlag";
 
 interface Manager {
@@ -31,6 +35,19 @@ interface PlayerInfo {
   position: string | null;
   team: string | null;
   gsisId: string | null;
+  age: number | null;
+  yearsExp: number | null;
+  status: string | null;
+  injuryStatus: string | null;
+}
+
+interface CurrentManager {
+  userId: string;
+  rosterId: number;
+  displayName: string;
+  teamName: string | null;
+  avatar: string | null;
+  rosteredSince: { season: string; week: number } | null;
 }
 
 interface WeeklyLogData {
@@ -38,6 +55,19 @@ interface WeeklyLogData {
   weeks: WeekEntry[];
   managers: Manager[];
   availableSeasons: string[];
+  currentManager: CurrentManager | null;
+}
+
+// Injury detail (Out/Doubtful/Questionable) takes priority over roster status:
+// it's the more actionable signal for fantasy decisions.
+function playerStatusLabel(
+  status: string | null,
+  injuryStatus: string | null
+): string | null {
+  if (injuryStatus) return injuryStatus;
+  if (status === "Injured Reserve") return "IR";
+  if (status === "Inactive") return "Inactive";
+  return null;
 }
 
 function nflStatusLabel(status: string | null, isByeWeek: boolean): string {
@@ -173,12 +203,22 @@ export default function PlayerDetailPage() {
     );
   }
 
-  const { player } = data;
+  const { player, currentManager } = data;
+  const statusLabel = playerStatusLabel(player.status, player.injuryStatus);
+  const metaParts: string[] = [];
+  if (player.position) metaParts.push(player.position);
+  if (player.team) metaParts.push(player.team);
+  if (player.age != null) metaParts.push(`${player.age} yo`);
+  if (player.yearsExp != null) {
+    metaParts.push(
+      player.yearsExp === 0 ? "Rookie" : `${player.yearsExp}y exp`
+    );
+  }
 
   return (
       <div>
         <div className="border-b">
-          <div className="container mx-auto px-6 py-3 flex items-center gap-4">
+          <div className="container mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-4">
             <Link
               href={`/league/${familyId}`}
               className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
@@ -186,27 +226,52 @@ export default function PlayerDetailPage() {
               <ArrowLeft className="h-4 w-4" />
               League
             </Link>
-            <div className="flex-1">
-              <h1 className="text-lg font-semibold">{player.name}</h1>
-              <div className="text-sm text-muted-foreground">
-                {player.position} {player.team ? `— ${player.team}` : ""}
-              </div>
-            </div>
-            <div className="flex items-center gap-4 ml-auto">
-              {graphEnabled && (
-                <Link
-                  href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
-                  className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
-                >
-                  Trace lineage
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-              )}
-            </div>
+            {graphEnabled && (
+              <Link
+                href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
+                className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
+              >
+                Trace lineage
+                <ArrowRight className="h-4 w-4" />
+              </Link>
+            )}
           </div>
         </div>
 
-        <main className="container mx-auto px-6 py-8">
+        <div className="border-b bg-card">
+          <div className="container mx-auto px-4 sm:px-6 py-5 sm:py-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-6">
+            <div className="min-w-0">
+              <h1 className="text-2xl sm:text-3xl font-semibold tracking-tight truncate">
+                {player.name}
+              </h1>
+              <div className="mt-1 text-sm text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1">
+                {metaParts.map((part, i) => (
+                  <Fragment key={`meta-${i}`}>
+                    {i > 0 && <span aria-hidden className="text-muted-foreground/50">·</span>}
+                    <span>{part}</span>
+                  </Fragment>
+                ))}
+                {statusLabel && (
+                  <>
+                    {metaParts.length > 0 && (
+                      <span aria-hidden className="text-muted-foreground/50">·</span>
+                    )}
+                    <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-grade-d/10 text-grade-d">
+                      {statusLabel}
+                    </span>
+                  </>
+                )}
+              </div>
+            </div>
+
+            <CurrentManagerBlock
+              familyId={familyId}
+              currentManager={currentManager}
+            />
+          </div>
+        </div>
+
+        <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
         {/* Summary Stats */}
         {stats && (
           <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
@@ -223,7 +288,7 @@ export default function PlayerDetailPage() {
         <div className="flex flex-wrap gap-4 mb-6">
           {/* Season filter */}
           {data.availableSeasons.length > 1 && (
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <FilterButton
                 active={!selectedSeason}
                 onClick={() => setSelectedSeason(null)}
@@ -244,7 +309,7 @@ export default function PlayerDetailPage() {
 
           {/* Manager filter */}
           {data.managers.length > 1 && (
-            <div className="flex gap-2">
+            <div className="flex flex-wrap gap-2">
               <FilterButton
                 active={!selectedManager}
                 onClick={() => setSelectedManager(null)}
@@ -268,7 +333,7 @@ export default function PlayerDetailPage() {
           )}
 
           {/* Status filter */}
-          <div className="flex gap-2">
+          <div className="flex flex-wrap gap-2">
             <FilterButton
               active={selectedStatus === "all"}
               onClick={() => setSelectedStatus("all")}
@@ -296,14 +361,14 @@ export default function PlayerDetailPage() {
             No weekly data found for this player
           </p>
         ) : (
-          <div className="border rounded-lg overflow-hidden">
-            <table className="w-full">
+          <div className="border rounded-lg overflow-x-auto">
+            <table className="w-full min-w-[480px]">
               <thead className="bg-muted/50">
                 <tr className="text-left text-sm">
                   <th className="px-4 py-3 font-medium">Week</th>
                   <th className="px-4 py-3 font-medium">Manager</th>
+                  <th className="px-4 py-3 font-medium">Lineup</th>
                   <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium">NFL</th>
                   <th className="px-4 py-3 font-medium text-right">Points</th>
                 </tr>
               </thead>
@@ -370,6 +435,60 @@ export default function PlayerDetailPage() {
         )}
       </main>
       </div>
+  );
+}
+
+function CurrentManagerBlock({
+  familyId,
+  currentManager,
+}: {
+  familyId: string;
+  currentManager: CurrentManager | null;
+}) {
+  if (!currentManager) {
+    return (
+      <div className="md:text-right text-sm text-muted-foreground inline-flex md:flex-col md:items-end items-center gap-1">
+        <span className="uppercase tracking-wide text-[11px] font-mono text-muted-foreground/70">
+          Currently
+        </span>
+        <span>Free agent</span>
+      </div>
+    );
+  }
+
+  const teamLabel = currentManager.teamName || currentManager.displayName;
+
+  return (
+    <Link
+      href={`/league/${familyId}/manager/${currentManager.userId}`}
+      className="group flex items-center md:flex-row-reverse gap-3 rounded-lg p-2 -m-2 hover:bg-muted/50 transition-colors min-w-0"
+    >
+      <ManagerAvatar
+        displayName={currentManager.displayName}
+        avatarUrl={currentManager.avatar}
+        size={44}
+      />
+      <div className="min-w-0 md:text-right">
+        <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
+          Currently rostered by
+        </div>
+        <div className="font-semibold text-foreground truncate group-hover:text-primary transition-colors">
+          {teamLabel}
+        </div>
+        <ManagerSecondaryName
+          displayName={currentManager.displayName}
+          teamName={currentManager.teamName}
+          parens={false}
+          className="block text-xs text-muted-foreground truncate"
+        />
+        {currentManager.rosteredSince && (
+          <div className="text-xs text-muted-foreground mt-0.5">
+            Since W{currentManager.rosteredSince.week}{" "}
+            {currentManager.rosteredSince.season}
+          </div>
+        )}
+      </div>
+    </Link>
   );
 }
 

--- a/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
+++ b/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
@@ -368,7 +368,10 @@ export async function GET(
       const displayName =
         swapped?.displayName ?? userRow?.displayName ?? owningRoster.ownerId;
       const teamName = swapped?.teamName ?? userRow?.teamName ?? null;
-      const avatar = demoSwap ? null : userRow?.avatar ?? null;
+      const avatarHash = demoSwap ? null : userRow?.avatar ?? null;
+      const avatar = avatarHash
+        ? `https://sleepercdn.com/avatars/thumbs/${avatarHash}`
+        : null;
 
       const sortedDesc = [...weeks].sort((a, b) => {
         const seasonDiff = parseInt(b.season, 10) - parseInt(a.season, 10);

--- a/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
+++ b/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
@@ -71,6 +71,10 @@ export async function GET(
         position: playerRows[0].position,
         team: playerRows[0].team,
         gsisId: playerRows[0].gsisId,
+        age: playerRows[0].age,
+        yearsExp: playerRows[0].yearsExp,
+        status: playerRows[0].status,
+        injuryStatus: playerRows[0].injuryStatus,
       }
     : null;
 
@@ -330,10 +334,72 @@ export async function GET(
     ...new Set(members.map((m) => m.season)),
   ].sort((a, b) => parseInt(b, 10) - parseInt(a, 10));
 
+  let currentManager: {
+    userId: string;
+    rosterId: number;
+    displayName: string;
+    teamName: string | null;
+    avatar: string | null;
+    rosteredSince: { season: string; week: number } | null;
+  } | null = null;
+
+  const sortedMembers = [...members].sort(
+    (a, b) => parseInt(b.season, 10) - parseInt(a.season, 10)
+  );
+  const currentLeagueId = sortedMembers[0]?.leagueId;
+
+  if (currentLeagueId) {
+    const currentLeagueRosters = rosterRows.filter(
+      (r) => r.leagueId === currentLeagueId
+    );
+    const owningRoster = currentLeagueRosters.find((r) => {
+      const players = (r.players as string[] | null) ?? [];
+      return players.includes(playerId);
+    });
+
+    if (owningRoster?.ownerId) {
+      const userRow = userRows.find(
+        (u) =>
+          u.leagueId === currentLeagueId && u.userId === owningRoster.ownerId
+      );
+      const swapped = demoSwap
+        ? lookupSwap(demoSwap, owningRoster.ownerId)
+        : undefined;
+      const displayName =
+        swapped?.displayName ?? userRow?.displayName ?? owningRoster.ownerId;
+      const teamName = swapped?.teamName ?? userRow?.teamName ?? null;
+      const avatar = demoSwap ? null : userRow?.avatar ?? null;
+
+      const sortedDesc = [...weeks].sort((a, b) => {
+        const seasonDiff = parseInt(b.season, 10) - parseInt(a.season, 10);
+        if (seasonDiff !== 0) return seasonDiff;
+        return b.week - a.week;
+      });
+      let rosteredSince: { season: string; week: number } | null = null;
+      for (const w of sortedDesc) {
+        if (w.manager?.userId === owningRoster.ownerId) {
+          rosteredSince = { season: w.season, week: w.week };
+        } else {
+          break;
+        }
+      }
+
+      currentManager = {
+        userId: owningRoster.ownerId,
+        rosterId: owningRoster.rosterId,
+        displayName,
+        teamName,
+        avatar,
+        rosteredSince,
+      };
+    }
+  }
+
   return NextResponse.json({
     player,
     weeks,
     managers: Array.from(managersMap.values()),
     availableSeasons,
+    currentManager,
   });
 }


### PR DESCRIPTION
## Summary

Redesigns the player page header (#91) and the weekly log (#90) together — folded in after PR review since the structural pattern from #90 was needed to address feedback on #91.

### Header (#91)
- **Hero**: stacks vertically on mobile, side-by-side on md+. Player name + meta (`position · team · age yo · Xy exp` + non-Active status badge) on the left, current-manager block on the right.
- **Avatar fix**: API now returns the full sleepercdn URL (was just a hash, so `<img>` was broken).
- **Lineage Tracer entry point** promoted from a small sub-header link to a sage-styled pill button in the hero next to the meta.
- **Empty state**: "Currently / Free agent" when no current owner.
- **Top stats trimmed** from 6 cards to 3: Weeks Rostered, Weeks Started, PPG. (Bench/total/started-PPG removed — table now provides per-stint detail.)

### Game log (#90)
- **One row per (season, manager)** by default — aggregate `{weeks, started, total pts, ppg}` per stint.
- Click → expands to weekly detail beneath.
- **Expand all / Collapse all** controls.
- **Weekly subtable** has a **sticky-left Week column** so when horizontal scroll kicks in (long status labels, narrow viewport), the row label stays pinned. Season label sits above each group as a section header.
- Weekly detail headers renamed: `Status` → `Lineup`, `NFL` → `Status` (longstanding column-label bug from #91).

### API
- `weekly-log` returns `currentManager` (resolved against `rosters.players` in the most recent league of the family) including `rosteredSince` stint boundary, plus `age`/`yearsExp`/`status`/`injuryStatus` on the player payload.

Closes #91, closes #90.

## Test plan

- [x] `npm run build` clean
- [x] `npm run lint` clean (only pre-existing warnings)
- [x] Desktop (1280px): hero side-by-side, avatar loads (sleepercdn URL), 3 stat cards, 3 season groups for Michael Wilson with aggregate stats, expand toggles weekly subtable
- [x] Mobile (360px iframe): hero stacks, avatar loads, page no horizontal overflow, weekly subtable sticky-left Week column with `position: sticky; left: 0px`
- [x] Empty state: Justin Tucker (unrostered) renders "Currently / Free agent"
- [x] Expand all → all 3 stints expanded; Collapse all → all collapsed
- [x] Lineage Tracer pill button visible and clickable
- [ ] Vercel preview spot-check on a real device

🤖 Generated with [Claude Code](https://claude.com/claude-code)