### PR TITLE
Trim gsis_id on Sleeper player sync (#125)

### DIFF
--- a/src/services/playerSync.ts
+++ b/src/services/playerSync.ts
@@ -43,7 +43,10 @@ export async function syncPlayers(force = false): Promise<number> {
       .filter((p) => p.position && FANTASY_POSITIONS.has(p.position))
       .map((p) => ({
         id: p.player_id,
-        gsisId: p.gsis_id,
+        // Sleeper occasionally returns gsis_id with stray whitespace (the 2019
+        // draft cohort all had a leading space) — normalize so joins onto the
+        // nflverse-sourced nfl_weekly_roster_status table actually match.
+        gsisId: p.gsis_id?.trim() || null,
         name: p.full_name || `${p.first_name} ${p.last_name}`,
         firstName: p.first_name,
         lastName: p.last_name,


### PR DESCRIPTION
## Summary
- Closes #125. A.J. Brown (and 54 other rostered players) showed no NFL status on the weekly log and no stint stats in the lineage tracer because `players.gsis_id` carried a stray leading space for the 2019 draft cohort, breaking every join onto `nfl_weekly_roster_status`.
- Trim `gsis_id` on write in `playerSync.ts` so the next Sleeper sync can't re-introduce the whitespace.
- Prod backfill already applied (`UPDATE players SET gsis_id = btrim(gsis_id) WHERE gsis_id <> btrim(gsis_id)` — 284 rows updated, AJB now joins to all 18 of his 2025 status rows). No app-side migration needed.

## Investigation notes
Three downstream consumers all silently failed for the affected players:
1. `weekly-log/route.ts:180` → Status column rendered `—` (the original #125 symptom)
2. `services/playerStintStats.ts:118-227` → empty `activeKeys` zeroed out PPG / Active% in the lineage tracer (the symptom that led to this fix)
3. `services/gradingCore.ts:783` → `activeWeeks` undercounted, biasing trade-grade production component

A separate latent bug surfaced during investigation — `rosterStatusSync.ts:69` short-circuits per season once any row exists, so in-progress seasons silently miss new weeks unless force-synced. Filed as [a comment on #20](https://github.com/jrygrande/dynasty-dna/issues/20#issuecomment-4370442018) since it belongs in the cron-design scope, not this fix.

## Test plan
- [x] Verify post-backfill: `SELECT COUNT(*) FROM players WHERE gsis_id <> btrim(gsis_id)` → 0
- [x] Verify AJB join: 17 ACT + 1 INA rows for 2025 (matches W1-W7 ACT, W8 INA, W9 bye, W10-W19 ACT)
- [ ] After deploy: open AJB in lineage tracer, confirm stint stats now populate
- [ ] After deploy: open `/league/[familyId]/player/5859`, confirm Status column populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)