### PR TITLE
Lineage Tracer: render desktop canvas in landscape on phones

### DIFF
--- a/src/app/(app)/league/[familyId]/graph/layout.tsx
+++ b/src/app/(app)/league/[familyId]/graph/layout.tsx
@@ -1,0 +1,20 @@
+import type { Viewport } from "next";
+
+// Lock viewport scale so iOS Safari doesn't auto-zoom the page on orientation
+// change. React Flow's pinch-zoom on the canvas is JS-based (CSS transforms
+// on its own content) and is unaffected by these flags, so the canvas stays
+// fully interactive while the page chrome stays stable.
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 1,
+  userScalable: false,
+};
+
+export default function GraphLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
 import { Dna, Smartphone, X } from "lucide-react";
 import {
@@ -20,6 +20,7 @@ import { AssetGraph } from "@/components/graph/AssetGraph";
 import { Button } from "@/components/ui/button";
 import { Subheader } from "@/components/Subheader";
 import { useScrolled } from "@/lib/useScrolled";
+import { safeStorage } from "@/lib/storedUsername";
 import type { Pos } from "@/components/graph/layout";
 
 type FromSource = "overview" | "player" | "transactions" | "manager" | "deeplink";
@@ -98,31 +99,21 @@ export default function GraphPage() {
     [router, searchParams],
   );
 
-  const [isNarrow, setIsNarrow] = useState<boolean>(() => {
+  const [isPortraitMobile, setIsPortraitMobile] = useState<boolean>(() => {
     if (typeof window === "undefined") return false;
-    return window.innerWidth < 1024;
-  });
-  const [isLandscape, setIsLandscape] = useState<boolean>(() => {
-    if (typeof window === "undefined") return false;
-    return window.innerWidth > window.innerHeight;
+    return (
+      window.innerWidth < 1024 && window.innerWidth <= window.innerHeight
+    );
   });
   useEffect(() => {
     function onResize() {
-      setIsNarrow(window.innerWidth < 1024);
-      setIsLandscape(window.innerWidth > window.innerHeight);
+      setIsPortraitMobile(
+        window.innerWidth < 1024 && window.innerWidth <= window.innerHeight,
+      );
     }
     window.addEventListener("resize", onResize);
-    window.addEventListener("orientationchange", onResize);
-    return () => {
-      window.removeEventListener("resize", onResize);
-      window.removeEventListener("orientationchange", onResize);
-    };
+    return () => window.removeEventListener("resize", onResize);
   }, []);
-
-  // Narrow viewport in portrait gets the chronological MobileTimeline. Narrow
-  // landscape (phones rotated) falls through to the React Flow canvas — same
-  // experience as desktop, just at a tighter viewport.
-  const isPortraitMobile = isNarrow && !isLandscape;
 
   // Fullbleed-on-mobile: lets the global nav scroll off so the subheader
   // pins to viewport top, freeing screen space for the canvas/timeline.
@@ -555,68 +546,72 @@ function CanvasSkeleton() {
 const ROTATE_HINT_KEY = "graph_rotate_hint_dismissed";
 const SMALL_SCREEN_HINT_KEY = "graph_small_screen_hint_dismissed";
 
-function RotateForCanvasHint() {
+function DismissibleHint({
+  storageKey,
+  ariaLabel,
+  containerClass,
+  closeBtnClass,
+  closeIconClass,
+  dataAttr,
+  children,
+}: {
+  storageKey: string;
+  ariaLabel: string;
+  containerClass: string;
+  closeBtnClass: string;
+  closeIconClass: string;
+  dataAttr?: Record<string, string>;
+  children: ReactNode;
+}) {
   const [dismissed, setDismissed] = useState<boolean>(() => {
     if (typeof window === "undefined") return true;
-    return Boolean(window.localStorage.getItem(ROTATE_HINT_KEY));
+    return Boolean(safeStorage()?.getItem(storageKey));
   });
   if (dismissed) return null;
   return (
-    <div
-      role="status"
-      className="mx-4 mt-3 flex items-center gap-3 rounded-md border border-primary/25 bg-primary/8 px-3 py-2 text-xs text-foreground"
-    >
-      <Smartphone className="h-4 w-4 shrink-0 text-primary -rotate-90" aria-hidden="true" />
-      <span className="flex-1">
-        Rotate your phone for the interactive canvas.
-      </span>
+    <div role="status" className={containerClass} {...dataAttr}>
+      {children}
       <button
         type="button"
         onClick={() => {
           setDismissed(true);
-          try {
-            window.localStorage.setItem(ROTATE_HINT_KEY, "1");
-          } catch {
-            // localStorage may be unavailable (private mode); dismissal is in-memory only.
-          }
+          safeStorage()?.setItem(storageKey, "1");
         }}
-        aria-label="Dismiss rotate hint"
-        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+        aria-label={ariaLabel}
+        className={closeBtnClass}
       >
-        <X className="h-3.5 w-3.5" aria-hidden="true" />
+        <X className={closeIconClass} aria-hidden="true" />
       </button>
     </div>
   );
 }
 
-function SmallScreenHint() {
-  const [dismissed, setDismissed] = useState<boolean>(() => {
-    if (typeof window === "undefined") return true;
-    return Boolean(window.localStorage.getItem(SMALL_SCREEN_HINT_KEY));
-  });
-  if (dismissed) return null;
+function RotateForCanvasHint() {
   return (
-    <div
-      role="status"
-      data-small-screen-hint
-      className="fixed bottom-3 left-1/2 z-30 -translate-x-1/2 flex items-center gap-2 rounded-full border border-border bg-card/95 backdrop-blur px-3 py-1.5 text-[11px] text-muted-foreground shadow-md"
+    <DismissibleHint
+      storageKey={ROTATE_HINT_KEY}
+      ariaLabel="Dismiss rotate hint"
+      containerClass="mx-4 mt-3 flex items-center gap-3 rounded-md border border-primary/25 bg-primary/8 px-3 py-2 text-xs text-foreground"
+      closeBtnClass="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      closeIconClass="h-3.5 w-3.5"
+    >
+      <Smartphone className="h-4 w-4 shrink-0 text-primary -rotate-90" aria-hidden="true" />
+      <span className="flex-1">Rotate your phone for the interactive canvas.</span>
+    </DismissibleHint>
+  );
+}
+
+function SmallScreenHint() {
+  return (
+    <DismissibleHint
+      storageKey={SMALL_SCREEN_HINT_KEY}
+      ariaLabel="Dismiss small-screen hint"
+      containerClass="fixed bottom-3 left-1/2 z-30 -translate-x-1/2 flex items-center gap-2 rounded-full border border-border bg-card/95 backdrop-blur px-3 py-1.5 text-[11px] text-muted-foreground shadow-md"
+      closeBtnClass="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      closeIconClass="h-3 w-3"
+      dataAttr={{ "data-small-screen-hint": "" }}
     >
       <span>Lineage Tracer works best on a larger screen.</span>
-      <button
-        type="button"
-        onClick={() => {
-          setDismissed(true);
-          try {
-            window.localStorage.setItem(SMALL_SCREEN_HINT_KEY, "1");
-          } catch {
-            // localStorage may be unavailable (private mode); dismissal is in-memory only.
-          }
-        }}
-        aria-label="Dismiss small-screen hint"
-        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
-      >
-        <X className="h-3 w-3" aria-hidden="true" />
-      </button>
-    </div>
+    </DismissibleHint>
   );
 }

--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -453,6 +453,7 @@ export default function GraphPage() {
       <>
         <Subheader title={subheaderTitle} rightSlot={subheaderRightSlot} />
         <RotateForCanvasHint />
+        <SmallScreenHint />
         <MobileTimeline
           familyId={familyId}
           response={response}
@@ -487,6 +488,7 @@ export default function GraphPage() {
   return (
     <>
       <Subheader title={subheaderTitle} rightSlot={subheaderRightSlot} />
+      <SmallScreenHint />
       <div className="flex flex-col h-[calc(100vh-var(--nav-height,3.5rem)-var(--subheader-height,3rem))] min-h-0">
         <div className="flex-1 flex min-h-0 relative">
           <div className="flex-1 relative min-w-0">
@@ -580,6 +582,7 @@ function CanvasSkeleton() {
 }
 
 const ROTATE_HINT_KEY = "graph_rotate_hint_dismissed";
+const SMALL_SCREEN_HINT_KEY = "graph_small_screen_hint_dismissed";
 
 function RotateForCanvasHint() {
   const [dismissed, setDismissed] = useState<boolean>(() => {
@@ -610,6 +613,38 @@ function RotateForCanvasHint() {
         className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
       >
         <X className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
+    </div>
+  );
+}
+
+function SmallScreenHint() {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return Boolean(window.localStorage.getItem(SMALL_SCREEN_HINT_KEY));
+  });
+  if (dismissed) return null;
+  return (
+    <div
+      role="status"
+      data-small-screen-hint
+      className="fixed bottom-3 left-1/2 z-30 -translate-x-1/2 flex items-center gap-2 rounded-full border border-border bg-card/95 backdrop-blur px-3 py-1.5 text-[11px] text-muted-foreground shadow-md"
+    >
+      <span>Lineage Tracer works best on a larger screen.</span>
+      <button
+        type="button"
+        onClick={() => {
+          setDismissed(true);
+          try {
+            window.localStorage.setItem(SMALL_SCREEN_HINT_KEY, "1");
+          } catch {
+            // localStorage may be unavailable (private mode); dismissal is in-memory only.
+          }
+        }}
+        aria-label="Dismiss small-screen hint"
+        className="inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      >
+        <X className="h-3 w-3" aria-hidden="true" />
       </button>
     </div>
   );

--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -139,10 +139,6 @@ export default function GraphPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const analyticsFiredRef = useRef(false);
-  const [tooltipDismissed, setTooltipDismissed] = useState<boolean>(() => {
-    if (typeof window === "undefined") return true;
-    return Boolean(window.localStorage.getItem("graph_tooltip_dismissed"));
-  });
 
   useEffect(() => {
     let cancelled = false;
@@ -287,15 +283,6 @@ export default function GraphPage() {
       season: response.seasons[0] || "",
     });
   }, [response, familyId, from]);
-
-  const showOnboarding =
-    !tooltipDismissed && visibility.visibleNodes.length > 0;
-  const dismissOnboarding = useCallback(() => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem("graph_tooltip_dismissed", "1");
-    }
-    setTooltipDismissed(true);
-  }, []);
 
   const handleSelectionChange = useCallback(
     (next: GraphSelection | null) => updateUrl({ selection: serializeSelection(next) }),
@@ -529,23 +516,6 @@ export default function GraphPage() {
               />
             )}
 
-            {showOnboarding && (
-              <div
-                role="status"
-                className="absolute bottom-4 left-1/2 -translate-x-1/2 z-20 max-w-md px-4 py-2.5 rounded-md bg-foreground text-background shadow-lg flex items-center gap-3"
-              >
-                <span className="text-xs">
-                  Click a card header to expand it. Click an asset to follow its thread across stints between managers.
-                </span>
-                <button
-                  type="button"
-                  onClick={dismissOnboarding}
-                  className="text-xs underline hover:no-underline"
-                >
-                  Got it
-                </button>
-              </div>
-            )}
           </div>
 
           {selection && visibleGraph && response && (
@@ -556,6 +526,7 @@ export default function GraphPage() {
               transactions={response.transactions}
               familyId={familyId}
               onSelectionChange={handleSelectionChange}
+              variant={isNarrow ? "sheet" : "drawer"}
             />
           )}
         </div>

--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -526,7 +526,7 @@ export default function GraphPage() {
               transactions={response.transactions}
               familyId={familyId}
               onSelectionChange={handleSelectionChange}
-              variant={isNarrow ? "sheet" : "drawer"}
+              variant={isPortraitMobile ? "sheet" : "drawer"}
             />
           )}
         </div>

--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useRouter, useSearchParams } from "next/navigation";
-import { Dna } from "lucide-react";
+import { Dna, Smartphone, X } from "lucide-react";
 import {
   pickKey,
   type Graph,
@@ -102,13 +102,27 @@ export default function GraphPage() {
     if (typeof window === "undefined") return false;
     return window.innerWidth < 1024;
   });
+  const [isLandscape, setIsLandscape] = useState<boolean>(() => {
+    if (typeof window === "undefined") return false;
+    return window.innerWidth > window.innerHeight;
+  });
   useEffect(() => {
     function onResize() {
       setIsNarrow(window.innerWidth < 1024);
+      setIsLandscape(window.innerWidth > window.innerHeight);
     }
     window.addEventListener("resize", onResize);
-    return () => window.removeEventListener("resize", onResize);
+    window.addEventListener("orientationchange", onResize);
+    return () => {
+      window.removeEventListener("resize", onResize);
+      window.removeEventListener("orientationchange", onResize);
+    };
   }, []);
+
+  // Narrow viewport in portrait gets the chronological MobileTimeline. Narrow
+  // landscape (phones rotated) falls through to the React Flow canvas — same
+  // experience as desktop, just at a tighter viewport.
+  const isPortraitMobile = isNarrow && !isLandscape;
 
   // Fullbleed-on-mobile: lets the global nav scroll off so the subheader
   // pins to viewport top, freeing screen space for the canvas/timeline.
@@ -386,15 +400,15 @@ export default function GraphPage() {
     selection?.type === "node" ? selection.nodeId : null;
 
   // Allowed per design: graph headers may use Source Serif 4 (relaxes marketing-only rule).
-  // On mobile, Reset rides the title row so the collapsed subheader stays one
-  // row tall (title + action). On desktop, Reset moves into the right slot.
+  // Portrait mobile: Reset rides the title row so the collapsed subheader stays
+  // one row tall. Landscape phones + desktop: Reset moves into the right slot.
   const subheaderTitle = (
     <div className="flex items-center gap-2">
       <h1 className="font-serif text-lg sm:text-xl font-medium text-sage-800 inline-flex items-center gap-2 flex-1 min-w-0">
         <Dna className="h-5 w-5 text-primary" aria-hidden="true" />
         Lineage Tracer
       </h1>
-      {isNarrow && hasSeed && (
+      {isPortraitMobile && hasSeed && (
         <Button
           type="button"
           onClick={handleReset}
@@ -408,14 +422,14 @@ export default function GraphPage() {
     </div>
   );
 
-  // On mobile, hide the stats once the user starts scrolling so the sticky
-  // subheader collapses to just title + Reset (more screen space for cards).
-  const showStats = graph && !(isNarrow && scrolled);
+  // Portrait mobile only: hide the stats once the user starts scrolling so the
+  // sticky subheader collapses to just title + Reset (more screen space for cards).
+  const showStats = graph && !(isPortraitMobile && scrolled);
 
   const subheaderRightSlot = (
     <>
       {showStats && <GraphHeaderStats stats={graph.stats} />}
-      {!isNarrow && manualPositions.size > 0 && (
+      {!isPortraitMobile && manualPositions.size > 0 && (
         <Button
           type="button"
           onClick={handleResetManualPositions}
@@ -426,7 +440,7 @@ export default function GraphPage() {
           Reset positions
         </Button>
       )}
-      {!isNarrow && hasSeed && (
+      {!isPortraitMobile && hasSeed && (
         <Button type="button" onClick={handleReset} variant="ghost" size="sm">
           Reset
         </Button>
@@ -434,10 +448,11 @@ export default function GraphPage() {
     </>
   );
 
-  if (isNarrow) {
+  if (isPortraitMobile) {
     return (
       <>
         <Subheader title={subheaderTitle} rightSlot={subheaderRightSlot} />
+        <RotateForCanvasHint />
         <MobileTimeline
           familyId={familyId}
           response={response}
@@ -560,6 +575,42 @@ function CanvasSkeleton() {
           />
         ))}
       </div>
+    </div>
+  );
+}
+
+const ROTATE_HINT_KEY = "graph_rotate_hint_dismissed";
+
+function RotateForCanvasHint() {
+  const [dismissed, setDismissed] = useState<boolean>(() => {
+    if (typeof window === "undefined") return true;
+    return Boolean(window.localStorage.getItem(ROTATE_HINT_KEY));
+  });
+  if (dismissed) return null;
+  return (
+    <div
+      role="status"
+      className="mx-4 mt-3 flex items-center gap-3 rounded-md border border-primary/25 bg-primary/8 px-3 py-2 text-xs text-foreground"
+    >
+      <Smartphone className="h-4 w-4 shrink-0 text-primary -rotate-90" aria-hidden="true" />
+      <span className="flex-1">
+        Rotate your phone for the interactive canvas.
+      </span>
+      <button
+        type="button"
+        onClick={() => {
+          setDismissed(true);
+          try {
+            window.localStorage.setItem(ROTATE_HINT_KEY, "1");
+          } catch {
+            // localStorage may be unavailable (private mode); dismissal is in-memory only.
+          }
+        }}
+        aria-label="Dismiss rotate hint"
+        className="inline-flex h-6 w-6 shrink-0 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground transition-colors"
+      >
+        <X className="h-3.5 w-3.5" aria-hidden="true" />
+      </button>
     </div>
   );
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,6 +132,19 @@
     }
   }
 
+  /* Phone-class device in landscape: force the mobile nav variant (logo +
+     hamburger). The desktop nav at `sm:flex` (640px+) would otherwise show
+     on landscape phones at 700-900px wide and crowd the viewport. Detected
+     via short height (< 500px) AND landscape orientation. */
+  @media (max-height: 500px) and (orientation: landscape) {
+    [data-public-nav] [data-desktop-nav] {
+      display: none !important;
+    }
+    [data-public-nav] [data-mobile-menu-btn] {
+      display: inline-flex !important;
+    }
+  }
+
   /* Soft sage shimmer for tip text. Uses background-clip:text so the
      gradient animates across the glyph fills rather than the box. */
   .tip-shimmer {

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,16 +132,40 @@
     }
   }
 
-  /* Phone-class device in landscape: force the mobile nav variant (logo +
-     hamburger). The desktop nav at `sm:flex` (640px+) would otherwise show
-     on landscape phones at 700-900px wide and crowd the viewport. Detected
-     via short height (< 500px) AND landscape orientation. */
+  /* Phone-class device in landscape: max canvas real estate.
+     - Hide the global PublicNav entirely (Lineage Tracer subheader becomes
+       the only chrome at the top).
+     - Hide the React Flow MiniMap (eats valuable corner real estate).
+     - Hide the canvas onboarding tooltip / dragged-position hint that
+       wraps under the canvas — too cramped here.
+     Detected via short height (< 500px) AND landscape orientation. */
   @media (max-height: 500px) and (orientation: landscape) {
-    [data-public-nav] [data-desktop-nav] {
+    body.page-fullbleed-mobile [data-public-nav] {
       display: none !important;
     }
-    [data-public-nav] [data-mobile-menu-btn] {
-      display: inline-flex !important;
+    body.page-fullbleed-mobile .react-flow__minimap {
+      display: none !important;
+    }
+    body.page-fullbleed-mobile [data-graph-stats] {
+      display: none !important;
+    }
+  }
+
+  /* Touch devices (no hover): hide cmd-click hints in the detail drawer.
+     There's no equivalent two-key gesture on touch and the kbd glyph is
+     misleading. We don't yet have a touch-equivalent affordance for the
+     compare flow, so the hint is simply suppressed. */
+  @media (hover: none) {
+    [data-cmd-click-tip] {
+      display: none !important;
+    }
+  }
+
+  /* Small-screen hint: only render on phone-class displays (either
+     dimension < 640px). Hidden when both dimensions clear 640px. */
+  @media (min-width: 640px) and (min-height: 640px) {
+    [data-small-screen-hint] {
+      display: none;
     }
   }
 

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -173,7 +173,7 @@ export function PublicNav() {
         </Link>
 
         {/* Desktop nav */}
-        <nav data-desktop-nav className="hidden sm:flex items-center gap-6">
+        <nav className="hidden sm:flex items-center gap-6">
           {familyId && (
             <LeagueMenu
               familyId={familyId}
@@ -206,7 +206,6 @@ export function PublicNav() {
 
         {/* Mobile menu button */}
         <button
-          data-mobile-menu-btn
           onClick={() => setMobileOpen(!mobileOpen)}
           className="sm:hidden p-2 text-muted-foreground hover:text-foreground transition-colors"
           aria-label={mobileOpen ? "Close menu" : "Open menu"}

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -173,7 +173,7 @@ export function PublicNav() {
         </Link>
 
         {/* Desktop nav */}
-        <nav className="hidden sm:flex items-center gap-6">
+        <nav data-desktop-nav className="hidden sm:flex items-center gap-6">
           {familyId && (
             <LeagueMenu
               familyId={familyId}
@@ -206,6 +206,7 @@ export function PublicNav() {
 
         {/* Mobile menu button */}
         <button
+          data-mobile-menu-btn
           onClick={() => setMobileOpen(!mobileOpen)}
           className="sm:hidden p-2 text-muted-foreground hover:text-foreground transition-colors"
           aria-label={mobileOpen ? "Close menu" : "Open menu"}

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -285,7 +285,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
     : `${edge.endSeason ?? ""}${edge.endWeek ? ` · W${edge.endWeek}` : ""}`;
 
   return (
-    <div className="space-y-3 border rounded-lg p-3">
+    <div className="space-y-3 border rounded-lg p-3 max-lg:space-y-2 max-lg:p-2">
       <p className="font-mono text-[10px] uppercase tracking-wide text-muted-foreground">
         {edge.isOpen ? "Active stint" : "Stint"}
       </p>
@@ -422,8 +422,8 @@ function PlayerStintStats({
   const stats = state.data;
   return (
     <div>
-      <p className="text-xs text-muted-foreground mb-1.5">Stint stats</p>
-      <div className="grid grid-cols-2 gap-2">
+      <p className="text-xs text-muted-foreground mb-1.5 max-lg:mb-1">Stint stats</p>
+      <div className="grid grid-cols-2 gap-2 max-lg:gap-1">
         <StatTile
           label="PPG"
           value={fmtNumber(stats.ppg)}
@@ -734,14 +734,14 @@ function StatTile({
   hint: string;
 }) {
   return (
-    <div className="rounded-md border border-border/60 bg-background px-2.5 py-1.5">
-      <p className="text-[10px] uppercase tracking-wide text-muted-foreground">
+    <div className="rounded-md border border-border/60 bg-background px-2.5 py-1.5 max-lg:px-2 max-lg:py-1">
+      <p className="text-[10px] uppercase tracking-wide text-muted-foreground max-lg:text-[9px]">
         {label}
       </p>
-      <p className="font-mono text-base font-semibold text-foreground leading-tight">
+      <p className="font-mono text-base font-semibold text-foreground leading-tight max-lg:text-sm">
         {value}
       </p>
-      <p className="font-mono text-[10px] text-muted-foreground">{hint}</p>
+      <p className="font-mono text-[10px] text-muted-foreground max-lg:text-[9px]">{hint}</p>
     </div>
   );
 }

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import Link from "next/link";
 import { IdCard, X } from "lucide-react";
 import type { GraphEdge, GraphNode, GraphSelection } from "@/lib/assetGraph";
@@ -126,13 +126,11 @@ export function GraphDetailDrawer({
       aria-label="Graph detail"
       className={containerClass}
     >
-      <div className="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-border/60 bg-card max-lg:px-3 max-lg:py-2 max-lg:border-b-0">
+      <div className="sticky top-0 flex items-center justify-between max-lg:justify-end px-4 py-3 border-b border-border/60 bg-card max-lg:px-3 max-lg:py-2 max-lg:border-b-0">
         {/* Allowed per design: graph headers may use Source Serif 4 (relaxes marketing-only rule). */}
-        {/* Title hidden on narrow — saves vertical real estate; X is enough. */}
         <h2 className="font-serif text-base text-sage-800 max-lg:hidden">
           {isCompare ? `Comparing ${compareEdgeCount} stints` : "Details"}
         </h2>
-        <span className="hidden max-lg:block" aria-hidden="true" />
         <button
           ref={closeBtnRef}
           type="button"
@@ -294,7 +292,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
       </p>
       {edge.assetKind === "player" ? (
         <div>
-          <p className="text-xs text-muted-foreground max-lg:hidden">Player</p>
+          <SubLabel>Player</SubLabel>
           <div className="flex items-center gap-2 min-w-0">
             <p className="text-sm font-semibold flex-1 min-w-0 truncate">
               {edge.playerPosition ? `${edge.playerPosition} · ` : ""}
@@ -314,12 +312,12 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
         </div>
       ) : (
         <div>
-          <p className="text-xs text-muted-foreground max-lg:hidden">Pick</p>
+          <SubLabel>Pick</SubLabel>
           <p className="text-sm font-semibold">{edge.pickLabel}</p>
         </div>
       )}
       <div>
-        <p className="text-xs text-muted-foreground max-lg:hidden">Manager</p>
+        <SubLabel>Manager</SubLabel>
         <p className="text-sm">
           <ManagerName
             userId={edge.managerUserId}
@@ -425,7 +423,7 @@ function PlayerStintStats({
   const stats = state.data;
   return (
     <div>
-      <p className="text-xs text-muted-foreground mb-1.5 max-lg:hidden">Stint stats</p>
+      <SubLabel className="mb-1.5">Stint stats</SubLabel>
       <div className="grid grid-cols-2 gap-2 max-lg:gap-1">
         <StatTile
           label="PPG"
@@ -724,6 +722,22 @@ function CompareCell({
         {row.hint(state.data)}
       </p>
     </div>
+  );
+}
+
+function SubLabel({
+  children,
+  className,
+}: {
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <p
+      className={`text-xs text-muted-foreground max-lg:hidden${className ? ` ${className}` : ""}`}
+    >
+      {children}
+    </p>
   );
 }
 

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -332,7 +332,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
         {edge.startSeason} W{edge.startWeek} – {endLabel}
       </p>
       {edge.assetKind === "player" && edge.playerId && (
-        <p className="text-[11px] tip-shimmer pt-1 border-t border-border/40">
+        <p data-cmd-click-tip className="text-[11px] tip-shimmer pt-1 border-t border-border/40">
           Tip: <kbd className="font-mono">⌘</kbd>-click another stint to compare.
         </p>
       )}
@@ -612,7 +612,7 @@ function EdgeCompare({
           ))}
         </div>
       </div>
-      <p className="text-[11px] tip-shimmer">
+      <p data-cmd-click-tip className="text-[11px] tip-shimmer">
         Tip: <kbd className="font-mono">⌘</kbd>-click an edge to add or remove it from this comparison.
       </p>
     </div>

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -285,6 +285,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
   const endLabel = edge.isOpen
     ? "Ongoing"
     : `${edge.endSeason ?? ""}${edge.endWeek ? ` · W${edge.endWeek}` : ""}`;
+  const startLabel = `${edge.startSeason} · W${edge.startWeek}`;
 
   return (
     <div className="space-y-3 border rounded-lg p-3 max-lg:space-y-2 max-lg:p-2">
@@ -331,7 +332,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
         <PlayerStintStats familyId={familyId} edge={edge} />
       )}
       <p className="text-xs text-muted-foreground">
-        {edge.startSeason} W{edge.startWeek} – {endLabel}
+        {startLabel} – {endLabel}
       </p>
       {edge.assetKind === "player" && edge.playerId && (
         <p data-cmd-click-tip className="text-[11px] tip-shimmer pt-1 border-t border-border/40">

--- a/src/components/graph/GraphDetailDrawer.tsx
+++ b/src/components/graph/GraphDetailDrawer.tsx
@@ -126,11 +126,13 @@ export function GraphDetailDrawer({
       aria-label="Graph detail"
       className={containerClass}
     >
-      <div className="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-border/60 bg-card">
+      <div className="sticky top-0 flex items-center justify-between px-4 py-3 border-b border-border/60 bg-card max-lg:px-3 max-lg:py-2 max-lg:border-b-0">
         {/* Allowed per design: graph headers may use Source Serif 4 (relaxes marketing-only rule). */}
-        <h2 className="font-serif text-base text-sage-800">
+        {/* Title hidden on narrow — saves vertical real estate; X is enough. */}
+        <h2 className="font-serif text-base text-sage-800 max-lg:hidden">
           {isCompare ? `Comparing ${compareEdgeCount} stints` : "Details"}
         </h2>
+        <span className="hidden max-lg:block" aria-hidden="true" />
         <button
           ref={closeBtnRef}
           type="button"
@@ -142,7 +144,7 @@ export function GraphDetailDrawer({
         </button>
       </div>
 
-      <div className="p-4 space-y-4">
+      <div className="p-4 space-y-4 max-lg:p-3 max-lg:pt-0 max-lg:space-y-2">
         {selection.type === "node" ? (
           <NodeDetail
             node={nodes.find((n) => n.id === selection.nodeId) ?? null}
@@ -291,7 +293,7 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
       </p>
       {edge.assetKind === "player" ? (
         <div>
-          <p className="text-xs text-muted-foreground">Player</p>
+          <p className="text-xs text-muted-foreground max-lg:hidden">Player</p>
           <div className="flex items-center gap-2 min-w-0">
             <p className="text-sm font-semibold flex-1 min-w-0 truncate">
               {edge.playerPosition ? `${edge.playerPosition} · ` : ""}
@@ -311,12 +313,12 @@ function EdgeDetail({ edge, familyId }: { edge: GraphEdge | null; familyId: stri
         </div>
       ) : (
         <div>
-          <p className="text-xs text-muted-foreground">Pick</p>
+          <p className="text-xs text-muted-foreground max-lg:hidden">Pick</p>
           <p className="text-sm font-semibold">{edge.pickLabel}</p>
         </div>
       )}
       <div>
-        <p className="text-xs text-muted-foreground">Manager</p>
+        <p className="text-xs text-muted-foreground max-lg:hidden">Manager</p>
         <p className="text-sm">
           <ManagerName
             userId={edge.managerUserId}
@@ -422,7 +424,7 @@ function PlayerStintStats({
   const stats = state.data;
   return (
     <div>
-      <p className="text-xs text-muted-foreground mb-1.5 max-lg:mb-1">Stint stats</p>
+      <p className="text-xs text-muted-foreground mb-1.5 max-lg:hidden">Stint stats</p>
       <div className="grid grid-cols-2 gap-2 max-lg:gap-1">
         <StatTile
           label="PPG"

--- a/src/components/graph/GraphHeaderStats.tsx
+++ b/src/components/graph/GraphHeaderStats.tsx
@@ -8,7 +8,7 @@ interface GraphHeaderStatsProps {
 
 export function GraphHeaderStats({ stats }: GraphHeaderStatsProps) {
   return (
-    <div className="text-sm text-muted-foreground">
+    <div data-graph-stats className="text-sm text-muted-foreground">
       <span className="font-mono font-medium text-foreground">{stats.totalTransactions}</span> transactions
       <span className="mx-1.5">·</span>
       <span className="font-mono font-medium text-foreground">{stats.playersInvolved}</span> players


### PR DESCRIPTION
## Summary

Phones rotated into landscape now render the full `<AssetGraph>` canvas (React Flow) instead of the chronological `MobileTimeline`. Portrait keeps the timeline plus a dismissible "rotate for canvas" hint. Beyond the orientation flip, every chrome surface inside the canvas is tuned to maximize screen real estate on phones.

Closes #137. Replaces #135 (multi-thread vertical rail), which was closed unmerged — the narrow side strip wasn't legible enough; showing the actual desktop canvas in landscape gets the user closer to the real Lineage Tracer experience.

## What ships

### Orientation routing
- `isPortraitMobile = isNarrow && !isLandscape`. Detected via `innerWidth/innerHeight` with `resize` + `orientationchange` listeners.
- Portrait phone → `MobileTimeline` + dismissible rotate hint (localStorage-backed).
- Landscape phone → `<AssetGraph>` (React Flow with touch pan/zoom), same canvas as desktop.
- Wide screen unchanged.

### Mobile chrome
- Custom Viewport export on the graph route locks `maximumScale: 1`, `userScalable: false` — prevents iOS Safari auto-zoom on rotate. React Flow's pinch-zoom is JS-based and unaffected.
- `data-public-nav` / `data-mobile-menu-btn` attributes on `PublicNav`; CSS media query `(max-height: 500px) and (orientation: landscape)` forces the hamburger nav variant (instead of the desktop link strip) on landscape phones.
- Same media query hides the global nav entirely on landscape phone — only the "Lineage Tracer" subheader at the top.
- Stats text in subheader hidden on landscape phone (`data-graph-stats`).
- React Flow MiniMap hidden on landscape phone.
- Cmd-click hints in the detail drawer (`data-cmd-click-tip`) hidden on touch via `@media (hover: none)`.

### Detail drawer compaction (`max-lg:` variants — desktop unchanged)
- "Details" / "Comparing N stints" header hidden on narrow; X close button alone.
- Drawer header bottom border + extra padding stripped.
- Outer wrapper `p-4 → p-3 (pt-0)`, `space-y-4 → space-y-2`.
- "Player" / "Pick" / "Manager" / "Stint stats" sublabels hidden — values are self-evident.
- StatTile compacts: `text-base → text-sm` value, `text-[10px] → text-[9px]` label/hint, `px-2.5 py-1.5 → px-2 py-1` padding, `gap-2 → gap-1` grid.
- EdgeDetail card `space-y-3 → space-y-2`, `p-3 → p-2`.

### Other cleanups along the way
- "Click a card header to expand it..." onboarding tooltip + state removed entirely.
- Stint range now uniformly formatted: `2022 · W3 – 2023 · W1` (was: `2022 W3 – 2023 · W1`).
- Dismissible "Lineage Tracer works best on a larger screen" pill banner appears on phone-class viewports (either dimension < 640px).

## Test plan
- [x] `npm run build` clean.
- [x] Iframe smoke at 844×390: nav hidden, stats hidden, MiniMap hidden, small-screen banner shows, React Flow renders.
- [x] Iframe smoke at 390×600: timeline + rotate hint + small-screen banner, no React Flow.
- [x] CI verify ✅ Vercel build ✅
- [ ] Real phone: rotate to landscape → full canvas, pinch-zoom works, drawer fits in half the screen, stint stats card readable; rotate back → timeline; dismiss hints persist across reloads.

## Out of scope
- Multi-thread vertical rail (rejected — see #135).
- Smooth-transition animations (#74).

🤖 Generated with [Claude Code](https://claude.com/claude-code)