### PR TITLE
Manager page formatting polish: grade pills, +/- icons, link hover, MPS tooltip

### DIFF
--- a/src/app/(app)/league/[familyId]/drafts/page.tsx
+++ b/src/app/(app)/league/[familyId]/drafts/page.tsx
@@ -232,7 +232,7 @@ function DraftBoard({ draft, familyId }: { draft: DraftData; familyId: string })
                           {pick.playerId ? (
                             <Link
                               href={`/league/${familyId}/player/${pick.playerId}`}
-                              className="font-medium text-sm truncate hover:underline"
+                              className="font-medium text-sm truncate hover:text-primary transition-colors"
                             >
                               {pick.playerName}
                             </Link>

--- a/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
+++ b/src/app/(app)/league/[familyId]/manager/[userId]/page.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
-import { ChevronDown, GitBranch, IdCard } from "lucide-react";
+import { ChevronDown, GitBranch, IdCard, Minus, Plus } from "lucide-react";
 import { GradeBadge } from "@/components/GradeBadge";
 import { ManagerRadarChart } from "@/components/ManagerRadarChart";
 import {
@@ -350,7 +350,7 @@ function ManagerPageContent({
         }
       />
 
-      <main className="container mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6 sm:space-y-8">
+      <main className="max-w-4xl mx-auto px-4 sm:px-6 py-6 sm:py-8 space-y-6 sm:space-y-8">
         {/* Section 1: Record / Points For / League Rank */}
         <section className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 sm:gap-4">
           <RecordTile stats={headerStats} />
@@ -985,12 +985,12 @@ function pickLabel(p: PickRef): string {
 function AssetList({
   players,
   picks,
-  sign,
+  kind,
   className,
 }: {
   players: PlayerRef[];
   picks: PickRef[];
-  sign: "+" | "−";
+  kind: "add" | "drop";
   className: string;
 }) {
   if (players.length === 0 && picks.length === 0) return null;
@@ -998,10 +998,11 @@ function AssetList({
     ...players.map((p) => p.name),
     ...picks.map((p) => `${pickLabel(p)} pick`),
   ];
+  const Icon = kind === "add" ? Plus : Minus;
   return (
-    <span className={className}>
-      {sign}
-      {items.join(", ")}
+    <span className={`inline-flex items-baseline gap-1 ${className}`}>
+      <Icon className="h-3 w-3 self-center shrink-0" aria-hidden />
+      <span className="min-w-0">{items.join(", ")}</span>
     </span>
   );
 }
@@ -1020,7 +1021,7 @@ function TransactionRow({
   return (
     <Link
       href={`/league/${familyId}/graph?seedTransactionId=${tx.id}&from=manager`}
-      className="px-3 sm:px-4 py-3 flex flex-col sm:flex-row sm:items-start sm:justify-between gap-2 sm:gap-4 hover:bg-muted/30 transition-colors"
+      className="px-3 sm:px-4 py-3 flex items-start gap-3 hover:bg-muted/30 transition-colors"
     >
       <div className="flex-1 min-w-0">
         <div className="flex items-center gap-2 mb-1 flex-wrap">
@@ -1033,52 +1034,53 @@ function TransactionRow({
           <div className="text-sm space-y-0.5">
             {hasReceived && (
               <div className="flex gap-2">
-                <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground mt-1 shrink-0 w-16">
+                <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground mt-0.5 shrink-0 w-16">
                   Received
                 </span>
                 <AssetList
                   players={tx.adds}
                   picks={tx.picksReceived}
-                  sign="+"
+                  kind="add"
                   className="text-primary"
                 />
               </div>
             )}
             {hasSent && (
               <div className="flex gap-2">
-                <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground mt-1 shrink-0 w-16">
+                <span className="text-[10px] font-mono uppercase tracking-wide text-muted-foreground mt-0.5 shrink-0 w-16">
                   Sent
                 </span>
                 <AssetList
                   players={tx.drops}
                   picks={tx.picksSent}
-                  sign="−"
+                  kind="drop"
                   className="text-muted-foreground"
                 />
               </div>
             )}
           </div>
         ) : (
-          <div className="text-sm">
+          <div className="text-sm flex flex-wrap items-baseline gap-x-2">
             <AssetList
               players={tx.adds}
               picks={tx.picksReceived}
-              sign="+"
+              kind="add"
               className="text-primary"
             />
-            {hasReceived && hasSent && (
-              <span className="text-muted-foreground mx-1">/</span>
-            )}
             <AssetList
               players={tx.drops}
               picks={tx.picksSent}
-              sign="−"
+              kind="drop"
               className="text-muted-foreground"
             />
           </div>
         )}
       </div>
-      {tx.grade && <GradeBadge grade={tx.grade} size="xs" />}
+      {tx.grade && (
+        <div className="shrink-0 self-start mt-0.5">
+          <GradeBadge grade={tx.grade} size="xs" />
+        </div>
+      )}
     </Link>
   );
 }
@@ -1210,12 +1212,14 @@ function DraftRow({
   const player = draft.player;
 
   const body = (
-    <div className="px-3 sm:px-4 py-3 flex items-center justify-between gap-3 hover:bg-muted/30 transition-colors min-h-[44px]">
+    <div className="group px-3 sm:px-4 py-3 flex items-center justify-between gap-3 hover:bg-muted/30 transition-colors min-h-[44px]">
       <div className="flex items-center gap-2 sm:gap-3 min-w-0 flex-1">
         <PositionChip position={player?.position ?? null} />
         <div className="flex-1 min-w-0">
           <div className="text-sm font-medium truncate">
-            {player?.name ?? "Unselected"}
+            <span className="group-hover:text-primary transition-colors">
+              {player?.name ?? "Unselected"}
+            </span>
             {draft.isKeeper && (
               <span className="ml-2 text-[10px] font-mono uppercase tracking-wide text-muted-foreground">
                 Keeper

--- a/src/components/InfoTooltip.tsx
+++ b/src/components/InfoTooltip.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { type ReactNode, useState } from "react";
+import { Info } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface InfoTooltipProps {
+  content: ReactNode;
+  label?: string;
+  className?: string;
+  iconClassName?: string;
+}
+
+// Desktop: hover/focus opens after a short delay.
+// Mobile: tap toggles the open state (Radix Tooltip alone is hover-only,
+// which leaves touch users with no way to read the tooltip).
+export function InfoTooltip({
+  content,
+  label,
+  className,
+  iconClassName = "h-3 w-3",
+}: InfoTooltipProps) {
+  const [open, setOpen] = useState(false);
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip open={open} onOpenChange={setOpen}>
+        <TooltipTrigger
+          type="button"
+          aria-label={label}
+          onClick={(e) => {
+            e.preventDefault();
+            e.stopPropagation();
+            setOpen((o) => !o);
+          }}
+          className={`inline-flex items-center cursor-help ${className ?? ""}`}
+        >
+          <Info className={iconClassName} aria-hidden />
+        </TooltipTrigger>
+        <TooltipContent>{content}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}

--- a/src/components/ManagerGradeCard.tsx
+++ b/src/components/ManagerGradeCard.tsx
@@ -1,5 +1,5 @@
-import { Info } from "lucide-react";
 import { GradeBadge } from "@/components/GradeBadge";
+import { InfoTooltip } from "@/components/InfoTooltip";
 import { PILLAR_LABELS } from "@/lib/pillars";
 import { ordinal } from "@/lib/utils";
 
@@ -35,12 +35,13 @@ export function ManagerGradeCard({
     <div className="border rounded-lg p-4 sm:p-6">
       <div className="flex items-baseline gap-2 mb-1">
         <h2 className="text-sm font-semibold">Manager Process Score</h2>
-        <span
-          className="inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-wider text-muted-foreground cursor-help"
-          title={MPS_TOOLTIP}
-        >
+        <span className="inline-flex items-center gap-1 text-[10px] font-mono uppercase tracking-wider text-muted-foreground">
           MPS
-          <Info className="h-3 w-3" aria-hidden />
+          <InfoTooltip
+            content={MPS_TOOLTIP}
+            label="What is MPS?"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          />
         </span>
       </div>
       <p className="text-xs text-muted-foreground mb-4">

--- a/src/components/TransactionCard.tsx
+++ b/src/components/TransactionCard.tsx
@@ -1,8 +1,19 @@
 import Link from "next/link";
-import { ArrowRight } from "lucide-react";
+import { ArrowRight, Minus, Plus } from "lucide-react";
 import { GradeBadge } from "./GradeBadge";
 import { ManagerName } from "./ManagerName";
 import { getRoundSuffix } from "@/lib/utils";
+
+// Subtle hover treatment for player-name links: an underline that fades in
+// on hover. Avoids the "dead text" problem where the link is the same color
+// as surrounding text.
+const PLAYER_LINK_HOVER =
+  "underline decoration-current/0 underline-offset-2 hover:decoration-current/60 transition-[text-decoration-color]";
+
+function AssetSign({ kind }: { kind: "add" | "drop" }) {
+  const Icon = kind === "add" ? Plus : Minus;
+  return <Icon className="h-3 w-3 inline-block align-text-bottom" aria-hidden />;
+}
 
 interface TransactionAdd {
   playerId: string;
@@ -69,7 +80,7 @@ function PlayerLink({ playerId, playerName, familyId, className }: {
   return (
     <Link
       href={`/league/${familyId}/player/${playerId}`}
-      className={`${className} hover:underline`}
+      className={`${className ?? ""} ${PLAYER_LINK_HOVER}`}
     >
       {playerName}
     </Link>
@@ -198,7 +209,7 @@ function TradeCard({ tx, familyId }: { tx: TransactionData; familyId?: string })
                 <p className="text-xs text-muted-foreground mb-1">Received</p>
                 {side.received.map((a) => (
                   <p key={a.playerId} className="text-sm text-primary">
-                    + <PlayerLink playerId={a.playerId} playerName={a.playerName} familyId={familyId} />
+                    <AssetSign kind="add" /> <PlayerLink playerId={a.playerId} playerName={a.playerName} familyId={familyId} />
                   </p>
                 ))}
               </div>
@@ -210,7 +221,7 @@ function TradeCard({ tx, familyId }: { tx: TransactionData; familyId?: string })
                 )}
                 {side.picksReceived.map((p, i) => (
                   <p key={i} className="text-sm text-primary">
-                    + {p.season} {p.round}{getRoundSuffix(p.round)} Round Pick
+                    <AssetSign kind="add" /> {p.season} {p.round}{getRoundSuffix(p.round)} Round Pick
                     {p.originalOwnerName && p.originalRosterId !== side.rosterId && (
                       <span className="text-xs text-muted-foreground ml-1">
                         (
@@ -237,7 +248,7 @@ function TradeCard({ tx, familyId }: { tx: TransactionData; familyId?: string })
                 <p className="text-xs text-muted-foreground mb-1">Sent</p>
                 {side.sent.map((d) => (
                   <p key={d.playerId} className="text-sm text-muted-foreground">
-                    − <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
+                    <AssetSign kind="drop" /> <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
                   </p>
                 ))}
               </div>
@@ -249,7 +260,7 @@ function TradeCard({ tx, familyId }: { tx: TransactionData; familyId?: string })
                 )}
                 {side.picksSent.map((p, i) => (
                   <p key={i} className="text-sm text-muted-foreground">
-                    − {p.season} {p.round}{getRoundSuffix(p.round)} Round Pick
+                    <AssetSign kind="drop" /> {p.season} {p.round}{getRoundSuffix(p.round)} Round Pick
                     {p.originalOwnerName && p.originalRosterId !== side.rosterId && (
                       <span className="text-xs text-muted-foreground ml-1">
                         (
@@ -305,7 +316,7 @@ function SimpleTransactionCard({ tx, familyId }: { tx: TransactionData; familyId
         {tx.adds.map((a) => (
           <p key={a.playerId} className="text-sm">
             <span className="text-primary font-medium">
-              + <PlayerLink playerId={a.playerId} playerName={a.playerName} familyId={familyId} />
+              <AssetSign kind="add" /> <PlayerLink playerId={a.playerId} playerName={a.playerName} familyId={familyId} />
             </span>
             <span className="text-muted-foreground ml-2 inline-flex items-center gap-1 align-middle">
               <ArrowRight className="h-3 w-3" />
@@ -320,7 +331,7 @@ function SimpleTransactionCard({ tx, familyId }: { tx: TransactionData; familyId
         {tx.drops.map((d) => (
           <p key={d.playerId} className="text-sm">
             <span className="text-muted-foreground font-medium">
-              − <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
+              <AssetSign kind="drop" /> <PlayerLink playerId={d.playerId} playerName={d.playerName} familyId={familyId} />
             </span>
             <span className="text-muted-foreground ml-2">
               from{" "}

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import * as React from "react";
+import * as TooltipPrimitive from "@radix-ui/react-tooltip";
+
+import { cn } from "@/lib/utils";
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 6, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-w-xs rounded-md border bg-card px-3 py-2 text-xs text-foreground shadow-md",
+        "animate-in fade-in-0 zoom-in-95",
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger };


### PR DESCRIPTION
## Summary
- **Page width**: cap `<main>` at `max-w-4xl` so sections size to a comfortable reading width instead of stretching to the container's full width on desktop.
- **Transaction grade pills**: drop `justify-between` so grade sits tight next to the content on desktop; on mobile the pill stays inline-tight at upper-right instead of stretching across the card.
- **Replace ASCII +/− with lucide icons**: manager-page AssetList + league TransactionCard player rows + pick rows all use `<Plus>` / `<Minus>` icons that inherit the surrounding text color.
- **Player link hover**: subtle effect so links don't read as dead text. Drafts row uses a group-hover sage color shift on the player name; TransactionCard player links use a fade-in underline; drafts table swaps `hover:underline` for the same `hover:text-primary` treatment.
- **MPS tooltip on mobile**: native `title` was slow on desktop and a no-op on mobile. Replaced with a Radix-based tooltip primitive (new `src/components/ui/tooltip.tsx` + `<InfoTooltip />`). Click/tap toggles on touch; hover with 150ms delay on desktop.

## Test plan
- [x] `npm run build` and `npm run lint` clean.
- [x] Manager page at desktop: stats / MPS / season-history / roster / transactions / drafts sit centered at ~896px max width; grade pills now adjacent to content.
- [x] Manager page at 360px (iframe): grade pills stay compact at upper right; transactions stack legibly.
- [x] MPS info icon: click on desktop shows tooltip immediately (no 1–2s delay); programmatic click via JS toggles open and renders the full text.
- [x] +/− render as icons in both manager page and league `/transactions` page.
- [x] Player name links across the site use the unified hover treatment (manager page roster, drafts row, league transactions card, league drafts table).

🤖 Generated with [Claude Code](https://claude.com/claude-code)