### PR TITLE
feat(league): default to all-time standings with championship trophies (#103)

### DIFF
--- a/src/app/(app)/league/[familyId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/page.tsx
@@ -147,9 +147,6 @@ export default function LeagueOverviewPage() {
             <h1 className="text-base sm:text-lg font-semibold truncate">
               {data.league.name}
             </h1>
-            <span className="text-sm text-muted-foreground shrink-0">
-              {isAllTime ? "All-time" : data.league.season}
-            </span>
           </div>
           <div className="flex items-center gap-2 sm:gap-3 shrink-0">
             <Link

--- a/src/app/(app)/league/[familyId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { useParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { ArrowLeft, Network } from "lucide-react";
 import {
@@ -9,6 +9,7 @@ import {
   type RosterGrade,
 } from "@/components/LineupEfficiencyCard";
 import { ManagerName, ManagerSecondaryName } from "@/components/ManagerName";
+import { ChampionshipTrophies } from "@/components/ChampionshipTrophy";
 import { useFlag } from "@/lib/useFlag";
 
 interface Roster {
@@ -19,11 +20,13 @@ interface Roster {
   ties: number;
   fpts: number;
   fptsAgainst: number;
+  seasonsPlayed: number;
+  championshipYears: string[];
 }
 
 interface LeagueUser {
   userId: string;
-  displayName: string;
+  displayName: string | null;
   teamName: string | null;
   avatar: string | null;
 }
@@ -33,42 +36,45 @@ interface LeagueOverviewData {
     id: string;
     name: string;
     season: string;
-    totalRosters: number;
-    status: string;
+    totalRosters: number | null;
+    status: string | null;
   };
-  familyId: string;
+  familyId: string | null;
   seasons: Array<{ leagueId: string; season: string }>;
   rosters: Roster[];
   users: LeagueUser[];
 }
 
+const ALL_TIME = "all";
+
 export default function LeagueOverviewPage() {
   const params = useParams();
+  const router = useRouter();
+  const searchParams = useSearchParams();
   const familyId = params.familyId as string;
+  const seasonParam = searchParams.get("season") ?? ALL_TIME;
+  const isAllTime = seasonParam === ALL_TIME;
   const [data, setData] = useState<LeagueOverviewData | null>(null);
   const [loading, setLoading] = useState(true);
   const [autoSyncing, setAutoSyncing] = useState(false);
-  const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
   const [lineupGrades, setLineupGrades] = useState<RosterGrade[] | null>(null);
   const graphEnabled = useFlag("ASSET_GRAPH_BROWSER");
 
-  useEffect(() => {
-    loadLeagueData();
-  }, [familyId, selectedSeason]);
-
-  async function loadLeagueData() {
+  const loadLeagueData = useCallback(async () => {
     setLoading(true);
-    const seasonQuery = selectedSeason ? `?season=${selectedSeason}` : "";
+    setLineupGrades(null);
+    const seasonQuery = `?season=${seasonParam}`;
     const res = await fetch(`/api/leagues/${familyId}${seasonQuery}`);
     if (res.ok) {
       const result = await res.json();
       setData(result);
       setLoading(false);
-      // Fetch lineup grades in background
-      fetch(`/api/leagues/${familyId}/lineup-grades${seasonQuery}`)
-        .then((r) => (r.ok ? r.json() : null))
-        .then((r) => setLineupGrades(r?.rosters || null))
-        .catch(() => setLineupGrades(null));
+      if (seasonParam !== ALL_TIME) {
+        fetch(`/api/leagues/${familyId}/lineup-grades${seasonQuery}`)
+          .then((r) => (r.ok ? r.json() : null))
+          .then((r) => setLineupGrades(r?.rosters || null))
+          .catch(() => setLineupGrades(null));
+      }
     } else if (res.status === 404) {
       // First-time visit for an unseeded family — kick off ingestion in the
       // background so the page settles into real data without exposing a
@@ -91,10 +97,16 @@ export default function LeagueOverviewPage() {
     } else {
       setLoading(false);
     }
-  }
+  }, [familyId, seasonParam]);
 
-  function handleSeasonClick(season: string) {
-    setSelectedSeason(season);
+  useEffect(() => {
+    loadLeagueData();
+  }, [loadLeagueData]);
+
+  function setSeason(value: string) {
+    const sp = new URLSearchParams(searchParams.toString());
+    sp.set("season", value);
+    router.replace(`?${sp.toString()}`, { scroll: false });
   }
 
   if (loading || autoSyncing) {
@@ -118,85 +130,85 @@ export default function LeagueOverviewPage() {
   }
 
   const userMap = new Map(data.users.map((u) => [u.userId, u]));
-  const standings = [...data.rosters].sort(
-    (a, b) => b.wins - a.wins || b.fpts - a.fpts
-  );
+  const standings = data.rosters;
 
   return (
-      <div>
-        {/* Sub-header */}
-        <div className="border-b">
-          <div className="container mx-auto px-6 py-3 flex items-center justify-between">
-            <div className="flex items-center gap-4">
+    <div>
+      <div className="border-b">
+        <div className="container mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
+          <div className="flex items-center gap-3 sm:gap-4 min-w-0">
+            <Link
+              href="/start"
+              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 shrink-0"
+            >
+              <ArrowLeft className="h-4 w-4" />
+              <span className="hidden sm:inline">My leagues</span>
+            </Link>
+            <h1 className="text-base sm:text-lg font-semibold truncate">
+              {data.league.name}
+            </h1>
+            <span className="text-sm text-muted-foreground shrink-0">
+              {isAllTime ? "All-time" : data.league.season}
+            </span>
+          </div>
+          <div className="flex items-center gap-2 sm:gap-3 shrink-0">
+            <Link
+              href={`/league/${familyId}/transactions`}
+              className="px-2.5 sm:px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
+            >
+              Transactions
+            </Link>
+            <Link
+              href={`/league/${familyId}/drafts`}
+              className="px-2.5 sm:px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
+            >
+              Drafts
+            </Link>
+            {graphEnabled && (
               <Link
-                href="/start"
-                className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
+                href={`/league/${familyId}/graph?from=overview`}
+                className="px-2.5 sm:px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors inline-flex items-center gap-2 font-medium"
               >
-                <ArrowLeft className="h-4 w-4" />
-                My leagues
+                <Network className="h-4 w-4" />
+                <span className="hidden sm:inline">Lineage Tracer</span>
               </Link>
-              <h1 className="text-lg font-semibold">{data.league.name}</h1>
-              <span className="text-sm text-muted-foreground">
-                {data.league.season}
-              </span>
-            </div>
-            <div className="flex items-center gap-3">
-              <Link
-                href={`/league/${familyId}/transactions`}
-                className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
+            )}
+          </div>
+        </div>
+      </div>
+
+      <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
+        <div className="-mx-4 sm:mx-0 mb-6 overflow-x-auto">
+          <div className="px-4 sm:px-0 flex gap-2 w-max">
+            <SeasonChip active={isAllTime} onClick={() => setSeason(ALL_TIME)}>
+              All-time
+            </SeasonChip>
+            {data.seasons.map((s) => (
+              <SeasonChip
+                key={s.leagueId}
+                active={!isAllTime && seasonParam === s.season}
+                onClick={() => setSeason(s.season)}
               >
-                Transactions
-              </Link>
-              <Link
-                href={`/league/${familyId}/drafts`}
-                className="px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
-              >
-                Drafts
-              </Link>
-              {graphEnabled && (
-                <Link
-                  href={`/league/${familyId}/graph?from=overview`}
-                  className="px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors inline-flex items-center gap-2 font-medium"
-                >
-                  <Network className="h-4 w-4" />
-                  Lineage Tracer
-                </Link>
-              )}
-            </div>
+                {s.season}
+              </SeasonChip>
+            ))}
           </div>
         </div>
 
-        <main className="container mx-auto px-6 py-8">
-        {/* Season selector */}
-        {data.seasons.length > 1 && (
-          <div className="flex gap-2 mb-6">
-            {data.seasons.map((s) => (
-              <button
-                key={s.leagueId}
-                onClick={() => handleSeasonClick(s.season)}
-                className={`px-3 py-1 text-sm rounded-full transition-colors ${
-                  s.leagueId === data.league.id
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-                }`}
-              >
-                {s.season}
-              </button>
-            ))}
-          </div>
-        )}
-
-        {/* Standings */}
         <section>
           <h2 className="text-lg font-semibold mb-4">Standings</h2>
-          <div className="border rounded-lg overflow-hidden">
+
+          <div className="hidden md:block border rounded-lg overflow-hidden">
             <table className="w-full">
               <thead className="bg-muted/50">
                 <tr className="text-left text-sm">
-                  <th className="px-4 py-3 font-medium">#</th>
+                  <th className="px-4 py-3 font-medium w-10">#</th>
                   <th className="px-4 py-3 font-medium">Manager</th>
                   <th className="px-4 py-3 font-medium text-right">W</th>
                   <th className="px-4 py-3 font-medium text-right">L</th>
+                  {isAllTime && (
+                    <th className="px-4 py-3 font-medium text-right">T</th>
+                  )}
                   <th className="px-4 py-3 font-medium text-right">PF</th>
                   <th className="px-4 py-3 font-medium text-right">PA</th>
                 </tr>
@@ -206,31 +218,42 @@ export default function LeagueOverviewPage() {
                   const user = userMap.get(roster.ownerId);
                   return (
                     <tr
-                      key={roster.rosterId}
+                      key={roster.ownerId}
                       className="border-t hover:bg-muted/30 transition-colors"
                     >
-                      <td className="px-4 py-3 text-sm text-muted-foreground">
+                      <td className="px-4 py-3 text-sm font-mono text-muted-foreground">
                         {idx + 1}
                       </td>
                       <td className="px-4 py-3">
-                        <Link
-                          href={`/league/${familyId}/manager/${roster.ownerId}`}
-                          className="font-medium hover:text-primary transition-colors"
-                        >
-                          <ManagerName
+                        <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                          <Link
+                            href={`/league/${familyId}/manager/${roster.ownerId}`}
+                            className="font-medium hover:text-primary transition-colors"
+                          >
+                            <ManagerName
+                              userId={roster.ownerId}
+                              rosterId={roster.rosterId}
+                              displayName={user?.displayName}
+                              teamName={user?.teamName}
+                            />
+                          </Link>
+                          <ChampionshipTrophies
+                            years={roster.championshipYears}
+                          />
+                          <ManagerSecondaryName
                             userId={roster.ownerId}
                             rosterId={roster.rosterId}
                             displayName={user?.displayName}
                             teamName={user?.teamName}
+                            className="text-sm text-muted-foreground"
                           />
-                        </Link>
-                        <ManagerSecondaryName
-                          userId={roster.ownerId}
-                          rosterId={roster.rosterId}
-                          displayName={user?.displayName}
-                          teamName={user?.teamName}
-                          className="text-sm text-muted-foreground ml-2"
-                        />
+                          {isAllTime && (
+                            <span className="text-xs font-mono text-muted-foreground">
+                              {roster.seasonsPlayed} season
+                              {roster.seasonsPlayed === 1 ? "" : "s"}
+                            </span>
+                          )}
+                        </div>
                       </td>
                       <td className="px-4 py-3 text-right font-mono text-sm">
                         {roster.wins}
@@ -238,6 +261,11 @@ export default function LeagueOverviewPage() {
                       <td className="px-4 py-3 text-right font-mono text-sm">
                         {roster.losses}
                       </td>
+                      {isAllTime && (
+                        <td className="px-4 py-3 text-right font-mono text-sm">
+                          {roster.ties}
+                        </td>
+                      )}
                       <td className="px-4 py-3 text-right font-mono text-sm">
                         {roster.fpts.toFixed(1)}
                       </td>
@@ -250,15 +278,109 @@ export default function LeagueOverviewPage() {
               </tbody>
             </table>
           </div>
+
+          <ul className="md:hidden space-y-2">
+            {standings.map((roster, idx) => {
+              const user = userMap.get(roster.ownerId);
+              return (
+                <li
+                  key={roster.ownerId}
+                  className="border rounded-lg bg-card p-3"
+                >
+                  <div className="flex items-start gap-3">
+                    <span className="font-mono text-sm text-muted-foreground pt-0.5 w-6 shrink-0">
+                      {idx + 1}
+                    </span>
+                    <div className="flex-1 min-w-0">
+                      <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+                        <Link
+                          href={`/league/${familyId}/manager/${roster.ownerId}`}
+                          className="font-medium hover:text-primary transition-colors break-words"
+                        >
+                          <ManagerName
+                            userId={roster.ownerId}
+                            rosterId={roster.rosterId}
+                            displayName={user?.displayName}
+                            teamName={user?.teamName}
+                          />
+                        </Link>
+                        <ChampionshipTrophies
+                          years={roster.championshipYears}
+                        />
+                      </div>
+                      <ManagerSecondaryName
+                        userId={roster.ownerId}
+                        rosterId={roster.rosterId}
+                        displayName={user?.displayName}
+                        teamName={user?.teamName}
+                        className="text-xs text-muted-foreground"
+                        parens={false}
+                      />
+                      <dl className="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-sm">
+                        <Stat label="Record">
+                          {roster.wins}-{roster.losses}
+                          {isAllTime ? `-${roster.ties}` : ""}
+                        </Stat>
+                        <Stat label="PF">{roster.fpts.toFixed(1)}</Stat>
+                        <Stat label="PA">{roster.fptsAgainst.toFixed(1)}</Stat>
+                        {isAllTime && (
+                          <Stat label="Seasons">{roster.seasonsPlayed}</Stat>
+                        )}
+                      </dl>
+                    </div>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
         </section>
 
-        {/* Lineup Efficiency */}
-        {lineupGrades && lineupGrades.length > 0 && (
+        {!isAllTime && lineupGrades && lineupGrades.length > 0 && (
           <div className="mt-8">
             <LineupEfficiencyCard rosters={lineupGrades} />
           </div>
         )}
       </main>
-      </div>
+    </div>
+  );
+}
+
+function SeasonChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`px-3 py-1 text-sm rounded-full transition-colors whitespace-nowrap shrink-0 ${
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function Stat({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-baseline gap-2">
+      <dt className="text-xs uppercase tracking-wide text-muted-foreground">
+        {label}
+      </dt>
+      <dd className="font-mono">{children}</dd>
+    </div>
   );
 }

--- a/src/app/api/leagues/[familyId]/route.ts
+++ b/src/app/api/leagues/[familyId]/route.ts
@@ -1,9 +1,14 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getDb, schema } from "@/db";
-import { eq } from "drizzle-orm";
+import { eq, inArray } from "drizzle-orm";
 import { resolveFamily } from "@/lib/familyResolution";
 import { DEMO_LEAGUE_NAME, getDemoSwapForRequest } from "@/lib/demoServer";
 import { swapLeagueUser } from "@/lib/demoTransforms";
+import {
+  getAllTimeStandings,
+  getChampionRosterFromBracket,
+} from "@/services/familyStandings";
+import type { SleeperBracketMatchup } from "@/lib/sleeper";
 
 export async function GET(
   req: NextRequest,
@@ -12,11 +17,11 @@ export async function GET(
   const db = getDb();
   const familyId = params.familyId;
   const seasonParam = req.nextUrl.searchParams.get("season");
+  const allTime = seasonParam === "all";
 
   const resolvedFamilyId = await resolveFamily(familyId);
 
   if (!resolvedFamilyId) {
-    // No family yet — try to return basic league data if a matching league row exists
     const leagues = await db
       .select()
       .from(schema.leagues)
@@ -28,15 +33,21 @@ export async function GET(
     }
 
     const league = leagues[0];
-    const rosters = await db
-      .select()
-      .from(schema.rosters)
-      .where(eq(schema.rosters.leagueId, league.id));
-
-    const users = await db
-      .select()
-      .from(schema.leagueUsers)
-      .where(eq(schema.leagueUsers.leagueId, league.id));
+    const [rosters, users] = await Promise.all([
+      db
+        .select()
+        .from(schema.rosters)
+        .where(eq(schema.rosters.leagueId, league.id)),
+      db
+        .select({
+          userId: schema.leagueUsers.userId,
+          displayName: schema.leagueUsers.displayName,
+          teamName: schema.leagueUsers.teamName,
+          avatar: schema.leagueUsers.avatar,
+        })
+        .from(schema.leagueUsers)
+        .where(eq(schema.leagueUsers.leagueId, league.id)),
+    ]);
 
     return NextResponse.json({
       league: {
@@ -56,17 +67,13 @@ export async function GET(
         ties: r.ties || 0,
         fpts: r.fpts || 0,
         fptsAgainst: r.fptsAgainst || 0,
+        seasonsPlayed: 1,
+        championshipYears: [] as string[],
       })),
-      users: users.map((u) => ({
-        userId: u.userId,
-        displayName: u.displayName,
-        teamName: u.teamName,
-        avatar: u.avatar,
-      })),
+      users,
     });
   }
 
-  // Got the family — load all seasons
   const members = await db
     .select()
     .from(schema.leagueFamilyMembers)
@@ -76,8 +83,87 @@ export async function GET(
     .map((m) => ({ leagueId: m.leagueId, season: m.season }))
     .sort((a, b) => Number(b.season) - Number(a.season));
 
-  // Pick the season to render. Default to the most recent season rather
-  // than rootLeagueId, which can be stale after a season rollover.
+  if (seasons.length === 0) {
+    return NextResponse.json({ error: "League not found" }, { status: 404 });
+  }
+
+  const demoSwap = await getDemoSwapForRequest(req, resolvedFamilyId);
+
+  if (allTime) {
+    const headerLeagueId = seasons[0].leagueId;
+    const seasonByLeague = new Map(seasons.map((s) => [s.leagueId, s.season]));
+
+    const [standings, allUsers, headerLeagues] = await Promise.all([
+      getAllTimeStandings(seasons),
+      db
+        .select({
+          leagueId: schema.leagueUsers.leagueId,
+          userId: schema.leagueUsers.userId,
+          displayName: schema.leagueUsers.displayName,
+          teamName: schema.leagueUsers.teamName,
+          avatar: schema.leagueUsers.avatar,
+        })
+        .from(schema.leagueUsers)
+        .where(
+          inArray(
+            schema.leagueUsers.leagueId,
+            seasons.map((s) => s.leagueId),
+          ),
+        ),
+      db
+        .select()
+        .from(schema.leagues)
+        .where(eq(schema.leagues.id, headerLeagueId))
+        .limit(1),
+    ]);
+
+    // Most recent season's record wins so each ownerId reflects their current
+    // identity in the family.
+    const userByOwner = new Map<
+      string,
+      {
+        userId: string;
+        displayName: string | null;
+        teamName: string | null;
+        avatar: string | null;
+      }
+    >();
+    const seasonByOwner = new Map<string, number>();
+    for (const u of allUsers) {
+      const seasonNum = Number(seasonByLeague.get(u.leagueId) ?? 0);
+      if ((seasonByOwner.get(u.userId) ?? -1) < seasonNum) {
+        seasonByOwner.set(u.userId, seasonNum);
+        userByOwner.set(u.userId, {
+          userId: u.userId,
+          displayName: u.displayName,
+          teamName: u.teamName,
+          avatar: u.avatar,
+        });
+      }
+    }
+
+    const renderedUsers = Array.from(userByOwner.values());
+    const headerLeague = headerLeagues[0];
+
+    return NextResponse.json({
+      league: {
+        id: headerLeague?.id ?? headerLeagueId,
+        name: demoSwap ? DEMO_LEAGUE_NAME : (headerLeague?.name ?? "League"),
+        season: "All-time",
+        totalRosters: headerLeague?.totalRosters ?? null,
+        status: headerLeague?.status ?? null,
+      },
+      familyId: resolvedFamilyId,
+      seasons,
+      rosters: standings,
+      users: demoSwap
+        ? renderedUsers.map((u) => swapLeagueUser(u, demoSwap))
+        : renderedUsers,
+    });
+  }
+
+  // Default to the most recent season rather than rootLeagueId, which can be
+  // stale after a season rollover.
   const currentLeagueId =
     (seasonParam &&
       seasons.find((s) => s.season === seasonParam)?.leagueId) ||
@@ -88,34 +174,38 @@ export async function GET(
     return NextResponse.json({ error: "League not found" }, { status: 404 });
   }
 
-  const leagues = await db
-    .select()
-    .from(schema.leagues)
-    .where(eq(schema.leagues.id, currentLeagueId))
-    .limit(1);
+  const [leagues, rosters, users] = await Promise.all([
+    db
+      .select()
+      .from(schema.leagues)
+      .where(eq(schema.leagues.id, currentLeagueId))
+      .limit(1),
+    db
+      .select()
+      .from(schema.rosters)
+      .where(eq(schema.rosters.leagueId, currentLeagueId)),
+    db
+      .select({
+        userId: schema.leagueUsers.userId,
+        displayName: schema.leagueUsers.displayName,
+        teamName: schema.leagueUsers.teamName,
+        avatar: schema.leagueUsers.avatar,
+      })
+      .from(schema.leagueUsers)
+      .where(eq(schema.leagueUsers.leagueId, currentLeagueId)),
+  ]);
 
   if (leagues.length === 0) {
     return NextResponse.json({ error: "League not found" }, { status: 404 });
   }
 
   const league = leagues[0];
-  const rosters = await db
-    .select()
-    .from(schema.rosters)
-    .where(eq(schema.rosters.leagueId, currentLeagueId));
-
-  const users = await db
-    .select()
-    .from(schema.leagueUsers)
-    .where(eq(schema.leagueUsers.leagueId, currentLeagueId));
-
-  const demoSwap = await getDemoSwapForRequest(req, resolvedFamilyId);
-  const renderedUsers = users.map((u) => ({
-    userId: u.userId,
-    displayName: u.displayName,
-    teamName: u.teamName,
-    avatar: u.avatar,
-  }));
+  const settings = league.settings as Record<string, unknown> | null;
+  const numPlayoffTeams = (settings?.playoff_teams as number) ?? 6;
+  const champRosterId = getChampionRosterFromBracket(
+    league.winnersBracket as SleeperBracketMatchup[] | null,
+    numPlayoffTeams,
+  );
 
   return NextResponse.json({
     league: {
@@ -135,9 +225,10 @@ export async function GET(
       ties: r.ties || 0,
       fpts: r.fpts || 0,
       fptsAgainst: r.fptsAgainst || 0,
+      seasonsPlayed: 1,
+      championshipYears:
+        champRosterId === r.rosterId ? [league.season] : [],
     })),
-    users: demoSwap
-      ? renderedUsers.map((u) => swapLeagueUser(u, demoSwap))
-      : renderedUsers,
+    users: demoSwap ? users.map((u) => swapLeagueUser(u, demoSwap)) : users,
   });
 }

--- a/src/components/ChampionshipTrophy.tsx
+++ b/src/components/ChampionshipTrophy.tsx
@@ -1,0 +1,38 @@
+import { Trophy } from "lucide-react";
+
+const ICON_CLASS = "h-3.5 w-3.5 text-primary shrink-0";
+
+export function ChampionshipTrophy({ year }: { year: string }) {
+  const label = `${year} champion`;
+  return (
+    <span
+      className="inline-flex items-center"
+      role="img"
+      aria-label={label}
+      title={label}
+    >
+      <Trophy className={ICON_CLASS} />
+    </span>
+  );
+}
+
+export function ChampionshipTrophies({ years }: { years: string[] }) {
+  if (years.length === 0) return null;
+  const sorted = [...years].sort();
+  const summary =
+    sorted.length === 1
+      ? `${sorted[0]} champion`
+      : `${sorted.length}× champion (${sorted.join(", ")})`;
+  return (
+    <span
+      className="inline-flex items-center gap-0.5 align-baseline"
+      role="img"
+      aria-label={summary}
+      title={summary}
+    >
+      {sorted.map((year) => (
+        <Trophy key={year} className={ICON_CLASS} aria-hidden />
+      ))}
+    </span>
+  );
+}

--- a/src/services/familyStandings.ts
+++ b/src/services/familyStandings.ts
@@ -1,0 +1,127 @@
+import { getDb, schema } from "@/db";
+import { inArray } from "drizzle-orm";
+import type { SleeperBracketMatchup } from "@/lib/sleeper";
+import { parsePlayoffResults } from "./outcomeScore";
+
+export interface FamilyMemberRef {
+  leagueId: string;
+  season: string;
+}
+
+export interface AllTimeStanding {
+  ownerId: string;
+  // Most recent rosterId for the owner — used so demo-mode swaps can resolve
+  // by roster.
+  rosterId: number;
+  wins: number;
+  losses: number;
+  ties: number;
+  fpts: number;
+  fptsAgainst: number;
+  seasonsPlayed: number;
+  championshipYears: string[];
+}
+
+export function getChampionRosterFromBracket(
+  bracket: SleeperBracketMatchup[] | null,
+  numPlayoffTeams: number,
+): number | null {
+  if (!bracket || bracket.length === 0) return null;
+  const results = parsePlayoffResults(bracket, numPlayoffTeams);
+  return results.find((r) => r.placement === 1)?.rosterId ?? null;
+}
+
+export async function getAllTimeStandings(
+  members: FamilyMemberRef[],
+): Promise<AllTimeStanding[]> {
+  if (members.length === 0) return [];
+  const db = getDb();
+
+  const leagueIds = members.map((m) => m.leagueId);
+  const seasonByLeague = new Map(members.map((m) => [m.leagueId, m.season]));
+
+  const [rosterRows, leagueRows] = await Promise.all([
+    db
+      .select({
+        leagueId: schema.rosters.leagueId,
+        rosterId: schema.rosters.rosterId,
+        ownerId: schema.rosters.ownerId,
+        wins: schema.rosters.wins,
+        losses: schema.rosters.losses,
+        ties: schema.rosters.ties,
+        fpts: schema.rosters.fpts,
+        fptsAgainst: schema.rosters.fptsAgainst,
+      })
+      .from(schema.rosters)
+      .where(inArray(schema.rosters.leagueId, leagueIds)),
+    db
+      .select({
+        id: schema.leagues.id,
+        settings: schema.leagues.settings,
+        winnersBracket: schema.leagues.winnersBracket,
+      })
+      .from(schema.leagues)
+      .where(inArray(schema.leagues.id, leagueIds)),
+  ]);
+
+  // Newest season first so the first roster row we see for an owner is the
+  // representative rosterId used for demo swaps and ManagerName fallbacks.
+  const sortedRosters = [...rosterRows].sort((a, b) => {
+    const sa = Number(seasonByLeague.get(a.leagueId) ?? 0);
+    const sb = Number(seasonByLeague.get(b.leagueId) ?? 0);
+    return sb - sa;
+  });
+
+  const ownerByRoster = new Map<string, string | null>();
+  for (const r of rosterRows) {
+    ownerByRoster.set(`${r.leagueId}:${r.rosterId}`, r.ownerId);
+  }
+
+  const byOwner = new Map<string, AllTimeStanding>();
+  for (const r of sortedRosters) {
+    if (!r.ownerId) continue;
+    const existing = byOwner.get(r.ownerId);
+    if (existing) {
+      existing.wins += r.wins ?? 0;
+      existing.losses += r.losses ?? 0;
+      existing.ties += r.ties ?? 0;
+      existing.fpts += r.fpts ?? 0;
+      existing.fptsAgainst += r.fptsAgainst ?? 0;
+      existing.seasonsPlayed += 1;
+    } else {
+      byOwner.set(r.ownerId, {
+        ownerId: r.ownerId,
+        rosterId: r.rosterId,
+        wins: r.wins ?? 0,
+        losses: r.losses ?? 0,
+        ties: r.ties ?? 0,
+        fpts: r.fpts ?? 0,
+        fptsAgainst: r.fptsAgainst ?? 0,
+        seasonsPlayed: 1,
+        championshipYears: [],
+      });
+    }
+  }
+
+  for (const row of leagueRows) {
+    const settings = row.settings as Record<string, unknown> | null;
+    const numPlayoffTeams = (settings?.playoff_teams as number) ?? 6;
+    const champRosterId = getChampionRosterFromBracket(
+      row.winnersBracket as SleeperBracketMatchup[] | null,
+      numPlayoffTeams,
+    );
+    if (champRosterId == null) continue;
+    const ownerId = ownerByRoster.get(`${row.id}:${champRosterId}`);
+    const season = seasonByLeague.get(row.id);
+    if (!ownerId || !season) continue;
+    byOwner.get(ownerId)?.championshipYears.push(season);
+  }
+
+  for (const owner of byOwner.values()) {
+    owner.championshipYears.sort();
+  }
+
+  return Array.from(byOwner.values()).sort(
+    (a, b) => b.wins - a.wins || b.fpts - a.fpts,
+  );
+}


### PR DESCRIPTION
Closes #103.

## Summary
- League page now opens to **All-time** standings (`?season=all`), summing W/L/T/PF/PA across every season in the family. The existing per-season chips still work; URL state is shareable.
- **Championship trophies** render inline next to each manager's name — once per championship in all-time, once next to the winner in a completed per-season view (no trophy on in-progress seasons — absence is the signal).
- `LineupEfficiencyCard` is hidden in all-time view (per-season metric only).
- New shared `ChampionshipTrophy` + `ChampionshipTrophies` components (lucide `Trophy` + native title tooltip) so #101 can drop them into the manager page without copy-paste.

## Mobile-first
- Standings reuses the #90/#91 responsive primitive — `<table>` at `md:` and up, card stack below.
- Trophies live in a `flex-wrap` cluster next to the manager name, so a 3× champion's icons stay inline when there's room and wrap to a new line beneath the name when the name is too long.
- Season chips horizontal-scroll inside their container; the page itself never gains horizontal scroll at 360px.

## Data layer
- New `src/services/familyStandings.ts` with `getAllTimeStandings(members)` and `getChampionRosterFromBracket(bracket, numPlayoffTeams)` — the latter wraps `parsePlayoffResults` so we don't duplicate bracket-walking logic.
- All-time path parallelizes the rosters + leagues + users queries.
- Per-season path derives the champion directly from the already-loaded `winnersBracket` (no extra DB round-trip for the lookup).
- Demo-mode anonymization works in all-time view by carrying a representative `rosterId` (most recent season) per ownerId so `swapLeagueUser` resolves.

## Test plan
- [x] `npm run lint` — no new warnings
- [x] `npm run build` — clean
- [x] All-time view: 3× champion (2021, 2023, 2025) renders three trophies with cluster tooltip; T column visible; seasons-played subscript visible
- [x] Per-season view (2025, complete): single trophy on winner only; T column hidden; lineup efficiency card visible
- [x] In-progress season (2026, `pre_draft`): no trophies anywhere
- [x] Mobile @ 360px iframe: card stack visible, page has no horizontal overflow, chips scroll inside their container
- [x] Mobile @ 414px iframe: same behavior
- [x] Desktop @ 900px iframe: table visible, card stack hidden
- [ ] Demo-mode swap renders pseudonyms in all-time view (worth a manual sanity check before merge)

## Related
- Builds the shared `ChampionshipTrophy` component for #101 (manager page redesign).
- Keeps using today's `← League` strip — #117 will sweep this and other pages onto a shared `BackButton`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)