### PR TITLE
Lineage Tracer: Player Card icon in detail drawer

### DIFF
--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -2,12 +2,11 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { X } from "lucide-react";
+import { IdCard, X } from "lucide-react";
 import type { GraphEdge, GraphNode, GraphSelection } from "@/lib/assetGraph";
 import type { EnrichedTransaction } from "@/lib/transactionEnrichment";
 import { TransactionCard, type TransactionData } from "@/components/TransactionCard";
 import { ManagerName } from "@/components/ManagerName";
-import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
 
 function toTransactionData(tx: EnrichedTransaction): TransactionData {
@@ -245,17 +244,22 @@ function NodeDetail({
       {firstAsset && firstAsset.kind === "player" && (
         <div>
           <p className="text-xs text-muted-foreground">Player</p>
-          <p className="text-sm">
-            {firstAsset.playerPosition ? `${firstAsset.playerPosition} · ` : ""}
-            {firstAsset.playerName}
-          </p>
-          {firstAsset.playerId && (
-            <Button asChild variant="outline" size="sm" className="mt-2 rounded-full">
-              <Link href={`/league/${familyId}/player/${encodeURIComponent(firstAsset.playerId)}`}>
-                Player Card
+          <div className="flex items-center gap-2 min-w-0">
+            <p className="text-sm flex-1 min-w-0 truncate">
+              {firstAsset.playerPosition ? `${firstAsset.playerPosition} · ` : ""}
+              {firstAsset.playerName}
+            </p>
+            {firstAsset.playerId && (
+              <Link
+                href={`/league/${familyId}/player/${encodeURIComponent(firstAsset.playerId)}`}
+                className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors shrink-0"
+                aria-label={`View ${firstAsset.playerName} player card`}
+                title="Player card"
+              >
+                <IdCard className="h-4 w-4" />
               </Link>
-            </Button>
-          )}
+            )}
+          </div>
         </div>
       )}
       {firstAsset && firstAsset.kind === "pick" && (
@@ -288,17 +292,22 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
       {edge.assetKind === "player" ? (
         <div>
           <p className="text-xs text-muted-foreground">Player</p>
-          <p className="text-sm font-semibold">
-            {edge.playerPosition ? `${edge.playerPosition} · ` : ""}
-            {edge.playerName}
-          </p>
-          {edge.playerId && (
-            <Button asChild variant="outline" size="sm" className="mt-2 rounded-full">
-              <Link href={`/league/${familyId}/player/${encodeURIComponent(edge.playerId)}`}>
-                Player Card
+          <div className="flex items-center gap-2 min-w-0">
+            <p className="text-sm font-semibold flex-1 min-w-0 truncate">
+              {edge.playerPosition ? `${edge.playerPosition} · ` : ""}
+              {edge.playerName}
+            </p>
+            {edge.playerId && (
+              <Link
+                href={`/league/${familyId}/player/${encodeURIComponent(edge.playerId)}`}
+                className="inline-flex items-center justify-center h-8 w-8 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground transition-colors shrink-0"
+                aria-label={`View ${edge.playerName} player card`}
+                title="Player card"
+              >
+                <IdCard className="h-4 w-4" />
               </Link>
-            </Button>
-          )}
+            )}
+          </div>
         </div>
       ) : (
         <div>

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -2,11 +2,12 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
-import { ArrowRight, X } from "lucide-react";
+import { X } from "lucide-react";
 import type { GraphEdge, GraphNode, GraphSelection } from "@/lib/assetGraph";
 import type { EnrichedTransaction } from "@/lib/transactionEnrichment";
 import { TransactionCard, type TransactionData } from "@/components/TransactionCard";
 import { ManagerName } from "@/components/ManagerName";
+import { Button } from "@/components/ui/button";
 import { trackEvent } from "@/lib/analytics";
 
 function toTransactionData(tx: EnrichedTransaction): TransactionData {
@@ -249,13 +250,11 @@ function NodeDetail({
             {firstAsset.playerName}
           </p>
           {firstAsset.playerId && (
-            <Link
-              href={`/league/${familyId}/player/${encodeURIComponent(firstAsset.playerId)}`}
-              className="inline-flex items-center gap-1 mt-1 text-xs text-primary hover:underline"
-            >
-              Open player
-              <ArrowRight className="h-3 w-3" aria-hidden="true" />
-            </Link>
+            <Button asChild variant="outline" size="sm" className="mt-2 rounded-full">
+              <Link href={`/league/${familyId}/player/${encodeURIComponent(firstAsset.playerId)}`}>
+                Player Card
+              </Link>
+            </Button>
           )}
         </div>
       )}
@@ -294,13 +293,11 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
             {edge.playerName}
           </p>
           {edge.playerId && (
-            <Link
-              href={`/league/${familyId}/player/${encodeURIComponent(edge.playerId)}`}
-              className="inline-flex items-center gap-1 mt-1 text-xs text-primary hover:underline"
-            >
-              Open player
-              <ArrowRight className="h-3 w-3" aria-hidden="true" />
-            </Link>
+            <Button asChild variant="outline" size="sm" className="mt-2 rounded-full">
+              <Link href={`/league/${familyId}/player/${encodeURIComponent(edge.playerId)}`}>
+                Player Card
+              </Link>
+            </Button>
           )}
         </div>
       ) : (


### PR DESCRIPTION
## Summary
- Replaces both `Open player →` inline links inside `GraphDetailDrawer` (NodeDetail + EdgeDetail) with a `<IdCard>` lucide icon-button placed inline next to the player name.
- Matches the manager-page roster pattern: `h-8 w-8 rounded-md text-muted-foreground hover:bg-muted hover:text-foreground` ghost-style affordance, `h-4 w-4` icon.
- Drops the now-unused `ArrowRight` import.

Closes #131. First of three carved from #123.

## Test plan
- [ ] `npm run build` clean ✅
- [ ] `npm run lint` clean (no new warnings) ✅
- [ ] Open `/league/<familyId>/graph`, click a transaction node → detail drawer's player section shows the IdCard icon next to the name, click navigates to player page.
- [ ] Click an asset edge → EdgeDetail shows the same icon-button, click navigates.
- [ ] Mobile (sheet variant, 360px iframe) and desktop (drawer variant) both render correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)