### PR TITLE
Lineage Tracer: sort asset picker by relevance

### DIFF
--- a/src/app/api/leagues/[familyId]/assets/route.ts
+++ b/src/app/api/leagues/[familyId]/assets/route.ts
@@ -10,7 +10,7 @@
 
 import { NextRequest, NextResponse } from "next/server";
 import { getDb, schema } from "@/db";
-import { and, eq, inArray, isNotNull } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, sql } from "drizzle-orm";
 import { resolveFamily } from "@/lib/familyResolution";
 import { resolveDraftPicks, findOriginalSlot, calculatePickNumber } from "@/lib/draft";
 import { pickKey } from "@/lib/assetGraph";
@@ -57,6 +57,16 @@ export async function GET(
     return NextResponse.json(empty);
   }
 
+  // Most-recent two seasons of the family — used for the "points" component
+  // of the player relevance sort.
+  const recentSeasons = Array.from(new Set(members.map((m) => m.season)))
+    .sort((a, b) => Number(b) - Number(a))
+    .slice(0, 2);
+  const recentSeasonsSet = new Set(recentSeasons);
+  const recentLeagueIds = members
+    .filter((m) => recentSeasonsSet.has(m.season))
+    .map((m) => m.leagueId);
+
   // ---- Distinct players from assetEvents ----
   const playerRows = await db
     .selectDistinct({ playerId: schema.assetEvents.playerId })
@@ -84,10 +94,71 @@ export async function GET(
           .where(inArray(schema.players.id, playerIds))
       : [];
 
+  // ---- Relevance signals: lifetime trades + recent points ----
+  const [playerTradeRows, playerPointsRows] = await Promise.all([
+    db
+      .select({
+        playerId: schema.assetEvents.playerId,
+        trades: sql<number>`count(*)`,
+      })
+      .from(schema.assetEvents)
+      .where(
+        and(
+          inArray(schema.assetEvents.leagueId, allLeagueIds),
+          eq(schema.assetEvents.eventType, "trade"),
+          eq(schema.assetEvents.assetKind, "player"),
+          isNotNull(schema.assetEvents.playerId),
+        ),
+      )
+      .groupBy(schema.assetEvents.playerId),
+    recentLeagueIds.length > 0
+      ? db
+          .select({
+            playerId: schema.playerScores.playerId,
+            points: sql<number>`coalesce(sum(${schema.playerScores.points}), 0)`,
+          })
+          .from(schema.playerScores)
+          .where(inArray(schema.playerScores.leagueId, recentLeagueIds))
+          .groupBy(schema.playerScores.playerId)
+      : Promise.resolve([] as Array<{ playerId: string; points: number }>),
+  ]);
+
+  const playerTradeMap = new Map<string, number>();
+  for (const row of playerTradeRows) {
+    if (row.playerId) playerTradeMap.set(row.playerId, Number(row.trades));
+  }
+  const playerPointsMap = new Map<string, number>();
+  for (const row of playerPointsRows) {
+    playerPointsMap.set(row.playerId, Number(row.points));
+  }
+
+  // Min-max normalize each signal independently, then sum so points and
+  // trades contribute equally regardless of their raw scale.
+  let maxPlayerPoints = 0;
+  let maxPlayerTrades = 0;
+  for (const p of playerMeta) {
+    maxPlayerPoints = Math.max(maxPlayerPoints, playerPointsMap.get(p.id) ?? 0);
+    maxPlayerTrades = Math.max(maxPlayerTrades, playerTradeMap.get(p.id) ?? 0);
+  }
+  const playerRelevanceMap = new Map<string, number>();
+  for (const p of playerMeta) {
+    const points = playerPointsMap.get(p.id) ?? 0;
+    const trades = playerTradeMap.get(p.id) ?? 0;
+    const score =
+      (maxPlayerPoints > 0 ? points / maxPlayerPoints : 0) +
+      (maxPlayerTrades > 0 ? trades / maxPlayerTrades : 0);
+    playerRelevanceMap.set(p.id, score);
+  }
+
   // Only include players we can identify; orphan IDs are filtered out — see issue #105.
   const players = playerMeta
     .map((p) => ({ id: p.id, name: p.name, position: p.position, team: p.team }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .sort((a, b) => {
+      const diff =
+        (playerRelevanceMap.get(b.id) ?? 0) - (playerRelevanceMap.get(a.id) ?? 0);
+      if (diff !== 0) return diff;
+      return a.name.localeCompare(b.name);
+    });
 
   // ---- Distinct picks from assetEvents ----
   const pickRows = await db
@@ -106,6 +177,45 @@ export async function GET(
         isNotNull(schema.assetEvents.pickOriginalRosterId),
       ),
     );
+
+  // ---- Pick trade counts (lifetime) for relevance sort ----
+  const pickTradeRows = await db
+    .select({
+      pickSeason: schema.assetEvents.pickSeason,
+      pickRound: schema.assetEvents.pickRound,
+      pickOriginalRosterId: schema.assetEvents.pickOriginalRosterId,
+      trades: sql<number>`count(*)`,
+    })
+    .from(schema.assetEvents)
+    .where(
+      and(
+        inArray(schema.assetEvents.leagueId, allLeagueIds),
+        eq(schema.assetEvents.eventType, "pick_trade"),
+        isNotNull(schema.assetEvents.pickSeason),
+        isNotNull(schema.assetEvents.pickRound),
+        isNotNull(schema.assetEvents.pickOriginalRosterId),
+      ),
+    )
+    .groupBy(
+      schema.assetEvents.pickSeason,
+      schema.assetEvents.pickRound,
+      schema.assetEvents.pickOriginalRosterId,
+    );
+  const pickTradeMap = new Map<string, number>();
+  for (const row of pickTradeRows) {
+    if (
+      row.pickSeason !== null &&
+      row.pickRound !== null &&
+      row.pickOriginalRosterId !== null
+    ) {
+      const key = pickKey({
+        pickSeason: row.pickSeason,
+        pickRound: row.pickRound,
+        pickOriginalRosterId: row.pickOriginalRosterId,
+      });
+      pickTradeMap.set(key, Number(row.trades));
+    }
+  }
 
   // ---- Original-owner display names: rosters -> leagueUsers ----
   const [rosters, users] = await Promise.all([
@@ -221,6 +331,9 @@ export async function GET(
       };
     })
     .sort((a, b) => {
+      const tradeDiff =
+        (pickTradeMap.get(b.key) ?? 0) - (pickTradeMap.get(a.key) ?? 0);
+      if (tradeDiff !== 0) return tradeDiff;
       if (a.season !== b.season) return Number(b.season) - Number(a.season);
       if (a.round !== b.round) return a.round - b.round;
       return (a.originalOwnerName ?? "").localeCompare(b.originalOwnerName ?? "");


### PR DESCRIPTION
Players sort by combined recent scoring (last 2 seasons) and lifetime
trade count, each min-max normalized so the two signals carry equal
weight. Picks sort by lifetime trade count, falling back to the prior
season/round/owner tiebreakers. Replaces the alphabetical default,
surfacing the most interesting assets first.

https://claude.ai/code/session_01T7jFt8tndM3Tjh56j2VZcx