### PR TITLE
Site-wide: shared Subheader + sticky nav stack + per-league hamburger nav (#117)

### DIFF
--- a/src/app/(app)/league/[familyId]/drafts/page.tsx
+++ b/src/app/(app)/league/[familyId]/drafts/page.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
+import { Subheader } from "@/components/Subheader";
 
 interface PickGrade {
   grade: string;
@@ -94,18 +94,7 @@ export default function DraftsPage() {
 
   return (
       <div>
-        <div className="border-b">
-          <div className="container mx-auto px-6 py-3 flex items-center gap-4">
-            <Link
-              href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              League
-            </Link>
-            <h1 className="text-lg font-semibold">Draft History</h1>
-          </div>
-        </div>
+        <Subheader title="Draft History" />
 
         <main className="container mx-auto px-6 py-8">
         {/* Season filter */}

--- a/src/app/(app)/league/[familyId]/drafts/page.tsx
+++ b/src/app/(app)/league/[familyId]/drafts/page.tsx
@@ -3,6 +3,8 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { FilterChip } from "@/components/FilterChip";
+import { PositionChip } from "@/components/PositionChip";
 import { Subheader } from "@/components/Subheader";
 
 interface PickGrade {
@@ -47,15 +49,6 @@ interface DraftsResponse {
   seasons: string[];
 }
 
-const POSITION_COLORS: Record<string, string> = {
-  QB: "bg-grade-f/12 text-grade-f",
-  RB: "bg-grade-b/12 text-grade-b",
-  WR: "bg-grade-a/12 text-grade-a",
-  TE: "bg-grade-d/12 text-grade-d",
-  K: "bg-chart-4/15 text-chart-4",
-  DEF: "bg-muted text-muted-foreground",
-};
-
 import { GradeBadge } from "@/components/GradeBadge";
 import { ManagerName } from "@/components/ManagerName";
 
@@ -92,40 +85,32 @@ export default function DraftsPage() {
     return () => controller.abort();
   }, [familyId, selectedSeason]);
 
+  const seasonChips =
+    data?.seasons && data.seasons.length > 1 ? (
+      <div className="flex flex-wrap gap-2">
+        <FilterChip
+          active={!selectedSeason}
+          onClick={() => setSelectedSeason(null)}
+        >
+          All Seasons
+        </FilterChip>
+        {data.seasons.map((s) => (
+          <FilterChip
+            key={s}
+            active={selectedSeason === s}
+            onClick={() => setSelectedSeason(s)}
+          >
+            {s}
+          </FilterChip>
+        ))}
+      </div>
+    ) : null;
+
   return (
       <div>
-        <Subheader title="Draft History" />
+        <Subheader title="Draft History" rightSlot={seasonChips} />
 
         <main className="container mx-auto px-6 py-8">
-        {/* Season filter */}
-        {data?.seasons && data.seasons.length > 1 && (
-          <div className="flex gap-2 mb-6">
-            <button
-              onClick={() => setSelectedSeason(null)}
-              className={`px-3 py-1 text-sm rounded-full transition-colors ${
-                !selectedSeason
-                  ? "bg-primary text-primary-foreground"
-                  : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-              }`}
-            >
-              All Seasons
-            </button>
-            {data.seasons.map((s) => (
-              <button
-                key={s}
-                onClick={() => setSelectedSeason(s)}
-                className={`px-3 py-1 text-sm rounded-full transition-colors ${
-                  selectedSeason === s
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-                }`}
-              >
-                {s}
-              </button>
-            ))}
-          </div>
-        )}
-
         {loading && (
           <div className="animate-pulse text-muted-foreground">
             Loading drafts...
@@ -243,13 +228,7 @@ function DraftBoard({ draft, familyId }: { draft: DraftData; familyId: string })
                     <td key={pick.pickNo} className="px-3 py-2">
                       <div className="space-y-0.5">
                         <div className="flex items-center gap-1.5">
-                          {pick.position && (
-                            <span
-                              className={`px-1.5 py-0 text-[10px] font-mono font-medium tracking-wide uppercase rounded-full ${POSITION_COLORS[pick.position] || ""}`}
-                            >
-                              {pick.position}
-                            </span>
-                          )}
+                          <PositionChip position={pick.position} size="xs" />
                           {pick.playerId ? (
                             <Link
                               href={`/league/${familyId}/player/${pick.playerId}`}

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -2,12 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import Link from "next/link";
-import { ArrowLeft } from "lucide-react";
 import { GradeBadge } from "@/components/GradeBadge";
 import { ManagerRadarChart } from "@/components/ManagerRadarChart";
 import { ManagerGradeCard } from "@/components/ManagerGradeCard";
 import { ManagerName, ManagerSecondaryName } from "@/components/ManagerName";
+import { Subheader } from "@/components/Subheader";
 import { TypeBadge } from "@/components/TransactionCard";
 import { PILLAR_LABELS } from "@/lib/pillars";
 
@@ -89,19 +88,10 @@ export default function ManagerPage() {
 
   return (
     <div>
-      {/* Sub-header */}
-      <div className="border-b">
-        <div className="container mx-auto px-6 py-3 flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            <Link
-              href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-primary transition-colors inline-flex items-center gap-1.5"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              League
-            </Link>
-            <span className="text-muted-foreground">/</span>
-            <h1 className="text-lg font-semibold">
+      <Subheader
+        title={
+          <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 min-w-0">
+            <h1 className="text-base sm:text-lg md:text-xl font-semibold line-clamp-1">
               <ManagerName
                 userId={manager.userId}
                 displayName={manager.displayName}
@@ -116,8 +106,8 @@ export default function ManagerPage() {
               className="text-sm text-muted-foreground"
             />
           </div>
-        </div>
-      </div>
+        }
+      />
 
       <main className="container mx-auto px-6 py-8 space-y-8">
         {/* Top section: Grade card + Radar chart */}

--- a/src/app/(app)/league/[familyId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/page.tsx
@@ -3,9 +3,10 @@
 import { useCallback, useEffect, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { ArrowLeft, Network } from "lucide-react";
 import { ManagerName, ManagerSecondaryName } from "@/components/ManagerName";
 import { ChampionshipTrophies } from "@/components/ChampionshipTrophy";
+import { Subheader } from "@/components/Subheader";
+import { BrandMark } from "@/components/BrandMark";
 import { useFlag } from "@/lib/useFlag";
 
 interface Roster {
@@ -122,45 +123,7 @@ export default function LeagueOverviewPage() {
 
   return (
     <div>
-      <div className="border-b">
-        <div className="container mx-auto px-4 sm:px-6 py-3 flex items-center justify-between gap-3">
-          <div className="flex items-center gap-3 sm:gap-4 min-w-0">
-            <Link
-              href="/start"
-              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5 shrink-0"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              <span className="hidden sm:inline">My leagues</span>
-            </Link>
-            <h1 className="text-base sm:text-lg font-semibold truncate">
-              {data.league.name}
-            </h1>
-          </div>
-          <div className="flex items-center gap-2 sm:gap-3 shrink-0">
-            <Link
-              href={`/league/${familyId}/transactions`}
-              className="px-2.5 sm:px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
-            >
-              Transactions
-            </Link>
-            <Link
-              href={`/league/${familyId}/drafts`}
-              className="px-2.5 sm:px-3 py-1.5 text-sm rounded-md border hover:bg-secondary transition-colors"
-            >
-              Drafts
-            </Link>
-            {graphEnabled && (
-              <Link
-                href={`/league/${familyId}/graph?from=overview`}
-                className="px-2.5 sm:px-3 py-1.5 text-sm rounded-md bg-primary text-primary-foreground hover:bg-primary/90 transition-colors inline-flex items-center gap-2 font-medium"
-              >
-                <Network className="h-4 w-4" />
-                <span className="hidden sm:inline">Lineage Tracer</span>
-              </Link>
-            )}
-          </div>
-        </div>
-      </div>
+      <Subheader title={data.league.name} />
 
       <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
         <div className="-mx-4 sm:mx-0 mb-6 overflow-x-auto">
@@ -179,6 +142,22 @@ export default function LeagueOverviewPage() {
             ))}
           </div>
         </div>
+
+        {graphEnabled && (
+          <Link
+            href={`/league/${familyId}/graph?from=overview`}
+            className="mb-6 block rounded-lg border border-primary/25 bg-primary/8 px-4 py-4 sm:px-5 hover:bg-primary/12 transition-colors"
+          >
+            <div className="flex items-center justify-between gap-3">
+              <p className="text-sm sm:text-base text-foreground">
+                <span className="font-semibold">Lineage Tracer</span>
+                <span className="text-muted-foreground"> — </span>
+                <span>Follow any player or pick through this league&apos;s history</span>
+              </p>
+              <BrandMark className="h-4 w-4 sm:h-[18px] sm:w-[18px] text-primary shrink-0" />
+            </div>
+          </Link>
+        )}
 
         <section>
           <h2 className="text-lg font-semibold mb-4">Standings</h2>

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -2,10 +2,8 @@
 
 import { Fragment, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
-import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
 import { ManagerName } from "@/components/ManagerName";
-import { useFlag } from "@/lib/useFlag";
+import { Subheader } from "@/components/Subheader";
 
 interface Manager {
   userId: string;
@@ -87,7 +85,6 @@ export default function PlayerDetailPage() {
 
   const [data, setData] = useState<WeeklyLogData | null>(null);
   const [loading, setLoading] = useState(true);
-  const graphEnabled = useFlag("ASSET_GRAPH_BROWSER");
 
   // Filters
   const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
@@ -177,34 +174,18 @@ export default function PlayerDetailPage() {
 
   return (
       <div>
-        <div className="border-b">
-          <div className="container mx-auto px-6 py-3 flex items-center gap-4">
-            <Link
-              href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              League
-            </Link>
-            <div className="flex-1">
-              <h1 className="text-lg font-semibold">{player.name}</h1>
-              <div className="text-sm text-muted-foreground">
+        <Subheader
+          title={
+            <div className="min-w-0">
+              <h1 className="text-base sm:text-lg md:text-xl font-semibold line-clamp-1">
+                {player.name}
+              </h1>
+              <div className="text-sm text-muted-foreground line-clamp-1">
                 {player.position} {player.team ? `— ${player.team}` : ""}
               </div>
             </div>
-            <div className="flex items-center gap-4 ml-auto">
-              {graphEnabled && (
-                <Link
-                  href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
-                  className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
-                >
-                  Trace lineage
-                  <ArrowRight className="h-4 w-4" />
-                </Link>
-              )}
-            </div>
-          </div>
-        </div>
+          }
+        />
 
         <main className="container mx-auto px-6 py-8">
         {/* Summary Stats */}

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -3,6 +3,7 @@
 import { Fragment, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import { ManagerName } from "@/components/ManagerName";
+import { PositionChip } from "@/components/PositionChip";
 import { Subheader } from "@/components/Subheader";
 
 interface Manager {
@@ -176,13 +177,16 @@ export default function PlayerDetailPage() {
       <div>
         <Subheader
           title={
-            <div className="min-w-0">
+            <div className="min-w-0 flex items-center gap-2">
+              <PositionChip position={player.position} />
               <h1 className="text-base sm:text-lg md:text-xl font-semibold line-clamp-1">
                 {player.name}
               </h1>
-              <div className="text-sm text-muted-foreground line-clamp-1">
-                {player.position} {player.team ? `— ${player.team}` : ""}
-              </div>
+              {player.team && (
+                <span className="text-sm text-muted-foreground shrink-0">
+                  {player.team}
+                </span>
+              )}
             </div>
           }
         />

--- a/src/app/(app)/league/[familyId]/transactions/page.tsx
+++ b/src/app/(app)/league/[familyId]/transactions/page.tsx
@@ -2,13 +2,11 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
-import Link from "next/link";
-import { ArrowLeft, ArrowRight } from "lucide-react";
 import {
   TransactionCard,
   type TransactionData,
 } from "@/components/TransactionCard";
-import { useFlag } from "@/lib/useFlag";
+import { Subheader } from "@/components/Subheader";
 
 interface TransactionsResponse {
   transactions: TransactionData[];
@@ -23,7 +21,6 @@ export default function TransactionsPage() {
   const familyId = params.familyId as string;
   const [data, setData] = useState<TransactionsResponse | null>(null);
   const [loading, setLoading] = useState(true);
-  const graphEnabled = useFlag("ASSET_GRAPH_BROWSER");
   const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
   const [selectedType, setSelectedType] = useState<string | null>(null);
   const [page, setPage] = useState(1);
@@ -61,80 +58,46 @@ export default function TransactionsPage() {
     { value: "free_agent", label: "Free Agents" },
   ];
 
+  const filterChips = (
+    <>
+      {data?.seasons && data.seasons.length > 1 && (
+        <div className="flex flex-wrap gap-2">
+          <FilterChip
+            active={!selectedSeason}
+            onClick={() => setSelectedSeason(null)}
+          >
+            All Seasons
+          </FilterChip>
+          {data.seasons.map((s) => (
+            <FilterChip
+              key={s}
+              active={selectedSeason === s}
+              onClick={() => setSelectedSeason(s)}
+            >
+              {s}
+            </FilterChip>
+          ))}
+        </div>
+      )}
+      <div className="flex flex-wrap gap-2">
+        {typeFilters.map((f) => (
+          <FilterChip
+            key={f.label}
+            active={selectedType === f.value}
+            onClick={() => setSelectedType(f.value)}
+          >
+            {f.label}
+          </FilterChip>
+        ))}
+      </div>
+    </>
+  );
+
   return (
       <div>
-        <div className="border-b">
-          <div className="container mx-auto px-6 py-3 flex items-center gap-4">
-            <Link
-              href={`/league/${familyId}`}
-              className="text-sm text-muted-foreground hover:text-foreground inline-flex items-center gap-1.5"
-            >
-              <ArrowLeft className="h-4 w-4" />
-              League
-            </Link>
-            <h1 className="text-lg font-semibold">Transactions</h1>
-            {graphEnabled && (
-              <Link
-                href={`/league/${familyId}/graph?from=transactions`}
-                className="text-sm text-muted-foreground hover:text-foreground ml-auto inline-flex items-center gap-1.5"
-              >
-                View as network
-                <ArrowRight className="h-4 w-4" />
-              </Link>
-            )}
-          </div>
-        </div>
+        <Subheader title="Transactions" rightSlot={filterChips} />
 
         <main className="container mx-auto px-6 py-8">
-        {/* Filters */}
-        <div className="flex flex-wrap gap-4 mb-6">
-          {/* Season filter */}
-          {data?.seasons && data.seasons.length > 1 && (
-            <div className="flex gap-2">
-              <button
-                onClick={() => setSelectedSeason(null)}
-                className={`px-3 py-1 text-sm rounded-full transition-colors ${
-                  !selectedSeason
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-                }`}
-              >
-                All Seasons
-              </button>
-              {data.seasons.map((s) => (
-                <button
-                  key={s}
-                  onClick={() => setSelectedSeason(s)}
-                  className={`px-3 py-1 text-sm rounded-full transition-colors ${
-                    selectedSeason === s
-                      ? "bg-primary text-primary-foreground"
-                      : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-                  }`}
-                >
-                  {s}
-                </button>
-              ))}
-            </div>
-          )}
-
-          {/* Type filter */}
-          <div className="flex gap-2">
-            {typeFilters.map((f) => (
-              <button
-                key={f.label}
-                onClick={() => setSelectedType(f.value)}
-                className={`px-3 py-1 text-sm rounded-full transition-colors ${
-                  selectedType === f.value
-                    ? "bg-primary text-primary-foreground"
-                    : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-                }`}
-              >
-                {f.label}
-              </button>
-            ))}
-          </div>
-        </div>
-
         {/* Loading state */}
         {loading && (
           <div className="animate-pulse text-muted-foreground">
@@ -187,5 +150,29 @@ export default function TransactionsPage() {
         )}
       </main>
       </div>
+  );
+}
+
+function FilterChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 text-sm rounded-full transition-colors whitespace-nowrap ${
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+      }`}
+    >
+      {children}
+    </button>
   );
 }

--- a/src/app/(app)/league/[familyId]/transactions/page.tsx
+++ b/src/app/(app)/league/[familyId]/transactions/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
+import { FilterChip } from "@/components/FilterChip";
 import {
   TransactionCard,
   type TransactionData,
@@ -150,29 +151,5 @@ export default function TransactionsPage() {
         )}
       </main>
       </div>
-  );
-}
-
-function FilterChip({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      className={`px-3 py-1 text-sm rounded-full transition-colors whitespace-nowrap ${
-        active
-          ? "bg-primary text-primary-foreground"
-          : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-      }`}
-    >
-      {children}
-    </button>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Inter, Source_Serif_4, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
 
@@ -24,6 +24,11 @@ export const metadata: Metadata = {
   title: "Dynasty DNA",
   description:
     "Measure dynasty fantasy football manager efficacy with data-driven analytics",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({

--- a/src/components/FilterChip.tsx
+++ b/src/components/FilterChip.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { type ReactNode } from "react";
+
+export function FilterChip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 text-sm rounded-full transition-colors whitespace-nowrap ${
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}

--- a/src/components/PositionChip.tsx
+++ b/src/components/PositionChip.tsx
@@ -1,0 +1,30 @@
+const POSITION_COLORS: Record<string, string> = {
+  QB: "bg-grade-f/12 text-grade-f",
+  RB: "bg-grade-b/12 text-grade-b",
+  WR: "bg-grade-a/12 text-grade-a",
+  TE: "bg-grade-d/12 text-grade-d",
+  K: "bg-chart-4/15 text-chart-4",
+  DEF: "bg-muted text-muted-foreground",
+};
+
+export function PositionChip({
+  position,
+  size = "sm",
+}: {
+  position: string | null | undefined;
+  size?: "xs" | "sm";
+}) {
+  if (!position) return null;
+  const palette = POSITION_COLORS[position] ?? "bg-muted text-muted-foreground";
+  const sizing =
+    size === "xs"
+      ? "px-1.5 py-0 text-[10px]"
+      : "px-2 py-0.5 text-xs";
+  return (
+    <span
+      className={`inline-flex items-center ${sizing} font-mono font-medium uppercase tracking-wide rounded-full ${palette}`}
+    >
+      {position}
+    </span>
+  );
+}

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -2,11 +2,13 @@
 
 import Link from "next/link";
 import { useRouter, usePathname } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Menu, X, ChevronDown } from "lucide-react";
 import { BrandLockup } from "./BrandMark";
 import { DemoChip } from "./DemoIndicators";
+import { useClickOutside } from "@/lib/useClickOutside";
 import { useDemoActive } from "@/lib/useDemoMap";
+import { useScrolled } from "@/lib/useScrolled";
 import {
   STORED_USERNAME_KEY,
   clearStoredUsername,
@@ -20,13 +22,69 @@ const navLinks: Array<{ href: string; label: string; soon?: boolean }> = [
   { href: "/experiments", label: "Experiments" },
 ];
 
+type LeagueMenuItem = {
+  href: string;
+  label: string;
+  exact?: boolean;
+  pathPrefix?: string;
+};
+
+// Dedupes concurrent mounts on the same family — both subscribe to the same
+// in-flight fetch instead of firing twice.
+const leagueNamePromises = new Map<string, Promise<string | null>>();
+
+function fetchLeagueName(familyId: string): Promise<string | null> {
+  const inFlight = leagueNamePromises.get(familyId);
+  if (inFlight) return inFlight;
+  const promise = fetch(`/api/leagues/${familyId}`)
+    .then((res) => (res.ok ? res.json() : null))
+    .then((data) => (data?.league?.name as string | undefined) ?? null)
+    .catch(() => null)
+    .then((name) => {
+      if (!name) leagueNamePromises.delete(familyId);
+      return name;
+    });
+  leagueNamePromises.set(familyId, promise);
+  return promise;
+}
+
+function extractFamilyId(pathname: string | null): string | null {
+  const m = pathname?.match(/^\/league\/([^/]+)/);
+  return m ? decodeURIComponent(m[1]) : null;
+}
+
+function useLeagueContext(): { familyId: string | null; leagueName: string | null } {
+  const pathname = usePathname();
+  const familyId = useMemo(() => extractFamilyId(pathname), [pathname]);
+  const [leagueName, setLeagueName] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!familyId) {
+      setLeagueName(null);
+      return;
+    }
+    let cancelled = false;
+    fetchLeagueName(familyId).then((name) => {
+      if (!cancelled) setLeagueName(name);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [familyId]);
+
+  return { familyId, leagueName };
+}
+
 export function PublicNav() {
   const pathname = usePathname();
   const router = useRouter();
+  const navRef = useRef<HTMLElement | null>(null);
   const [mobileOpen, setMobileOpen] = useState(false);
   const [storedUsername, setStoredUsername] = useState<string | null>(null);
   const [hydrated, setHydrated] = useState(false);
   const { active: demoActive } = useDemoActive();
+  const { familyId, leagueName } = useLeagueContext();
+  const scrolled = useScrolled();
 
   useEffect(() => {
     setMobileOpen(false);
@@ -42,6 +100,26 @@ export function PublicNav() {
     }
     window.addEventListener("storage", onStorage);
     return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  // Publish nav height as --nav-height so sticky sub-headers can dock below.
+  useEffect(() => {
+    const node = navRef.current;
+    if (!node) return;
+    let last = -1;
+    const setVar = () => {
+      const h = node.getBoundingClientRect().height;
+      if (h === last) return;
+      last = h;
+      document.body.style.setProperty("--nav-height", `${h}px`);
+    };
+    setVar();
+    const observer = new ResizeObserver(setVar);
+    observer.observe(node);
+    return () => {
+      observer.disconnect();
+      document.body.style.removeProperty("--nav-height");
+    };
   }, []);
 
   function handleSwitchUser() {
@@ -82,7 +160,12 @@ export function PublicNav() {
   }
 
   return (
-    <header className="border-b">
+    <header
+      ref={navRef}
+      className={`sticky top-0 z-40 bg-background border-b transition-shadow ${
+        scrolled ? "shadow-sm" : ""
+      }`}
+    >
       <div className="container mx-auto px-6 py-4 flex items-center justify-between gap-4">
         <Link href="/" aria-label="Dynasty DNA home">
           <BrandLockup />
@@ -90,6 +173,13 @@ export function PublicNav() {
 
         {/* Desktop nav */}
         <nav className="hidden sm:flex items-center gap-6">
+          {familyId && (
+            <LeagueMenu
+              familyId={familyId}
+              leagueName={leagueName}
+              currentPath={pathname}
+            />
+          )}
           {renderNavLinks()}
           {/* Render server-side default; client swaps in user chip on mount.
               Keeps SSR markup stable; suppressHydrationWarning narrows the
@@ -127,6 +217,14 @@ export function PublicNav() {
       {/* Mobile nav */}
       {mobileOpen && (
         <nav className="sm:hidden border-t px-6 py-4 flex flex-col gap-4 bg-background">
+          {familyId && (
+            <MobileLeagueSection
+              familyId={familyId}
+              leagueName={leagueName}
+              currentPath={pathname}
+              onNavigate={() => setMobileOpen(false)}
+            />
+          )}
           {renderNavLinks(() => setMobileOpen(false))}
           <div suppressHydrationWarning>
             {hydrated && demoActive ? (
@@ -172,6 +270,132 @@ export function PublicNav() {
   );
 }
 
+function leagueMenuItems(familyId: string): LeagueMenuItem[] {
+  return [
+    { href: `/league/${familyId}`, label: "Overview", exact: true },
+    { href: `/league/${familyId}/transactions`, label: "Transactions" },
+    { href: `/league/${familyId}/drafts`, label: "Drafts" },
+    {
+      href: `/league/${familyId}/graph?from=overview`,
+      label: "Lineage Tracer",
+      pathPrefix: `/league/${familyId}/graph`,
+    },
+  ];
+}
+
+function isLeagueItemActive(
+  item: LeagueMenuItem,
+  currentPath: string | null
+): boolean {
+  if (item.exact) return currentPath === item.href;
+  if (item.pathPrefix) return !!currentPath?.startsWith(item.pathPrefix);
+  return currentPath === item.href;
+}
+
+function LeagueMenu({
+  familyId,
+  leagueName,
+  currentPath,
+}: {
+  familyId: string;
+  leagueName: string | null;
+  currentPath: string | null;
+}) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement | null>(null);
+  const items = useMemo(() => leagueMenuItems(familyId), [familyId]);
+  useClickOutside(ref, () => setOpen(false));
+
+  useEffect(() => {
+    setOpen(false);
+  }, [currentPath]);
+
+  const label = leagueName ?? "League";
+
+  return (
+    <div ref={ref} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="inline-flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground transition-colors max-w-[14rem]"
+        aria-haspopup="menu"
+        aria-expanded={open}
+      >
+        <span className="truncate">{label}</span>
+        <ChevronDown className="h-3.5 w-3.5 shrink-0" />
+      </button>
+      {open && (
+        <div
+          role="menu"
+          aria-label={label}
+          className="absolute left-0 mt-2 w-56 rounded-md border bg-card shadow-md py-1 z-50"
+        >
+          <div className="px-3 py-1.5 text-[11px] font-mono uppercase tracking-wide text-muted-foreground border-b">
+            {label}
+          </div>
+          {items.map((item) => {
+            const isActive = isLeagueItemActive(item, currentPath);
+            return (
+              <Link
+                key={item.label}
+                href={item.href}
+                role="menuitem"
+                onClick={() => setOpen(false)}
+                className={`block px-3 py-2 text-sm hover:bg-muted ${
+                  isActive ? "text-foreground font-medium" : ""
+                }`}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function MobileLeagueSection({
+  familyId,
+  leagueName,
+  currentPath,
+  onNavigate,
+}: {
+  familyId: string;
+  leagueName: string | null;
+  currentPath: string | null;
+  onNavigate: () => void;
+}) {
+  const items = useMemo(() => leagueMenuItems(familyId), [familyId]);
+  const label = leagueName ?? "League";
+  return (
+    <div className="flex flex-col gap-2 pb-2 border-b">
+      <span className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground truncate">
+        {label}
+      </span>
+      <div className="flex flex-col gap-2 pl-1">
+        {items.map((item) => {
+          const isActive = isLeagueItemActive(item, currentPath);
+          return (
+            <Link
+              key={item.label}
+              href={item.href}
+              onClick={onNavigate}
+              className={`text-sm transition-colors ${
+                isActive
+                  ? "text-foreground font-medium"
+                  : "text-muted-foreground hover:text-foreground"
+              }`}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 function UserChip({
   username,
   onSwitchUser,
@@ -181,16 +405,7 @@ function UserChip({
 }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement | null>(null);
-
-  useEffect(() => {
-    function onClickOutside(e: MouseEvent) {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
-      }
-    }
-    document.addEventListener("mousedown", onClickOutside);
-    return () => document.removeEventListener("mousedown", onClickOutside);
-  }, []);
+  useClickOutside(ref, () => setOpen(false));
 
   return (
     <div ref={ref} className="relative">

--- a/src/components/Subheader.tsx
+++ b/src/components/Subheader.tsx
@@ -13,7 +13,7 @@ export function Subheader({ title, rightSlot }: SubheaderProps) {
 
   return (
     <div
-      className={`sticky z-30 bg-background border-b border-border/50 transition-shadow ${
+      className={`sticky z-30 bg-background transition-shadow ${
         scrolled ? "shadow-sm" : ""
       }`}
       style={{ top: "var(--nav-height, 0px)" }}

--- a/src/components/Subheader.tsx
+++ b/src/components/Subheader.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { useScrolled } from "@/lib/useScrolled";
+
+interface SubheaderProps {
+  title: ReactNode;
+  rightSlot?: ReactNode;
+}
+
+export function Subheader({ title, rightSlot }: SubheaderProps) {
+  const scrolled = useScrolled();
+
+  return (
+    <div
+      className={`sticky z-30 bg-background border-b border-border/50 transition-shadow ${
+        scrolled ? "shadow-sm" : ""
+      }`}
+      style={{ top: "var(--nav-height, 0px)" }}
+    >
+      <div
+        className={`container mx-auto px-4 sm:px-6 py-3 ${
+          rightSlot
+            ? "flex flex-col sm:flex-row sm:items-center gap-2 sm:gap-4"
+            : "flex items-center gap-3 sm:gap-4"
+        }`}
+      >
+        <div className="min-w-0 flex-1">
+          {typeof title === "string" ? (
+            <h1 className="text-base sm:text-lg md:text-xl font-semibold line-clamp-1">
+              {title}
+            </h1>
+          ) : (
+            title
+          )}
+        </div>
+        {rightSlot && (
+          <div className="flex flex-wrap items-center gap-2">{rightSlot}</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/lib/useClickOutside.ts
+++ b/src/lib/useClickOutside.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, type RefObject } from "react";
+
+export function useClickOutside<T extends HTMLElement>(
+  ref: RefObject<T>,
+  onOutside: () => void
+): void {
+  useEffect(() => {
+    function handler(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        onOutside();
+      }
+    }
+    document.addEventListener("mousedown", handler);
+    return () => document.removeEventListener("mousedown", handler);
+  }, [ref, onOutside]);
+}

--- a/src/lib/useScrolled.ts
+++ b/src/lib/useScrolled.ts
@@ -1,0 +1,18 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function useScrolled(threshold = 0): boolean {
+  const [scrolled, setScrolled] = useState(false);
+
+  useEffect(() => {
+    function update() {
+      setScrolled(window.scrollY > threshold);
+    }
+    update();
+    window.addEventListener("scroll", update, { passive: true });
+    return () => window.removeEventListener("scroll", update);
+  }, [threshold]);
+
+  return scrolled;
+}


### PR DESCRIPTION
## Summary

Closes #117.

- **New `<Subheader>` component** (`title` + optional `rightSlot`) sticky-docked at `var(--nav-height)`. Replaces the five bespoke sub-header strips across the league pages. Back-links are dropped everywhere — browser back / swipe-back + the new hamburger League section cover up-nav and escape-to-home.
- **`PublicNav` is sticky** (`top-0 z-40`), publishes its height to `<body>` as `--nav-height` via a `ResizeObserver`, and grows a **route-conditional League section** on desktop (dropdown) and mobile (hamburger). Section header is the active league's actual name (demo-swap aware); items are Overview / Transactions / Drafts / Lineage Tracer.
- **Lineage Tracer hero card** on the league page (between season chips and Standings): sage-accented full-bleed card with the BrandMark helix as a trailing flourish, the whole card linking to `/graph?from=overview`.
- **Transactions filter chips** move into the Subheader's `rightSlot`.
- **Elevation cue** (`shadow-sm`) appears on both sticky bars when `window.scrollY > 0` via a small `useScrolled` hook.
- Title scaling: `text-base sm:text-lg md:text-xl` + `line-clamp-1` so 35+ char league names stay legible at 360px.
- Refactor: extracted `useClickOutside`, `isLeagueItemActive`, and a Promise-based league-name fetch dedupe so the new dropdown / mobile section / existing UserChip share primitives. ResizeObserver writes `--nav-height` only when height actually changes.

## Test plan

- [x] `npm run lint` clean (only pre-existing warnings)
- [x] `npm run build` clean
- [x] Desktop (1280×900): sticky nav + sub-header stack; subheader top equals `--nav-height` (65px); shadow appears on scroll; League dropdown shows Coaches Anonymous + 4 items with active state on Overview
- [x] Mobile iframe (360×800): hamburger menu shows the League section with the league name as the header label, plus the four nav items
- [x] League page hero card renders with sage tokens + helix glyph; whole card is the link to graph
- [x] Demo-swap propagates: hamburger League header reads "Coaches Anonymous" (not the real league name)
- [x] Player / Manager / Drafts / Transactions pages all render through `<Subheader>`; no back-links remain; transactions filter chips live in `rightSlot`
- [x] `--nav-height` body var stays in sync across viewport resize (ResizeObserver tested)
- [ ] Mobile Safari smoke test on a real device (sticky-inside-scroll-container regression check)
- [ ] Vercel preview spot-check

## Out of scope

- `/league/[familyId]/graph` (full-bleed canvas; deferred).
- Cross-page sharing of the league-name cache so the overview page can prime the nav's fetch (small win, separate PR).
- Promoting the duplicated rounded chip pattern across drafts / player / overview pages into a shared `<FilterChip>` (separate cleanup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)