### PR TITLE
Player page: hero header redesign + collapsible season×manager game log (#91, #90)

### DIFF
--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -148,28 +148,33 @@ export default function PlayerDetailPage() {
     setLoading(false);
   }
 
-  const filteredWeeks = useMemo(() => {
+  // Headline stats follow season + manager filters but ignore the status
+  // filter — they're identity-level numbers about rostership, not a slice
+  // of which weeks the user is currently inspecting.
+  const scopedWeeks = useMemo(() => {
     if (!data) return [];
-    let weeks = data.weeks;
-    if (selectedManager) {
-      weeks = weeks.filter((w) => w.manager?.userId === selectedManager);
-    }
+    if (!selectedManager) return data.weeks;
+    return data.weeks.filter((w) => w.manager?.userId === selectedManager);
+  }, [data, selectedManager]);
+
+  const filteredWeeks = useMemo(() => {
     if (selectedStatus === "starter") {
-      weeks = weeks.filter((w) => w.fantasyStatus === "starter");
-    } else if (selectedStatus === "bench") {
-      weeks = weeks.filter((w) => w.fantasyStatus === "bench");
+      return scopedWeeks.filter((w) => w.fantasyStatus === "starter");
     }
-    return weeks;
-  }, [data, selectedManager, selectedStatus]);
+    if (selectedStatus === "bench") {
+      return scopedWeeks.filter((w) => w.fantasyStatus === "bench");
+    }
+    return scopedWeeks;
+  }, [scopedWeeks, selectedStatus]);
 
   const stats = useMemo(() => {
-    if (filteredWeeks.length === 0) return null;
-    const totalWeeks = filteredWeeks.length;
-    const starterWeeks = filteredWeeks.filter((w) => w.fantasyStatus === "starter").length;
-    const totalPoints = filteredWeeks.reduce((sum, w) => sum + w.points, 0);
+    if (scopedWeeks.length === 0) return null;
+    const totalWeeks = scopedWeeks.length;
+    const starterWeeks = scopedWeeks.filter((w) => w.fantasyStatus === "starter").length;
+    const totalPoints = scopedWeeks.reduce((sum, w) => sum + w.points, 0);
     const ppgAll = totalPoints / totalWeeks;
     return { totalWeeks, starterWeeks, ppgAll };
-  }, [filteredWeeks]);
+  }, [scopedWeeks]);
 
   const sections: CollapsibleSection[] = useMemo(() => {
     type Stint = {
@@ -244,14 +249,6 @@ export default function PlayerDetailPage() {
 
   const { player, currentManager } = data;
   const statusLabel = playerStatusLabel(player.status, player.injuryStatus);
-  const metaParts: string[] = [];
-  if (player.team) metaParts.push(player.team);
-  if (player.age != null) metaParts.push(`${player.age} yo`);
-  if (player.yearsExp != null) {
-    metaParts.push(
-      player.yearsExp === 0 ? "Rookie" : `${player.yearsExp}y exp`
-    );
-  }
 
   return (
     <div>
@@ -269,58 +266,33 @@ export default function PlayerDetailPage() {
             )}
           </div>
         }
+        rightSlot={
+          graphEnabled ? (
+            <Link
+              href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
+              className="inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-full bg-primary/10 text-primary hover:bg-primary/15 transition-colors whitespace-nowrap"
+            >
+              <GitBranch className="h-3.5 w-3.5" />
+              Trace lineage
+            </Link>
+          ) : undefined
+        }
       />
 
-      <div className="border-b bg-card">
-        <div className="container mx-auto px-4 sm:px-6 py-5 sm:py-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-6">
-          <div className="min-w-0">
-            <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight truncate">
-              {player.name}
-            </h2>
-            <div className="mt-1 text-sm text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1">
-              {metaParts.map((part, i) => (
-                <Fragment key={`meta-${i}`}>
-                  {i > 0 && <span aria-hidden className="text-muted-foreground/50">·</span>}
-                  <span>{part}</span>
-                </Fragment>
-              ))}
-              {statusLabel && (
-                <>
-                  {metaParts.length > 0 && (
-                    <span aria-hidden className="text-muted-foreground/50">·</span>
-                  )}
-                  <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-grade-d/10 text-grade-d">
-                    {statusLabel}
-                  </span>
-                </>
-              )}
-            </div>
-            {graphEnabled && (
-              <Link
-                href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
-                className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-full bg-primary/10 text-primary hover:bg-primary/15 transition-colors"
-              >
-                <GitBranch className="h-3.5 w-3.5" />
-                Trace lineage
-              </Link>
-            )}
-          </div>
-
-          <CurrentManagerBlock
+      <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-8">
+          <PlayerMetaTile
+            team={player.team}
+            age={player.age}
+            yearsExp={player.yearsExp}
+            statusLabel={statusLabel}
+          />
+          <CurrentManagerTile
             familyId={familyId}
             currentManager={currentManager}
           />
+          {stats && <PlayerStatsTile stats={stats} />}
         </div>
-      </div>
-
-      <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
-        {stats && (
-          <div className="grid grid-cols-3 gap-3 sm:gap-4 mb-8">
-            <StatCard label="Weeks Rostered" value={stats.totalWeeks} />
-            <StatCard label="Weeks Started" value={stats.starterWeeks} />
-            <StatCard label="PPG" value={stats.ppgAll.toFixed(1)} />
-          </div>
-        )}
 
         <div className="flex flex-wrap gap-x-4 gap-y-3 mb-6">
           {data.availableSeasons.length > 1 && (
@@ -455,7 +427,54 @@ function WeeklyDetail({ weeks }: { weeks: WeekEntry[] }) {
   );
 }
 
-function CurrentManagerBlock({
+function PlayerMetaTile({
+  team,
+  age,
+  yearsExp,
+  statusLabel,
+}: {
+  team: string | null;
+  age: number | null;
+  yearsExp: number | null;
+  statusLabel: string | null;
+}) {
+  const parts: string[] = [];
+  if (team) parts.push(team);
+  if (age != null) parts.push(`${age} yo`);
+  if (yearsExp != null) {
+    parts.push(yearsExp === 0 ? "Rookie" : `${yearsExp}y exp`);
+  }
+
+  return (
+    <div className="border rounded-lg p-4 flex flex-col gap-1">
+      <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
+        Player
+      </div>
+      <div className="text-sm flex flex-wrap items-center gap-x-2 gap-y-1">
+        {parts.map((part, i) => (
+          <Fragment key={`meta-${i}`}>
+            {i > 0 && (
+              <span aria-hidden className="text-muted-foreground/50">·</span>
+            )}
+            <span>{part}</span>
+          </Fragment>
+        ))}
+        {statusLabel && (
+          <>
+            {parts.length > 0 && (
+              <span aria-hidden className="text-muted-foreground/50">·</span>
+            )}
+            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-grade-d/10 text-grade-d">
+              {statusLabel}
+            </span>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CurrentManagerTile({
   familyId,
   currentManager,
 }: {
@@ -464,11 +483,11 @@ function CurrentManagerBlock({
 }) {
   if (!currentManager) {
     return (
-      <div className="md:text-right text-sm text-muted-foreground inline-flex md:flex-col md:items-end items-center gap-1">
-        <span className="uppercase tracking-wide text-[11px] font-mono text-muted-foreground/70">
+      <div className="border rounded-lg p-4 flex flex-col gap-1">
+        <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
           Currently
-        </span>
-        <span>Free agent</span>
+        </div>
+        <div className="text-sm text-muted-foreground">Free agent</div>
       </div>
     );
   }
@@ -478,18 +497,18 @@ function CurrentManagerBlock({
   return (
     <Link
       href={`/league/${familyId}/manager/${currentManager.userId}`}
-      className="group flex items-center md:flex-row-reverse gap-3 rounded-lg p-2 -m-2 hover:bg-muted/50 transition-colors min-w-0"
+      className="group border rounded-lg p-4 flex items-center gap-3 hover:bg-muted/30 transition-colors min-w-0"
     >
       <ManagerAvatar
         displayName={currentManager.displayName}
         avatarUrl={currentManager.avatar}
-        size={44}
+        size={40}
       />
-      <div className="min-w-0 md:text-right">
+      <div className="min-w-0 flex-1">
         <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
           Currently rostered by
         </div>
-        <div className="font-semibold text-foreground truncate group-hover:text-primary transition-colors">
+        <div className="text-sm font-semibold text-foreground truncate group-hover:text-primary transition-colors">
           {teamLabel}
         </div>
         <ManagerSecondaryName
@@ -509,11 +528,28 @@ function CurrentManagerBlock({
   );
 }
 
-function StatCard({ label, value }: { label: string; value: string | number }) {
+function PlayerStatsTile({
+  stats,
+}: {
+  stats: { totalWeeks: number; starterWeeks: number; ppgAll: number };
+}) {
   return (
-    <div className="border rounded-lg p-4">
-      <div className="text-2xl font-bold">{value}</div>
-      <div className="text-xs text-muted-foreground">{label}</div>
+    <div className="border rounded-lg p-4 flex items-center gap-6">
+      <div className="min-w-0">
+        <div
+          className="text-2xl font-bold font-mono tabular-nums underline decoration-dotted decoration-muted-foreground/40 underline-offset-4 cursor-help"
+          title={`Started ${stats.starterWeeks} of ${stats.totalWeeks} weeks rostered`}
+        >
+          {stats.starterWeeks}/{stats.totalWeeks}
+        </div>
+        <div className="text-xs text-muted-foreground">Weeks Started</div>
+      </div>
+      <div className="min-w-0">
+        <div className="text-2xl font-bold font-mono tabular-nums">
+          {stats.ppgAll.toFixed(1)}
+        </div>
+        <div className="text-xs text-muted-foreground">PPG</div>
+      </div>
     </div>
   );
 }

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -34,6 +34,8 @@ interface WeekEntry {
   nflStatus: string | null;
   nflStatusAbbr: string | null;
   isByeWeek: boolean;
+  opponent: string | null;
+  isAway: boolean;
 }
 
 interface PlayerInfo {
@@ -400,6 +402,12 @@ export default function PlayerDetailPage() {
   );
 }
 
+function opponentLabel(w: WeekEntry): string {
+  if (w.isByeWeek) return "BYE";
+  if (!w.opponent) return "—";
+  return w.isAway ? `@${w.opponent}` : w.opponent;
+}
+
 function WeeklyDetail({ weeks }: { weeks: WeekEntry[] }) {
   return (
     <div className="border-t bg-muted/10 overflow-x-auto">
@@ -414,6 +422,10 @@ function WeeklyDetail({ weeks }: { weeks: WeekEntry[] }) {
             </th>
             <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide">
               Status
+            </th>
+            <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide">
+              <span className="hidden md:inline">Opponent</span>
+              <span className="md:hidden">Opp</span>
             </th>
             <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide text-right">
               Points
@@ -445,6 +457,7 @@ function WeeklyDetail({ weeks }: { weeks: WeekEntry[] }) {
                     {nflStatusLabel(w.nflStatus, w.isByeWeek)}
                   </span>
                 </td>
+                <td className="px-3 py-2 font-mono">{opponentLabel(w)}</td>
                 <td className="px-3 py-2 text-right font-mono">
                   {w.points.toFixed(1)}
                 </td>

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { Fragment, useEffect, useState, useMemo } from "react";
+import { type ReactNode, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
 import { GitBranch } from "lucide-react";
@@ -167,14 +167,28 @@ export default function PlayerDetailPage() {
     return scopedWeeks;
   }, [scopedWeeks, selectedStatus]);
 
+  // Started/Rostered ratio is identity-level (ignores status filter).
+  // PPG follows the status filter — Started/Benched switches the denominator
+  // so the headline number reflects what the user is looking at.
   const stats = useMemo(() => {
     if (scopedWeeks.length === 0) return null;
     const totalWeeks = scopedWeeks.length;
     const starterWeeks = scopedWeeks.filter((w) => w.fantasyStatus === "starter").length;
-    const totalPoints = scopedWeeks.reduce((sum, w) => sum + w.points, 0);
-    const ppgAll = totalPoints / totalWeeks;
-    return { totalWeeks, starterWeeks, ppgAll };
-  }, [scopedWeeks]);
+    const ppgWeeks =
+      selectedStatus === "all"
+        ? scopedWeeks
+        : scopedWeeks.filter((w) => w.fantasyStatus === selectedStatus);
+    const ppg = ppgWeeks.length
+      ? ppgWeeks.reduce((s, w) => s + w.points, 0) / ppgWeeks.length
+      : 0;
+    const ppgLabel =
+      selectedStatus === "starter"
+        ? "PPG when Started"
+        : selectedStatus === "bench"
+          ? "PPG on Bench"
+          : "PPG";
+    return { totalWeeks, starterWeeks, ppg, ppgLabel };
+  }, [scopedWeeks, selectedStatus]);
 
   const sections: CollapsibleSection[] = useMemo(() => {
     type Stint = {
@@ -280,8 +294,8 @@ export default function PlayerDetailPage() {
       />
 
       <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
-        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 sm:gap-4 mb-8">
-          <PlayerMetaTile
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4 mb-8">
+          <SituationTile
             team={player.team}
             age={player.age}
             yearsExp={player.yearsExp}
@@ -291,7 +305,12 @@ export default function PlayerDetailPage() {
             familyId={familyId}
             currentManager={currentManager}
           />
-          {stats && <PlayerStatsTile stats={stats} />}
+          {stats && (
+            <ProductionTile
+              stats={stats}
+              className="sm:row-span-2 lg:row-span-1"
+            />
+          )}
         </div>
 
         <div className="flex flex-wrap gap-x-4 gap-y-3 mb-6">
@@ -427,7 +446,39 @@ function WeeklyDetail({ weeks }: { weeks: WeekEntry[] }) {
   );
 }
 
-function PlayerMetaTile({
+function TileLabel({ children }: { children: ReactNode }) {
+  return (
+    <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
+      {children}
+    </div>
+  );
+}
+
+function StatBlock({
+  value,
+  label,
+  tooltip,
+  className,
+}: {
+  value: ReactNode;
+  label: ReactNode;
+  tooltip?: string;
+  className?: string;
+}) {
+  const valueClass = tooltip
+    ? "text-2xl font-bold font-mono tabular-nums underline decoration-dotted decoration-muted-foreground/40 underline-offset-4 cursor-help"
+    : "text-2xl font-bold font-mono tabular-nums";
+  return (
+    <div className={`min-w-0 flex-1 ${className ?? ""}`}>
+      <div className={valueClass} title={tooltip}>
+        {value}
+      </div>
+      <div className="text-xs text-muted-foreground mt-0.5">{label}</div>
+    </div>
+  );
+}
+
+function SituationTile({
   team,
   age,
   yearsExp,
@@ -438,37 +489,41 @@ function PlayerMetaTile({
   yearsExp: number | null;
   statusLabel: string | null;
 }) {
-  const parts: string[] = [];
-  if (team) parts.push(team);
-  if (age != null) parts.push(`${age} yo`);
+  const facts: { label: string; value: ReactNode }[] = [];
+  if (team) facts.push({ label: "Team", value: team });
+  if (age != null) facts.push({ label: "Age", value: age });
   if (yearsExp != null) {
-    parts.push(yearsExp === 0 ? "Rookie" : `${yearsExp}y exp`);
+    facts.push({
+      label: "Exp",
+      value: yearsExp === 0 ? "Rookie" : `${yearsExp}y`,
+    });
+  }
+  if (statusLabel) {
+    facts.push({
+      label: "Status",
+      value: (
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-grade-d/10 text-grade-d">
+          {statusLabel}
+        </span>
+      ),
+    });
   }
 
   return (
-    <div className="border rounded-lg p-4 flex flex-col gap-1">
-      <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
-        Player
-      </div>
-      <div className="text-sm flex flex-wrap items-center gap-x-2 gap-y-1">
-        {parts.map((part, i) => (
-          <Fragment key={`meta-${i}`}>
-            {i > 0 && (
-              <span aria-hidden className="text-muted-foreground/50">·</span>
-            )}
-            <span>{part}</span>
-          </Fragment>
+    <div className="border rounded-lg p-4 flex flex-col gap-3">
+      <TileLabel>Situation</TileLabel>
+      <div className="flex items-center divide-x divide-border/60">
+        {facts.map((f, i) => (
+          <div
+            key={i}
+            className="px-3 first:pl-0 last:pr-0 min-w-0 flex-1"
+          >
+            <div className="text-base font-semibold truncate">{f.value}</div>
+            <div className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground mt-0.5">
+              {f.label}
+            </div>
+          </div>
         ))}
-        {statusLabel && (
-          <>
-            {parts.length > 0 && (
-              <span aria-hidden className="text-muted-foreground/50">·</span>
-            )}
-            <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-grade-d/10 text-grade-d">
-              {statusLabel}
-            </span>
-          </>
-        )}
       </div>
     </div>
   );
@@ -483,10 +538,8 @@ function CurrentManagerTile({
 }) {
   if (!currentManager) {
     return (
-      <div className="border rounded-lg p-4 flex flex-col gap-1">
-        <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
-          Currently
-        </div>
+      <div className="border rounded-lg p-4 flex flex-col gap-3">
+        <TileLabel>Currently</TileLabel>
         <div className="text-sm text-muted-foreground">Free agent</div>
       </div>
     );
@@ -499,16 +552,9 @@ function CurrentManagerTile({
       href={`/league/${familyId}/manager/${currentManager.userId}`}
       className="group border rounded-lg p-4 flex items-center gap-3 hover:bg-muted/30 transition-colors min-w-0"
     >
-      <ManagerAvatar
-        displayName={currentManager.displayName}
-        avatarUrl={currentManager.avatar}
-        size={40}
-      />
       <div className="min-w-0 flex-1">
-        <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
-          Currently rostered by
-        </div>
-        <div className="text-sm font-semibold text-foreground truncate group-hover:text-primary transition-colors">
+        <TileLabel>Currently rostered by</TileLabel>
+        <div className="mt-1 text-sm font-semibold text-foreground truncate group-hover:text-primary transition-colors">
           {teamLabel}
         </div>
         <ManagerSecondaryName
@@ -524,31 +570,43 @@ function CurrentManagerTile({
           </div>
         )}
       </div>
+      <ManagerAvatar
+        displayName={currentManager.displayName}
+        avatarUrl={currentManager.avatar}
+        size={40}
+      />
     </Link>
   );
 }
 
-function PlayerStatsTile({
+function ProductionTile({
   stats,
+  className,
 }: {
-  stats: { totalWeeks: number; starterWeeks: number; ppgAll: number };
+  stats: {
+    totalWeeks: number;
+    starterWeeks: number;
+    ppg: number;
+    ppgLabel: string;
+  };
+  className?: string;
 }) {
   return (
-    <div className="border rounded-lg p-4 flex items-center gap-6">
-      <div className="min-w-0">
+    <div
+      className={`border rounded-lg p-4 flex flex-col gap-3 ${className ?? ""}`}
+    >
+      <TileLabel>Production</TileLabel>
+      <div className="flex-1 flex flex-row sm:flex-col lg:flex-row sm:justify-center gap-4 sm:gap-3 lg:gap-4">
+        <StatBlock
+          value={`${stats.starterWeeks}/${stats.totalWeeks}`}
+          label="Weeks Started"
+          tooltip={`Started ${stats.starterWeeks} of ${stats.totalWeeks} weeks rostered`}
+        />
         <div
-          className="text-2xl font-bold font-mono tabular-nums underline decoration-dotted decoration-muted-foreground/40 underline-offset-4 cursor-help"
-          title={`Started ${stats.starterWeeks} of ${stats.totalWeeks} weeks rostered`}
-        >
-          {stats.starterWeeks}/{stats.totalWeeks}
-        </div>
-        <div className="text-xs text-muted-foreground">Weeks Started</div>
-      </div>
-      <div className="min-w-0">
-        <div className="text-2xl font-bold font-mono tabular-nums">
-          {stats.ppgAll.toFixed(1)}
-        </div>
-        <div className="text-xs text-muted-foreground">PPG</div>
+          aria-hidden
+          className="border-l sm:border-l-0 sm:border-t lg:border-t-0 lg:border-l border-border/60"
+        />
+        <StatBlock value={stats.ppg.toFixed(1)} label={stats.ppgLabel} />
       </div>
     </div>
   );

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -132,15 +132,12 @@ export default function PlayerDetailPage() {
 
   useEffect(() => {
     loadData();
-  }, [familyId, playerId, selectedSeason]);
+  }, [familyId, playerId]);
 
   async function loadData() {
     setLoading(true);
-    const params = new URLSearchParams();
-    if (selectedSeason) params.set("season", selectedSeason);
-
     const res = await fetch(
-      `/api/leagues/${familyId}/player/${playerId}/weekly-log?${params.toString()}`
+      `/api/leagues/${familyId}/player/${playerId}/weekly-log`
     );
     if (res.ok) {
       setData(await res.json());
@@ -148,14 +145,19 @@ export default function PlayerDetailPage() {
     setLoading(false);
   }
 
-  // Headline stats follow season + manager filters but ignore the status
-  // filter — they're identity-level numbers about rostership, not a slice
-  // of which weeks the user is currently inspecting.
+  // Season + manager filters narrow the headline stats; status filter only
+  // affects PPG (handled below) and which weeks appear in the game log.
+  // currentManager comes straight from the API and is always all-time —
+  // never narrowed by any filter.
   const scopedWeeks = useMemo(() => {
     if (!data) return [];
-    if (!selectedManager) return data.weeks;
-    return data.weeks.filter((w) => w.manager?.userId === selectedManager);
-  }, [data, selectedManager]);
+    let weeks = data.weeks;
+    if (selectedSeason) weeks = weeks.filter((w) => w.season === selectedSeason);
+    if (selectedManager) {
+      weeks = weeks.filter((w) => w.manager?.userId === selectedManager);
+    }
+    return weeks;
+  }, [data, selectedSeason, selectedManager]);
 
   const filteredWeeks = useMemo(() => {
     if (selectedStatus === "starter") {

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -159,6 +159,15 @@ export default function PlayerDetailPage() {
     return weeks;
   }, [data, selectedSeason, selectedManager]);
 
+  // Only seasons where the player actually has scoring rows — not every
+  // season in the league family.
+  const seasonsWithData = useMemo(() => {
+    if (!data) return [];
+    return [...new Set(data.weeks.map((w) => w.season))].sort(
+      (a, b) => parseInt(b, 10) - parseInt(a, 10)
+    );
+  }, [data]);
+
   const filteredWeeks = useMemo(() => {
     if (selectedStatus === "starter") {
       return scopedWeeks.filter((w) => w.fantasyStatus === "starter");
@@ -316,7 +325,7 @@ export default function PlayerDetailPage() {
         </div>
 
         <div className="flex flex-wrap gap-x-4 gap-y-3 mb-6">
-          {data.availableSeasons.length > 1 && (
+          {seasonsWithData.length > 1 && (
             <div className="flex flex-wrap gap-2">
               <FilterChip
                 active={!selectedSeason}
@@ -324,7 +333,7 @@ export default function PlayerDetailPage() {
               >
                 All Seasons
               </FilterChip>
-              {data.availableSeasons.map((s) => (
+              {seasonsWithData.map((s) => (
                 <FilterChip
                   key={s}
                   active={selectedSeason === s}

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -189,14 +189,17 @@ export default function PlayerDetailPage() {
   // Started/Rostered ratio is identity-level (ignores status filter).
   // PPG follows the status filter — Started/Benched switches the denominator
   // so the headline number reflects what the user is looking at.
+  // Bye weeks are excluded from every calc — a bye is not a fantasy
+  // opportunity, so counting it inflates "rostered" and drags PPG down.
   const stats = useMemo(() => {
-    if (scopedWeeks.length === 0) return null;
-    const totalWeeks = scopedWeeks.length;
-    const starterWeeks = scopedWeeks.filter((w) => w.fantasyStatus === "starter").length;
+    const playedWeeks = scopedWeeks.filter((w) => !w.isByeWeek);
+    if (playedWeeks.length === 0) return null;
+    const totalWeeks = playedWeeks.length;
+    const starterWeeks = playedWeeks.filter((w) => w.fantasyStatus === "starter").length;
     const ppgWeeks =
       selectedStatus === "all"
-        ? scopedWeeks
-        : scopedWeeks.filter((w) => w.fantasyStatus === selectedStatus);
+        ? playedWeeks
+        : playedWeeks.filter((w) => w.fantasyStatus === selectedStatus);
     const ppg = ppgWeeks.length
       ? ppgWeeks.reduce((s, w) => s + w.points, 0) / ppgWeeks.length
       : 0;
@@ -209,13 +212,14 @@ export default function PlayerDetailPage() {
     return { totalWeeks, starterWeeks, ppg, ppgLabel };
   }, [scopedWeeks, selectedStatus, selectedLocation]);
 
+  // Per-stint aggregates exclude byes so "wks", "started", "pts", "ppg"
+  // all describe playable weeks. The detail table still renders all
+  // weeks (including bye rows) — exclusion is for calcs, not display.
   const sections: CollapsibleSection[] = useMemo(() => {
     type Stint = {
       key: string;
       managerDisplayName: string | null;
       weeks: WeekEntry[];
-      starterWeeks: number;
-      totalPoints: number;
     };
     const map = new Map<string, Map<string, Stint>>();
     for (const w of filteredWeeks) {
@@ -228,39 +232,44 @@ export default function PlayerDetailPage() {
           key: `${w.season}|${userKey}`,
           managerDisplayName: w.manager?.displayName ?? null,
           weeks: [],
-          starterWeeks: 0,
-          totalPoints: 0,
         };
         seasonMap.set(userKey, stint);
       }
       stint.weeks.push(w);
-      if (w.fantasyStatus === "starter") stint.starterWeeks++;
-      stint.totalPoints += w.points;
     }
+
+    function aggregate(weeks: WeekEntry[]) {
+      const played = weeks.filter((w) => !w.isByeWeek);
+      const totalPoints = played.reduce((s, w) => s + w.points, 0);
+      return {
+        totalWeeks: played.length,
+        starterWeeks: played.filter((w) => w.fantasyStatus === "starter").length,
+        totalPoints,
+        ppg: played.length ? totalPoints / played.length : 0,
+      };
+    }
+
     return [...map.entries()]
       .sort(([a], [b]) => parseInt(b, 10) - parseInt(a, 10))
       .map(([season, stintMap]) => ({
         key: season,
         heading: `${season} Season`,
         rows: [...stintMap.values()]
-          .sort((a, b) => b.totalPoints - a.totalPoints)
-          .map((stint) => {
-            const totalWeeks = stint.weeks.length;
-            const ppgAll = totalWeeks ? stint.totalPoints / totalWeeks : 0;
-            return {
-              key: stint.key,
-              title: stint.managerDisplayName ?? "Unrostered",
-              meta: (
-                <>
-                  <span>{totalWeeks} wks</span>
-                  <span>{stint.starterWeeks} started</span>
-                  <span>{stint.totalPoints.toFixed(1)} pts</span>
-                  <span>{ppgAll.toFixed(1)} ppg</span>
-                </>
-              ),
-              detail: <WeeklyDetail weeks={stint.weeks} />,
-            };
-          }),
+          .map((stint) => ({ stint, agg: aggregate(stint.weeks) }))
+          .sort((a, b) => b.agg.totalPoints - a.agg.totalPoints)
+          .map(({ stint, agg }) => ({
+            key: stint.key,
+            title: stint.managerDisplayName ?? "Unrostered",
+            meta: (
+              <>
+                <span>{agg.totalWeeks} wks</span>
+                <span>{agg.starterWeeks} started</span>
+                <span>{agg.totalPoints.toFixed(1)} pts</span>
+                <span>{agg.ppg.toFixed(1)} ppg</span>
+              </>
+            ),
+            detail: <WeeklyDetail weeks={stint.weeks} />,
+          })),
       }));
   }, [filteredWeeks]);
 

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -131,6 +131,7 @@ export default function PlayerDetailPage() {
   const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
   const [selectedManager, setSelectedManager] = useState<string | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<"all" | "starter" | "bench">("all");
+  const [selectedLocation, setSelectedLocation] = useState<"all" | "home" | "away">("all");
 
   useEffect(() => {
     loadData();
@@ -158,8 +159,13 @@ export default function PlayerDetailPage() {
     if (selectedManager) {
       weeks = weeks.filter((w) => w.manager?.userId === selectedManager);
     }
+    if (selectedLocation === "home") {
+      weeks = weeks.filter((w) => w.opponent !== null && !w.isAway);
+    } else if (selectedLocation === "away") {
+      weeks = weeks.filter((w) => w.opponent !== null && w.isAway);
+    }
     return weeks;
-  }, [data, selectedSeason, selectedManager]);
+  }, [data, selectedSeason, selectedManager, selectedLocation]);
 
   // Only seasons where the player actually has scoring rows — not every
   // season in the league family.
@@ -194,14 +200,14 @@ export default function PlayerDetailPage() {
     const ppg = ppgWeeks.length
       ? ppgWeeks.reduce((s, w) => s + w.points, 0) / ppgWeeks.length
       : 0;
-    const ppgLabel =
-      selectedStatus === "starter"
-        ? "PPG when Started"
-        : selectedStatus === "bench"
-          ? "PPG on Bench"
-          : "PPG";
+    const suffixes: string[] = [];
+    if (selectedLocation === "home") suffixes.push("Home");
+    if (selectedLocation === "away") suffixes.push("Away");
+    if (selectedStatus === "starter") suffixes.push("Started");
+    if (selectedStatus === "bench") suffixes.push("Bench");
+    const ppgLabel = suffixes.length ? `PPG · ${suffixes.join(" · ")}` : "PPG";
     return { totalWeeks, starterWeeks, ppg, ppgLabel };
-  }, [scopedWeeks, selectedStatus]);
+  }, [scopedWeeks, selectedStatus, selectedLocation]);
 
   const sections: CollapsibleSection[] = useMemo(() => {
     type Stint = {
@@ -389,6 +395,27 @@ export default function PlayerDetailPage() {
               onClick={() => setSelectedStatus("bench")}
             >
               Benched
+            </FilterChip>
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            <FilterChip
+              active={selectedLocation === "all"}
+              onClick={() => setSelectedLocation("all")}
+            >
+              All
+            </FilterChip>
+            <FilterChip
+              active={selectedLocation === "home"}
+              onClick={() => setSelectedLocation("home")}
+            >
+              Home
+            </FilterChip>
+            <FilterChip
+              active={selectedLocation === "away"}
+              onClick={() => setSelectedLocation("away")}
+            >
+              Away
             </FilterChip>
           </div>
         </div>

--- a/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/player/[playerId]/page.tsx
@@ -2,9 +2,21 @@
 
 import { Fragment, useEffect, useState, useMemo } from "react";
 import { useParams } from "next/navigation";
-import { ManagerName } from "@/components/ManagerName";
+import Link from "next/link";
+import { GitBranch } from "lucide-react";
+import {
+  ManagerName,
+  ManagerAvatar,
+  ManagerSecondaryName,
+} from "@/components/ManagerName";
 import { PositionChip } from "@/components/PositionChip";
+import { FilterChip } from "@/components/FilterChip";
 import { Subheader } from "@/components/Subheader";
+import {
+  CollapsibleSeasonTable,
+  type CollapsibleSection,
+} from "@/components/CollapsibleSeasonTable";
+import { useFlag } from "@/lib/useFlag";
 
 interface Manager {
   userId: string;
@@ -30,6 +42,19 @@ interface PlayerInfo {
   position: string | null;
   team: string | null;
   gsisId: string | null;
+  age: number | null;
+  yearsExp: number | null;
+  status: string | null;
+  injuryStatus: string | null;
+}
+
+interface CurrentManager {
+  userId: string;
+  rosterId: number;
+  displayName: string;
+  teamName: string | null;
+  avatar: string | null;
+  rosteredSince: { season: string; week: number } | null;
 }
 
 interface WeeklyLogData {
@@ -37,6 +62,19 @@ interface WeeklyLogData {
   weeks: WeekEntry[];
   managers: Manager[];
   availableSeasons: string[];
+  currentManager: CurrentManager | null;
+}
+
+// Injury detail (Out/Doubtful/Questionable) takes priority over roster status:
+// it's the more actionable signal for fantasy decisions.
+function playerStatusLabel(
+  status: string | null,
+  injuryStatus: string | null
+): string | null {
+  if (injuryStatus) return injuryStatus;
+  if (status === "Injured Reserve") return "IR";
+  if (status === "Inactive") return "Inactive";
+  return null;
 }
 
 function nflStatusLabel(status: string | null, isByeWeek: boolean): string {
@@ -86,8 +124,8 @@ export default function PlayerDetailPage() {
 
   const [data, setData] = useState<WeeklyLogData | null>(null);
   const [loading, setLoading] = useState(true);
+  const graphEnabled = useFlag("ASSET_GRAPH_BROWSER");
 
-  // Filters
   const [selectedSeason, setSelectedSeason] = useState<string | null>(null);
   const [selectedManager, setSelectedManager] = useState<string | null>(null);
   const [selectedStatus, setSelectedStatus] = useState<"all" | "starter" | "bench">("all");
@@ -110,7 +148,6 @@ export default function PlayerDetailPage() {
     setLoading(false);
   }
 
-  // Client-side filters (manager + starter/bench applied after fetch)
   const filteredWeeks = useMemo(() => {
     if (!data) return [];
     let weeks = data.weeks;
@@ -125,34 +162,68 @@ export default function PlayerDetailPage() {
     return weeks;
   }, [data, selectedManager, selectedStatus]);
 
-  // Summary stats
   const stats = useMemo(() => {
     if (filteredWeeks.length === 0) return null;
     const totalWeeks = filteredWeeks.length;
     const starterWeeks = filteredWeeks.filter((w) => w.fantasyStatus === "starter").length;
-    const benchWeeks = totalWeeks - starterWeeks;
     const totalPoints = filteredWeeks.reduce((sum, w) => sum + w.points, 0);
-    const starterPoints = filteredWeeks
-      .filter((w) => w.fantasyStatus === "starter")
-      .reduce((sum, w) => sum + w.points, 0);
     const ppgAll = totalPoints / totalWeeks;
-    const ppgStarter = starterWeeks > 0 ? starterPoints / starterWeeks : 0;
-
-    return { totalWeeks, starterWeeks, benchWeeks, totalPoints, ppgAll, ppgStarter };
+    return { totalWeeks, starterWeeks, ppgAll };
   }, [filteredWeeks]);
 
-  // Group weeks by season for dividers
-  const groupedWeeks = useMemo(() => {
-    const groups: { season: string; weeks: WeekEntry[] }[] = [];
-    let currentSeason = "";
+  const sections: CollapsibleSection[] = useMemo(() => {
+    type Stint = {
+      key: string;
+      managerDisplayName: string | null;
+      weeks: WeekEntry[];
+      starterWeeks: number;
+      totalPoints: number;
+    };
+    const map = new Map<string, Map<string, Stint>>();
     for (const w of filteredWeeks) {
-      if (w.season !== currentSeason) {
-        currentSeason = w.season;
-        groups.push({ season: currentSeason, weeks: [] });
+      const userKey = w.manager?.userId ?? "__unrostered";
+      if (!map.has(w.season)) map.set(w.season, new Map());
+      const seasonMap = map.get(w.season)!;
+      let stint = seasonMap.get(userKey);
+      if (!stint) {
+        stint = {
+          key: `${w.season}|${userKey}`,
+          managerDisplayName: w.manager?.displayName ?? null,
+          weeks: [],
+          starterWeeks: 0,
+          totalPoints: 0,
+        };
+        seasonMap.set(userKey, stint);
       }
-      groups[groups.length - 1].weeks.push(w);
+      stint.weeks.push(w);
+      if (w.fantasyStatus === "starter") stint.starterWeeks++;
+      stint.totalPoints += w.points;
     }
-    return groups;
+    return [...map.entries()]
+      .sort(([a], [b]) => parseInt(b, 10) - parseInt(a, 10))
+      .map(([season, stintMap]) => ({
+        key: season,
+        heading: `${season} Season`,
+        rows: [...stintMap.values()]
+          .sort((a, b) => b.totalPoints - a.totalPoints)
+          .map((stint) => {
+            const totalWeeks = stint.weeks.length;
+            const ppgAll = totalWeeks ? stint.totalPoints / totalWeeks : 0;
+            return {
+              key: stint.key,
+              title: stint.managerDisplayName ?? "Unrostered",
+              meta: (
+                <>
+                  <span>{totalWeeks} wks</span>
+                  <span>{stint.starterWeeks} started</span>
+                  <span>{stint.totalPoints.toFixed(1)} pts</span>
+                  <span>{ppgAll.toFixed(1)} ppg</span>
+                </>
+              ),
+              detail: <WeeklyDetail weeks={stint.weeks} />,
+            };
+          }),
+      }));
   }, [filteredWeeks]);
 
   if (loading) {
@@ -171,73 +242,117 @@ export default function PlayerDetailPage() {
     );
   }
 
-  const { player } = data;
+  const { player, currentManager } = data;
+  const statusLabel = playerStatusLabel(player.status, player.injuryStatus);
+  const metaParts: string[] = [];
+  if (player.team) metaParts.push(player.team);
+  if (player.age != null) metaParts.push(`${player.age} yo`);
+  if (player.yearsExp != null) {
+    metaParts.push(
+      player.yearsExp === 0 ? "Rookie" : `${player.yearsExp}y exp`
+    );
+  }
 
   return (
-      <div>
-        <Subheader
-          title={
-            <div className="min-w-0 flex items-center gap-2">
-              <PositionChip position={player.position} />
-              <h1 className="text-base sm:text-lg md:text-xl font-semibold line-clamp-1">
-                {player.name}
-              </h1>
-              {player.team && (
-                <span className="text-sm text-muted-foreground shrink-0">
-                  {player.team}
-                </span>
+    <div>
+      <Subheader
+        title={
+          <div className="min-w-0 flex items-center gap-2">
+            <PositionChip position={player.position} />
+            <h1 className="text-base sm:text-lg md:text-xl font-semibold line-clamp-1">
+              {player.name}
+            </h1>
+            {player.team && (
+              <span className="text-sm text-muted-foreground shrink-0">
+                {player.team}
+              </span>
+            )}
+          </div>
+        }
+      />
+
+      <div className="border-b bg-card">
+        <div className="container mx-auto px-4 sm:px-6 py-5 sm:py-6 flex flex-col md:flex-row md:items-center md:justify-between gap-4 md:gap-6">
+          <div className="min-w-0">
+            <h2 className="text-2xl sm:text-3xl font-semibold tracking-tight truncate">
+              {player.name}
+            </h2>
+            <div className="mt-1 text-sm text-muted-foreground flex flex-wrap items-center gap-x-2 gap-y-1">
+              {metaParts.map((part, i) => (
+                <Fragment key={`meta-${i}`}>
+                  {i > 0 && <span aria-hidden className="text-muted-foreground/50">·</span>}
+                  <span>{part}</span>
+                </Fragment>
+              ))}
+              {statusLabel && (
+                <>
+                  {metaParts.length > 0 && (
+                    <span aria-hidden className="text-muted-foreground/50">·</span>
+                  )}
+                  <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-grade-d/10 text-grade-d">
+                    {statusLabel}
+                  </span>
+                </>
               )}
             </div>
-          }
-        />
+            {graphEnabled && (
+              <Link
+                href={`/league/${familyId}/graph?seedPlayerId=${playerId}&from=player`}
+                className="mt-3 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm rounded-full bg-primary/10 text-primary hover:bg-primary/15 transition-colors"
+              >
+                <GitBranch className="h-3.5 w-3.5" />
+                Trace lineage
+              </Link>
+            )}
+          </div>
 
-        <main className="container mx-auto px-6 py-8">
-        {/* Summary Stats */}
+          <CurrentManagerBlock
+            familyId={familyId}
+            currentManager={currentManager}
+          />
+        </div>
+      </div>
+
+      <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8">
         {stats && (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-4 mb-8">
+          <div className="grid grid-cols-3 gap-3 sm:gap-4 mb-8">
             <StatCard label="Weeks Rostered" value={stats.totalWeeks} />
             <StatCard label="Weeks Started" value={stats.starterWeeks} />
-            <StatCard label="Weeks Benched" value={stats.benchWeeks} />
-            <StatCard label="Total Points" value={stats.totalPoints.toFixed(1)} />
-            <StatCard label="PPG (Started)" value={stats.ppgStarter.toFixed(1)} />
-            <StatCard label="PPG (All)" value={stats.ppgAll.toFixed(1)} />
+            <StatCard label="PPG" value={stats.ppgAll.toFixed(1)} />
           </div>
         )}
 
-        {/* Filters */}
-        <div className="flex flex-wrap gap-4 mb-6">
-          {/* Season filter */}
+        <div className="flex flex-wrap gap-x-4 gap-y-3 mb-6">
           {data.availableSeasons.length > 1 && (
-            <div className="flex gap-2">
-              <FilterButton
+            <div className="flex flex-wrap gap-2">
+              <FilterChip
                 active={!selectedSeason}
                 onClick={() => setSelectedSeason(null)}
               >
                 All Seasons
-              </FilterButton>
+              </FilterChip>
               {data.availableSeasons.map((s) => (
-                <FilterButton
+                <FilterChip
                   key={s}
                   active={selectedSeason === s}
                   onClick={() => setSelectedSeason(s)}
                 >
                   {s}
-                </FilterButton>
+                </FilterChip>
               ))}
             </div>
           )}
 
-          {/* Manager filter */}
           {data.managers.length > 1 && (
-            <div className="flex gap-2">
-              <FilterButton
+            <div className="flex flex-wrap gap-2">
+              <FilterChip
                 active={!selectedManager}
                 onClick={() => setSelectedManager(null)}
               >
                 All Managers
-              </FilterButton>
+              </FilterChip>
               {data.managers.map((m) => (
-                <FilterButton
+                <FilterChip
                   key={m.userId}
                   active={selectedManager === m.userId}
                   onClick={() => setSelectedManager(m.userId)}
@@ -247,114 +362,150 @@ export default function PlayerDetailPage() {
                     displayName={m.displayName}
                     variant="display-only"
                   />
-                </FilterButton>
+                </FilterChip>
               ))}
             </div>
           )}
 
-          {/* Status filter */}
-          <div className="flex gap-2">
-            <FilterButton
+          <div className="flex flex-wrap gap-2">
+            <FilterChip
               active={selectedStatus === "all"}
               onClick={() => setSelectedStatus("all")}
             >
               All
-            </FilterButton>
-            <FilterButton
+            </FilterChip>
+            <FilterChip
               active={selectedStatus === "starter"}
               onClick={() => setSelectedStatus("starter")}
             >
               Started
-            </FilterButton>
-            <FilterButton
+            </FilterChip>
+            <FilterChip
               active={selectedStatus === "bench"}
               onClick={() => setSelectedStatus("bench")}
             >
               Benched
-            </FilterButton>
+            </FilterChip>
           </div>
         </div>
 
-        {/* Weekly Log Table */}
-        {filteredWeeks.length === 0 ? (
-          <p className="text-muted-foreground text-center py-8">
-            No weekly data found for this player
-          </p>
-        ) : (
-          <div className="border rounded-lg overflow-hidden">
-            <table className="w-full">
-              <thead className="bg-muted/50">
-                <tr className="text-left text-sm">
-                  <th className="px-4 py-3 font-medium">Week</th>
-                  <th className="px-4 py-3 font-medium">Manager</th>
-                  <th className="px-4 py-3 font-medium">Status</th>
-                  <th className="px-4 py-3 font-medium">NFL</th>
-                  <th className="px-4 py-3 font-medium text-right">Points</th>
-                </tr>
-              </thead>
-              <tbody>
-                {groupedWeeks.map((group) => (
-                  <Fragment key={`group-${group.season}`}>
-                    {/* Season divider */}
-                    {data.availableSeasons.length > 1 && (
-                      <tr>
-                        <td
-                          colSpan={5}
-                          className="px-4 py-2 bg-muted/30 text-xs font-semibold text-muted-foreground uppercase tracking-wider"
-                        >
-                          {group.season} Season
-                        </td>
-                      </tr>
-                    )}
-                    {group.weeks.map((w) => {
-                      const badge = fantasyStatusBadge(w);
-                      return (
-                        <tr
-                          key={`${w.leagueId}-${w.season}-${w.week}`}
-                          className="border-t hover:bg-muted/30 transition-colors"
-                        >
-                          <td className="px-4 py-3 text-sm font-mono">
-                            W{w.week}
-                          </td>
-                          <td className="px-4 py-3 text-sm">
-                            {w.manager ? (
-                              <ManagerName
-                                userId={w.manager.userId}
-                                rosterId={w.manager.rosterId}
-                                displayName={w.manager.displayName}
-                                variant="display-only"
-                                fallback="—"
-                              />
-                            ) : (
-                              "—"
-                            )}
-                          </td>
-                          <td className="px-4 py-3">
-                            <span
-                              className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${badge.className}`}
-                            >
-                              {badge.label}
-                            </span>
-                          </td>
-                          <td className="px-4 py-3">
-                            <span className={`text-sm ${nflStatusColor(w.nflStatus, w.isByeWeek)}`}>
-                              {nflStatusLabel(w.nflStatus, w.isByeWeek)}
-                            </span>
-                          </td>
-                          <td className="px-4 py-3 text-right font-mono text-sm">
-                            {w.points.toFixed(1)}
-                          </td>
-                        </tr>
-                      );
-                    })}
-                  </Fragment>
-                ))}
-              </tbody>
-            </table>
+        <CollapsibleSeasonTable
+          sections={sections}
+          emptyMessage="No weekly data found for this player"
+        />
+      </main>
+    </div>
+  );
+}
+
+function WeeklyDetail({ weeks }: { weeks: WeekEntry[] }) {
+  return (
+    <div className="border-t bg-muted/10 overflow-x-auto">
+      <table className="w-full text-sm border-collapse">
+        <thead className="bg-muted/30 text-left">
+          <tr>
+            <th className="sticky left-0 z-10 bg-muted/30 px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide shadow-[1px_0_0_0_var(--border)]">
+              Week
+            </th>
+            <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide">
+              Lineup
+            </th>
+            <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide">
+              Status
+            </th>
+            <th className="px-3 py-2 font-medium font-mono text-xs uppercase tracking-wide text-right">
+              Points
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {weeks.map((w) => {
+            const badge = fantasyStatusBadge(w);
+            return (
+              <tr
+                key={`${w.leagueId}-${w.season}-${w.week}`}
+                className="border-t border-border/60"
+              >
+                <td className="sticky left-0 z-10 bg-card px-3 py-2 font-mono shadow-[1px_0_0_0_var(--border)]">
+                  W{w.week}
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`inline-block px-2 py-0.5 text-xs font-medium rounded-full ${badge.className}`}
+                  >
+                    {badge.label}
+                  </span>
+                </td>
+                <td className="px-3 py-2">
+                  <span
+                    className={`${nflStatusColor(w.nflStatus, w.isByeWeek)}`}
+                  >
+                    {nflStatusLabel(w.nflStatus, w.isByeWeek)}
+                  </span>
+                </td>
+                <td className="px-3 py-2 text-right font-mono">
+                  {w.points.toFixed(1)}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function CurrentManagerBlock({
+  familyId,
+  currentManager,
+}: {
+  familyId: string;
+  currentManager: CurrentManager | null;
+}) {
+  if (!currentManager) {
+    return (
+      <div className="md:text-right text-sm text-muted-foreground inline-flex md:flex-col md:items-end items-center gap-1">
+        <span className="uppercase tracking-wide text-[11px] font-mono text-muted-foreground/70">
+          Currently
+        </span>
+        <span>Free agent</span>
+      </div>
+    );
+  }
+
+  const teamLabel = currentManager.teamName || currentManager.displayName;
+
+  return (
+    <Link
+      href={`/league/${familyId}/manager/${currentManager.userId}`}
+      className="group flex items-center md:flex-row-reverse gap-3 rounded-lg p-2 -m-2 hover:bg-muted/50 transition-colors min-w-0"
+    >
+      <ManagerAvatar
+        displayName={currentManager.displayName}
+        avatarUrl={currentManager.avatar}
+        size={44}
+      />
+      <div className="min-w-0 md:text-right">
+        <div className="text-[11px] font-mono uppercase tracking-wide text-muted-foreground">
+          Currently rostered by
+        </div>
+        <div className="font-semibold text-foreground truncate group-hover:text-primary transition-colors">
+          {teamLabel}
+        </div>
+        <ManagerSecondaryName
+          displayName={currentManager.displayName}
+          teamName={currentManager.teamName}
+          parens={false}
+          className="block text-xs text-muted-foreground truncate"
+        />
+        {currentManager.rosteredSince && (
+          <div className="text-xs text-muted-foreground mt-0.5">
+            Since W{currentManager.rosteredSince.week}{" "}
+            {currentManager.rosteredSince.season}
           </div>
         )}
-      </main>
       </div>
+    </Link>
   );
 }
 
@@ -364,28 +515,5 @@ function StatCard({ label, value }: { label: string; value: string | number }) {
       <div className="text-2xl font-bold">{value}</div>
       <div className="text-xs text-muted-foreground">{label}</div>
     </div>
-  );
-}
-
-function FilterButton({
-  active,
-  onClick,
-  children,
-}: {
-  active: boolean;
-  onClick: () => void;
-  children: React.ReactNode;
-}) {
-  return (
-    <button
-      onClick={onClick}
-      className={`px-3 py-1 text-sm rounded-full transition-colors ${
-        active
-          ? "bg-primary text-primary-foreground"
-          : "bg-secondary text-secondary-foreground hover:bg-secondary/80"
-      }`}
-    >
-      {children}
-    </button>
   );
 }

--- a/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
+++ b/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
@@ -188,10 +188,12 @@ export async function GET(
     }
   }
 
-  // --- Build bye week map from nfl_schedule ---
-  // For each (season, team), find weeks where team has no game
+  // teamScheduleMap: "{season}|{team}" → week → { opponent, isAway }
+  // Drives both bye-week detection (team has no game that week) and the
+  // Opponent column on the weekly log.
   const relevantSeasons = [...new Set(members.map((m) => parseInt(m.season, 10)))].filter((n) => !isNaN(n));
-  const byeWeekMap = new Map<string, Set<number>>(); // "season|team" → bye week numbers
+  const teamScheduleMap = new Map<string, Map<number, { opponent: string; isAway: boolean }>>();
+  const seasonAllWeeks = new Map<number, Set<number>>();
 
   if (relevantSeasons.length > 0) {
     const scheduleRows = await db
@@ -199,47 +201,40 @@ export async function GET(
       .from(schema.nflSchedule)
       .where(inArray(schema.nflSchedule.season, relevantSeasons));
 
-    // Group schedule by season
-    const schedBySeason = new Map<number, typeof scheduleRows>();
-    for (const row of scheduleRows) {
-      const arr = schedBySeason.get(row.season) || [];
-      arr.push(row);
-      schedBySeason.set(row.season, arr);
-    }
+    for (const g of scheduleRows) {
+      if (!seasonAllWeeks.has(g.season)) seasonAllWeeks.set(g.season, new Set());
+      seasonAllWeeks.get(g.season)!.add(g.week);
 
-    for (const season of relevantSeasons) {
-      const games = schedBySeason.get(season) || [];
-      if (games.length === 0) continue;
-
-      // All weeks in this season's schedule
-      const allWeeks = new Set(games.map((g) => g.week));
-      // Teams playing each week
-      const teamWeeks = new Map<string, Set<number>>();
-      for (const g of games) {
-        if (!teamWeeks.has(g.homeTeam)) teamWeeks.set(g.homeTeam, new Set());
-        if (!teamWeeks.has(g.awayTeam)) teamWeeks.set(g.awayTeam, new Set());
-        teamWeeks.get(g.homeTeam)!.add(g.week);
-        teamWeeks.get(g.awayTeam)!.add(g.week);
-      }
-
-      for (const [team, weeks] of teamWeeks) {
-        const byes = new Set<number>();
-        for (const week of allWeeks) {
-          if (!weeks.has(week)) byes.add(week);
-        }
-        if (byes.size > 0) {
-          byeWeekMap.set(`${season}|${team}`, byes);
-        }
-      }
+      const homeKey = `${g.season}|${g.homeTeam}`;
+      const awayKey = `${g.season}|${g.awayTeam}`;
+      if (!teamScheduleMap.has(homeKey)) teamScheduleMap.set(homeKey, new Map());
+      if (!teamScheduleMap.has(awayKey)) teamScheduleMap.set(awayKey, new Map());
+      teamScheduleMap.get(homeKey)!.set(g.week, { opponent: g.awayTeam, isAway: false });
+      teamScheduleMap.get(awayKey)!.set(g.week, { opponent: g.homeTeam, isAway: true });
     }
   }
 
-  // --- Assemble weekly log ---
+  // Player's NFL team for a given (season, week). Falls back to nearby
+  // weeks for traded/inactive players, then to player's current Sleeper
+  // team — needed for bye detection and opponent lookup.
+  function resolveTeam(seasonNum: number, week: number): string | null {
+    const direct = nflStatusMap.get(`${seasonNum}|${week}`)?.team;
+    if (direct) return direct;
+    if (player?.gsisId) {
+      for (let delta = 1; delta <= 18; delta++) {
+        const before = nflStatusMap.get(`${seasonNum}|${week - delta}`);
+        if (before?.team) return before.team;
+        const after = nflStatusMap.get(`${seasonNum}|${week + delta}`);
+        if (after?.team) return after.team;
+      }
+    }
+    return player?.team ?? null;
+  }
+
   const weeks = scores.map((s) => {
     const season = leagueSeasonMap.get(s.leagueId) || "";
     const seasonNum = parseInt(season, 10);
 
-    // Lineup slot derivation
     const matchupKey = `${s.leagueId}|${s.week}|${s.rosterId}`;
     const starters = matchupMap.get(matchupKey) || [];
     const rosterPositions = leagueRosterPositions.get(s.leagueId) || [];
@@ -251,41 +246,23 @@ export async function GET(
       }
     }
 
-    // Manager info
     const ownerKey = `${s.leagueId}|${s.rosterId}`;
     const owner = rosterOwnerMap.get(ownerKey);
 
-    // NFL status
-    const nflKey = `${seasonNum}|${s.week}`;
-    const nflStatus = nflStatusMap.get(nflKey);
+    const nflStatus = nflStatusMap.get(`${seasonNum}|${s.week}`);
 
-    // Bye week detection: use team from roster status for this week,
-    // or infer from nearest adjacent week (handles traded players + bye weeks where no roster row exists)
+    const team = resolveTeam(seasonNum, s.week);
+    let opponent: string | null = null;
+    let isAway = false;
     let isByeWeek = false;
-    if (player?.gsisId && !nflStatus) {
-      // No roster status row — could be bye week or missing data
-      // Infer team from nearest adjacent week's roster status
-      let inferredTeam: string | null = null;
-      for (let delta = 1; delta <= 18; delta++) {
-        const before = nflStatusMap.get(`${seasonNum}|${s.week - delta}`);
-        if (before?.team) { inferredTeam = before.team; break; }
-        const after = nflStatusMap.get(`${seasonNum}|${s.week + delta}`);
-        if (after?.team) { inferredTeam = after.team; break; }
+    if (team) {
+      const game = teamScheduleMap.get(`${seasonNum}|${team}`)?.get(s.week);
+      if (game) {
+        opponent = game.opponent;
+        isAway = game.isAway;
+      } else if (seasonAllWeeks.get(seasonNum)?.has(s.week)) {
+        isByeWeek = true;
       }
-      if (inferredTeam) {
-        const teamByes = byeWeekMap.get(`${seasonNum}|${inferredTeam}`);
-        if (teamByes?.has(s.week)) isByeWeek = true;
-      }
-    } else if (nflStatus?.team) {
-      // Has roster status — check if this week is a bye for that team
-      // (shouldn't happen since bye = no roster row, but defensive)
-      const teamByes = byeWeekMap.get(`${seasonNum}|${nflStatus.team}`);
-      if (teamByes?.has(s.week)) isByeWeek = true;
-    } else if (!player?.gsisId && player?.team) {
-      // Fallback: no gsis_id at all — use player's current team from Sleeper
-      // Won't handle mid-season trades, but better than no bye detection
-      const teamByes = byeWeekMap.get(`${seasonNum}|${player.team}`);
-      if (teamByes?.has(s.week)) isByeWeek = true;
     }
 
     return {
@@ -301,6 +278,8 @@ export async function GET(
       nflStatus: nflStatus?.status || null,
       nflStatusAbbr: nflStatus?.statusAbbr || null,
       isByeWeek,
+      opponent,
+      isAway,
     };
   });
 

--- a/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
+++ b/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
@@ -16,9 +16,12 @@ import { lookupSwap } from "@/lib/demoAnonymize";
  * - Fantasy points scored
  *
  * Query params:
- *   ?season=2025          — filter to specific season
  *   ?rosterId=3           — filter to specific roster/manager
  *   ?starterOnly=true     — only show weeks where player was started
+ *
+ * Season filtering is intentionally client-side — `currentManager` and
+ * `rosteredSince` must always reflect the all-time identity of the player,
+ * not the selected season window.
  */
 export async function GET(
   req: NextRequest,
@@ -27,7 +30,6 @@ export async function GET(
   const db = getDb();
   const { familyId, playerId } = params;
   const searchParams = req.nextUrl.searchParams;
-  const seasonFilter = searchParams.get("season");
   const rosterIdFilter = searchParams.get("rosterId");
   const starterOnly = searchParams.get("starterOnly") === "true";
 
@@ -36,26 +38,17 @@ export async function GET(
     return NextResponse.json({ error: "Not found" }, { status: 404 });
   }
 
-  // Get all family members (leagueId + season)
   const members = await db
     .select()
     .from(schema.leagueFamilyMembers)
     .where(eq(schema.leagueFamilyMembers.familyId, resolvedFamilyId));
 
-  let filteredMembers = members;
-  if (seasonFilter) {
-    filteredMembers = members.filter((m) => m.season === seasonFilter);
-  }
-
-  const leagueIds = filteredMembers.map((m) => m.leagueId);
+  const leagueIds = members.map((m) => m.leagueId);
   if (leagueIds.length === 0) {
     return NextResponse.json({ weeks: [], player: null, managers: [] });
   }
 
-  // Map leagueId → season
-  const leagueSeasonMap = new Map(
-    filteredMembers.map((m) => [m.leagueId, m.season])
-  );
+  const leagueSeasonMap = new Map(members.map((m) => [m.leagueId, m.season]));
 
   // --- Load player info ---
   const playerRows = await db

--- a/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
+++ b/src/app/api/leagues/[familyId]/player/[playerId]/weekly-log/route.ts
@@ -71,6 +71,10 @@ export async function GET(
         position: playerRows[0].position,
         team: playerRows[0].team,
         gsisId: playerRows[0].gsisId,
+        age: playerRows[0].age,
+        yearsExp: playerRows[0].yearsExp,
+        status: playerRows[0].status,
+        injuryStatus: playerRows[0].injuryStatus,
       }
     : null;
 
@@ -330,10 +334,72 @@ export async function GET(
     ...new Set(members.map((m) => m.season)),
   ].sort((a, b) => parseInt(b, 10) - parseInt(a, 10));
 
+  // --- Current manager: who rosters this player in the most recent league? ---
+  let currentManager: {
+    userId: string;
+    rosterId: number;
+    displayName: string;
+    teamName: string | null;
+    avatar: string | null;
+    rosteredSince: { season: string; week: number } | null;
+  } | null = null;
+
+  const sortedMembers = [...members].sort(
+    (a, b) => parseInt(b.season, 10) - parseInt(a.season, 10)
+  );
+  const currentLeagueId = sortedMembers[0]?.leagueId;
+
+  if (currentLeagueId) {
+    const owningRoster = rosterRows.find((r) => {
+      if (r.leagueId !== currentLeagueId) return false;
+      const players = (r.players as string[] | null) ?? [];
+      return players.includes(playerId);
+    });
+
+    if (owningRoster?.ownerId) {
+      const userRow = userRows.find(
+        (u) =>
+          u.leagueId === currentLeagueId && u.userId === owningRoster.ownerId
+      );
+      const swapped = demoSwap
+        ? lookupSwap(demoSwap, owningRoster.ownerId)
+        : undefined;
+      const displayName =
+        swapped?.displayName ?? userRow?.displayName ?? owningRoster.ownerId;
+      const teamName = swapped?.teamName ?? userRow?.teamName ?? null;
+      const avatarHash = demoSwap ? null : userRow?.avatar ?? null;
+      const avatar = avatarHash
+        ? `https://sleepercdn.com/avatars/thumbs/${avatarHash}`
+        : null;
+
+      // weeks is sorted season DESC, week ASC — iterating from the end walks
+      // newest → oldest to find the start of the current contiguous stint.
+      let rosteredSince: { season: string; week: number } | null = null;
+      for (let i = weeks.length - 1; i >= 0; i--) {
+        const w = weeks[i];
+        if (w.manager?.userId === owningRoster.ownerId) {
+          rosteredSince = { season: w.season, week: w.week };
+        } else {
+          break;
+        }
+      }
+
+      currentManager = {
+        userId: owningRoster.ownerId,
+        rosterId: owningRoster.rosterId,
+        displayName,
+        teamName,
+        avatar,
+        rosteredSince,
+      };
+    }
+  }
+
   return NextResponse.json({
     player,
     weeks,
     managers: Array.from(managersMap.values()),
     availableSeasons,
+    currentManager,
   });
 }

--- a/src/components/CollapsibleSeasonTable.tsx
+++ b/src/components/CollapsibleSeasonTable.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import { Fragment, type ReactNode, useState } from "react";
+import { ChevronDown } from "lucide-react";
+
+export interface CollapsibleSectionRow {
+  key: string;
+  title: ReactNode;
+  meta?: ReactNode;
+  detail: ReactNode;
+}
+
+export interface CollapsibleSection {
+  key: string;
+  heading?: string;
+  rows: CollapsibleSectionRow[];
+}
+
+interface Props {
+  sections: CollapsibleSection[];
+  emptyMessage?: string;
+  expandAllLabel?: string;
+  collapseAllLabel?: string;
+}
+
+export function CollapsibleSeasonTable({
+  sections,
+  emptyMessage = "No data",
+  expandAllLabel = "Expand all",
+  collapseAllLabel = "Collapse all",
+}: Props) {
+  const [expandedKeys, setExpandedKeys] = useState<Set<string>>(new Set());
+
+  function toggle(key: string) {
+    setExpandedKeys((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }
+
+  const hasRows = sections.some((s) => s.rows.length > 0);
+  if (!hasRows) {
+    return (
+      <p className="text-muted-foreground text-center py-8">{emptyMessage}</p>
+    );
+  }
+
+  return (
+    <>
+      <div className="flex items-center justify-end gap-3 mb-3 text-xs">
+        <button
+          type="button"
+          onClick={() =>
+            setExpandedKeys(
+              new Set(sections.flatMap((s) => s.rows.map((r) => r.key)))
+            )
+          }
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {expandAllLabel}
+        </button>
+        <span aria-hidden className="text-muted-foreground/40">
+          |
+        </span>
+        <button
+          type="button"
+          onClick={() => setExpandedKeys(new Set())}
+          className="text-muted-foreground hover:text-foreground transition-colors"
+        >
+          {collapseAllLabel}
+        </button>
+      </div>
+
+      <div className="space-y-5">
+        {sections.map((section) => (
+          <section key={section.key}>
+            {section.heading && (
+              <h3 className="text-xs font-mono uppercase tracking-wider text-muted-foreground mb-2 px-1">
+                {section.heading}
+              </h3>
+            )}
+            <div className="border rounded-lg overflow-hidden bg-card">
+              {section.rows.map((row, idx) => {
+                const expanded = expandedKeys.has(row.key);
+                return (
+                  <Fragment key={row.key}>
+                    <button
+                      type="button"
+                      onClick={() => toggle(row.key)}
+                      className={`w-full px-3 sm:px-4 py-3 flex items-center gap-3 text-left hover:bg-muted/30 transition-colors ${
+                        idx > 0 ? "border-t" : ""
+                      }`}
+                      aria-expanded={expanded}
+                    >
+                      <ChevronDown
+                        className={`h-4 w-4 text-muted-foreground transition-transform shrink-0 ${
+                          expanded ? "" : "-rotate-90"
+                        }`}
+                      />
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium truncate">{row.title}</div>
+                        {row.meta && (
+                          <div className="mt-0.5 text-xs text-muted-foreground font-mono flex flex-wrap gap-x-3 gap-y-0.5">
+                            {row.meta}
+                          </div>
+                        )}
+                      </div>
+                    </button>
+                    {expanded && row.detail}
+                  </Fragment>
+                );
+              })}
+            </div>
+          </section>
+        ))}
+      </div>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- Closes #91 (header redesign + table-heading rename) and #90 (collapsible season×manager game log) in one PR — they're on the same surface and the rename is a 2-character bug fix that shouldn't ship separately.
- Reconciles with #117 / #122: the shared `<Subheader>` stays as sticky chrome; the new hero block lives in main content under it.
- Introduces a shared `<CollapsibleSeasonTable>` primitive (sections → rows → expandable detail) — built generic so #101 (manager season history) can reuse the same pattern.

## What changed
**Player page hero (#91)**
- Player name + meta (team · age · years exp), with non-Active NFL status (e.g. "IR", "Out") promoted to a badge in the meta line.
- "Currently rostered by" card on the right (md+) / below (mobile): avatar + team + manager + "Since W{week} {season}" — replaces the previous "scan the table to find current owner" UX.
- Free-agent fallback when no current owner.
- `Trace lineage` pill stays inside the hero (still gated by `ASSET_GRAPH_BROWSER`).
- Top stat cards trimmed 6 → 3 (Weeks Rostered, Weeks Started, PPG).

**Game log (#90)**
- One row per `(season, manager)` stint by default — aggregate weeks / started / total pts / ppg.
- Click → expand to weekly grain. Expand-all / Collapse-all.
- Expanded weekly subtable has a sticky-left Week column so narrow viewports keep the row label pinned during horizontal scroll.
- Filters (Manager / Season / Status) wrap on mobile via `<FilterChip>`.

**Table-heading rename (#91)**
- `Status` → `Lineup` (lineup-slot column)
- `NFL` → `Status` (NFL-availability column)

**API (`/api/leagues/[familyId]/player/[playerId]/weekly-log`)**
- Returns `currentManager` (resolved from the most recent league's `rosters.players` containing `playerId`, with the contiguous "rosteredSince" stint boundary computed by walking weeks newest→oldest).
- Adds `age`, `yearsExp`, `status`, `injuryStatus` on the `player` object.
- Avatar is now a full `sleepercdn.com` URL.

## Mobile
- Verified at 360px (iframe): no horizontal page scroll; hero stacks; filters wrap; weekly subtable fits.
- Demo mode (`/demo` redirect) still works.

## Test plan
- [ ] Player with multi-season + multi-manager history: stints render correctly, expand reveals weekly rows.
- [ ] Player with no current owner (free agent): shows "Currently / Free agent".
- [ ] Demo mode: anonymized names show in hero + manager rows; avatar falls back to initials chip.
- [ ] At 360px viewport: no horizontal scroll on the page; sticky-left Week column stays pinned in expanded weekly tables.
- [ ] Trace lineage pill renders only when `ASSET_GRAPH_BROWSER` is on.

## Background
Original branch work lived on `feat/91-player-header-redesign` (PR #116) but predated #117/#122 and conflicted heavily with the new Subheader. This PR re-implements the same intent on top of the merged primitives, extracts the table pattern into a shared component, and folds in `/simplify` cleanup (single-pass stint aggregation; no redundant re-sort in the API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)