### PR TITLE
Land at top on nav, clamp horizontal overflow on mobile

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -108,6 +108,15 @@
   * {
     @apply border-border;
   }
+  /* Clamp document width on every device. Without this, a single overflowing
+     descendant (sticky table, long unbroken token, fixed-width chart) widens
+     the layout viewport on iOS/Android — the user lands on a page that looks
+     scaled-in / shifted right. `overflow-x: clip` keeps painting fully but
+     prevents the document from becoming horizontally scrollable. */
+  html,
+  body {
+    overflow-x: clip;
+  }
   body {
     @apply bg-background text-foreground font-sans;
     font-feature-settings: "cv11", "ss01";

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Inter, Source_Serif_4, JetBrains_Mono } from "next/font/google";
 import "./globals.css";
+import { ScrollToTopOnRouteChange } from "@/components/ScrollToTopOnRouteChange";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -41,7 +42,10 @@ export default function RootLayout({
       lang="en"
       className={`${inter.variable} ${sourceSerif.variable} ${jetBrainsMono.variable}`}
     >
-      <body>{children}</body>
+      <body>
+        <ScrollToTopOnRouteChange />
+        {children}
+      </body>
     </html>
   );
 }

--- a/src/components/ScrollToTopOnRouteChange.tsx
+++ b/src/components/ScrollToTopOnRouteChange.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname } from "next/navigation";
+
+// Next.js App Router scrolls the new page root into view, which lands behind
+// the sticky <PublicNav>. Force absolute top after every pathname change —
+// but yield to hash-jumps and to the browser's own back/forward restoration.
+export function ScrollToTopOnRouteChange() {
+  const pathname = usePathname();
+  const isPop = useRef(false);
+
+  useEffect(() => {
+    const onPop = () => {
+      isPop.current = true;
+    };
+    window.addEventListener("popstate", onPop);
+    return () => window.removeEventListener("popstate", onPop);
+  }, []);
+
+  useEffect(() => {
+    if (isPop.current) {
+      isPop.current = false;
+      return;
+    }
+    if (window.location.hash) return;
+    const id = requestAnimationFrame(() => window.scrollTo(0, 0));
+    return () => cancelAnimationFrame(id);
+  }, [pathname]);
+
+  return null;
+}


### PR DESCRIPTION
## Summary
- **Scroll lands at top after every route change.** Next.js App Router scrolls the new page root into view, which on this layout lands at scrollY ≈ nav-height because the sticky `<PublicNav>` precedes the page root in DOM order — the route's top tiles end up partially behind the nav. A small client component mounted in the root layout forces `scrollTo(0, 0)` after every pathname change, with guards so it yields to `#hash` jumps and the browser's back/forward scroll restoration.
- **Mobile no longer feels zoomed-in.** A single overflowing descendant (sticky table cells, fixed-width charts, long unbroken tokens) was widening the layout viewport on iOS/Android. Added `overflow-x: clip` on `html, body` to keep the document width clamped to the device. `clip` (vs `hidden`) doesn't establish a scroll container, so sticky nav + sub-header keep working — verified.

## Test plan
- [ ] On the Vercel preview, scroll the manager page deep, click any roster player link → player page lands at scrollY=0 with the player tiles visible.
- [ ] Same flow on mobile viewport (DevTools device emulation, ~390px wide).
- [ ] On any page, scroll down then click back → browser-restored scroll position is preserved (not clobbered to 0).
- [ ] If a link with `#anchor` exists anywhere, clicking it jumps to the anchor instead of scrolling to top.
- [ ] On league overview (mobile width) the layout no longer feels zoomed/shifted; sticky nav and sub-header still pin correctly when scrolling within the page.
- [ ] Query-string-only updates (e.g. season filter on manager page, txType on transactions) preserve scrollY.

🤖 Generated with [Claude Code](https://claude.com/claude-code)