### PR TITLE
Sync 3: Fix isSeasonSynced footgun for current-season nflverse data (#146)

### DIFF
--- a/drizzle/0015_green_omega_flight.sql
+++ b/drizzle/0015_green_omega_flight.sql
@@ -1,0 +1,7 @@
+CREATE TABLE "nflverse_watermarks" (
+	"source" text NOT NULL,
+	"season" integer NOT NULL,
+	"last_synced_week" integer DEFAULT 0 NOT NULL,
+	"last_synced_at" timestamp DEFAULT now() NOT NULL,
+	CONSTRAINT "nflverse_watermarks_source_season_pk" PRIMARY KEY("source","season")
+);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,2722 @@
+{
+  "id": "2cd2330a-8f6c-4e2d-8765-671631c7d627",
+  "prevId": "9d199902-c41f-4e3a-acc2-a42513620e6b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.algorithm_config": {
+      "name": "algorithm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "algorithm_config_active_idx": {
+          "name": "algorithm_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "algorithm_config_experiment_id_experiment_runs_id_fk": {
+          "name": "algorithm_config_experiment_id_experiment_runs_id_fk",
+          "tableFrom": "algorithm_config",
+          "tableTo": "experiment_runs",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_events": {
+      "name": "asset_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_kind": {
+          "name": "asset_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_season": {
+          "name": "pick_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_round": {
+          "name": "pick_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_original_roster_id": {
+          "name": "pick_original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_roster_id": {
+          "name": "from_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_roster_id": {
+          "name": "to_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "asset_events_player_idx": {
+          "name": "asset_events_player_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_tx_idx": {
+          "name": "asset_events_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_pick_idx": {
+          "name": "asset_events_pick_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_round",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_original_roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_grades": {
+      "name": "draft_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_value": {
+          "name": "benchmark_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_production": {
+          "name": "player_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_production": {
+          "name": "benchmark_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_size": {
+          "name": "benchmark_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_grades_draft_idx": {
+          "name": "draft_grades_draft_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_player_idx": {
+          "name": "draft_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_unique_idx": {
+          "name": "draft_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_grades_draft_id_drafts_id_fk": {
+          "name": "draft_grades_draft_id_drafts_id_fk",
+          "tableFrom": "draft_grades",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_slot": {
+          "name": "draft_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_keeper": {
+          "name": "is_keeper",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_draft_id_drafts_id_fk": {
+          "name": "draft_picks_draft_id_drafts_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "draft_picks_draft_id_pick_no_pk": {
+          "name": "draft_picks_draft_id_pick_no_pk",
+          "columns": [
+            "draft_id",
+            "pick_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_to_roster_id": {
+          "name": "slot_to_roster_id",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "drafts_league_id_leagues_id_fk": {
+          "name": "drafts_league_id_leagues_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_runs": {
+      "name": "experiment_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hypothesis": {
+          "name": "hypothesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_criteria": {
+          "name": "acceptance_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_reason": {
+          "name": "verdict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scorecard": {
+          "name": "scorecard",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiment_runs_name_idx": {
+          "name": "experiment_runs_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fantasy_calc_values": {
+      "name": "fantasy_calc_values",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_flex": {
+          "name": "is_super_flex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ppr": {
+          "name": "ppr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_rank": {
+          "name": "position_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "fantasy_calc_values_player_id_is_super_flex_ppr_pk": {
+          "name": "fantasy_calc_values_player_id_is_super_flex_ppr_pk",
+          "columns": [
+            "player_id",
+            "is_super_flex",
+            "ppr"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_families": {
+      "name": "league_families",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_league_id": {
+          "name": "root_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo_eligible": {
+          "name": "demo_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "league_families_root_league_id_unique": {
+          "name": "league_families_root_league_id_unique",
+          "columns": [
+            {
+              "expression": "root_league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_family_members": {
+      "name": "league_family_members",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "league_family_members_league_id_idx": {
+          "name": "league_family_members_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "league_family_members_family_id_league_families_id_fk": {
+          "name": "league_family_members_family_id_league_families_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "league_families",
+          "columnsFrom": [
+            "family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_family_members_league_id_leagues_id_fk": {
+          "name": "league_family_members_league_id_leagues_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_family_members_family_id_league_id_pk": {
+          "name": "league_family_members_family_id_league_id_pk",
+          "columns": [
+            "family_id",
+            "league_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_users": {
+      "name": "league_users",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_users_league_id_leagues_id_fk": {
+          "name": "league_users_league_id_leagues_id_fk",
+          "tableFrom": "league_users",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_users_league_id_user_id_pk": {
+          "name": "league_users_league_id_user_id_pk",
+          "columns": [
+            "league_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_league_id": {
+          "name": "previous_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scoring_settings": {
+          "name": "scoring_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_positions": {
+          "name": "roster_positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_rosters": {
+          "name": "total_rosters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winners_bracket": {
+          "name": "winners_bracket",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manager_metrics": {
+      "name": "manager_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manager_metrics_unique_idx": {
+          "name": "manager_metrics_unique_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchups": {
+      "name": "matchups",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_points": {
+          "name": "starter_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_points": {
+          "name": "player_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchups_league_id_week_roster_id_pk": {
+          "name": "matchups_league_id_week_roster_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_injuries": {
+      "name": "nfl_injuries",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_type": {
+          "name": "game_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_primary_injury": {
+          "name": "report_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_secondary_injury": {
+          "name": "report_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_status": {
+          "name": "practice_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_primary_injury": {
+          "name": "practice_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_secondary_injury": {
+          "name": "practice_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_modified": {
+          "name": "date_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_injuries_gsis_idx": {
+          "name": "nfl_injuries_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_injuries_season_week_gsis_id_pk": {
+          "name": "nfl_injuries_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_schedule": {
+      "name": "nfl_schedule",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team": {
+          "name": "home_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team": {
+          "name": "away_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_date": {
+          "name": "game_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_schedule_season_week_home_team_pk": {
+          "name": "nfl_schedule_season_week_home_team_pk",
+          "columns": [
+            "season",
+            "week",
+            "home_team"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_state": {
+      "name": "nfl_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'nfl'"
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_type": {
+          "name": "season_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_weekly_roster_status": {
+      "name": "nfl_weekly_roster_status",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_abbr": {
+          "name": "status_abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_roster_status_gsis_idx": {
+          "name": "nfl_roster_status_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_weekly_roster_status_season_week_gsis_id_pk": {
+          "name": "nfl_weekly_roster_status_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nflverse_watermarks": {
+      "name": "nflverse_watermarks",
+      "schema": "",
+      "columns": {
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_week": {
+          "name": "last_synced_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nflverse_watermarks_source_season_pk": {
+          "name": "nflverse_watermarks_source_season_pk",
+          "columns": [
+            "source",
+            "season"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_scores": {
+      "name": "player_scores",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_scores_league_id_week_roster_id_player_id_pk": {
+          "name": "player_scores_league_id_week_roster_id_player_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id",
+            "player_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injury_status": {
+          "name": "injury_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "years_exp": {
+          "name": "years_exp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rosters": {
+      "name": "rosters",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserve": {
+          "name": "reserve",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "ties": {
+          "name": "ties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts": {
+          "name": "fpts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts_against": {
+          "name": "fpts_against",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rosters_owner_idx": {
+          "name": "rosters_owner_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rosters_league_id_leagues_id_fk": {
+          "name": "rosters_league_id_leagues_id_fk",
+          "tableFrom": "rosters",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rosters_league_id_roster_id_pk": {
+          "name": "rosters_league_id_roster_id_pk",
+          "columns": [
+            "league_id",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_jobs": {
+      "name": "sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "done": {
+          "name": "done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_jobs_ref_status_idx": {
+          "name": "sync_jobs_ref_status_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_watermarks": {
+      "name": "sync_watermarks",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_week": {
+          "name": "last_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_watermarks_league_id_data_type_pk": {
+          "name": "sync_watermarks_league_id_data_type_pk",
+          "columns": [
+            "league_id",
+            "data_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trade_grades": {
+      "name": "trade_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fantasy_calc_value": {
+          "name": "fantasy_calc_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trade_grades_tx_idx": {
+          "name": "trade_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trade_grades_unique_idx": {
+          "name": "trade_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trade_grades_transaction_id_transactions_id_fk": {
+          "name": "trade_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "trade_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traded_picks": {
+      "name": "traded_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_roster_id": {
+          "name": "original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_owner_id": {
+          "name": "current_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_owner_id": {
+          "name": "previous_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "traded_picks_league_season_idx": {
+          "name": "traded_picks_league_season_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "traded_picks_league_id_leagues_id_fk": {
+          "name": "traded_picks_league_id_leagues_id_fk",
+          "tableFrom": "traded_picks",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_ids": {
+          "name": "roster_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adds": {
+          "name": "adds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drops": {
+          "name": "drops",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_picks": {
+          "name": "draft_picks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_league_week_idx": {
+          "name": "transactions_league_week_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_league_id_leagues_id_fk": {
+          "name": "transactions_league_id_leagues_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_email_league_unique": {
+          "name": "waitlist_email_league_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_league_id_idx": {
+          "name": "waitlist_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waiver_grades": {
+      "name": "waiver_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_player_id": {
+          "name": "dropped_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_value": {
+          "name": "dropped_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_bid": {
+          "name": "faab_bid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_efficiency": {
+          "name": "faab_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waiver_grades_tx_idx": {
+          "name": "waiver_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_player_idx": {
+          "name": "waiver_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_unique_idx": {
+          "name": "waiver_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "waiver_grades_transaction_id_transactions_id_fk": {
+          "name": "waiver_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "waiver_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1777809025774,
       "tag": "0014_rename_overall_score_to_manager_process_score",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1778157072912,
+      "tag": "0015_green_omega_flight",
+      "breakpoints": true
     }
   ]
 }

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -625,3 +625,23 @@ export const syncWatermarks = pgTable(
     pk: primaryKey({ columns: [sw.leagueId, sw.dataType] }),
   })
 );
+
+// Per-(source, season) watermark for nflverse-sourced data.
+// Distinct from `sync_watermarks` (which is league-scoped) because nflverse
+// data is global and not tied to any league. `lastSyncedWeek` lets the current
+// season re-fetch incrementally without forcing every cron tick to be a full
+// season reload.
+export const nflverseWatermarks = pgTable(
+  "nflverse_watermarks",
+  {
+    source: text("source").notNull(), // 'roster_status' | 'injuries' | 'schedule'
+    season: integer("season").notNull(),
+    lastSyncedWeek: integer("last_synced_week").notNull().default(0),
+    lastSyncedAt: timestamp("last_synced_at", { mode: "date" })
+      .defaultNow()
+      .notNull(),
+  },
+  (nw) => ({
+    pk: primaryKey({ columns: [nw.source, nw.season] }),
+  })
+);

--- a/src/services/__tests__/nflverseWatermark.test.ts
+++ b/src/services/__tests__/nflverseWatermark.test.ts
@@ -1,0 +1,86 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the shouldSkipSeasonSync branching logic that fixes #146.
+ * The previous implementation skipped any season that had at least one row
+ * in the destination table — which silently dropped new weekly data during
+ * the in-progress season. The new logic only skips _historical_ seasons.
+ */
+
+import { shouldSkipSeasonSync } from "../nflverseWatermark";
+
+const CURRENT = 2026;
+
+function makeHasRows(populated: Set<number>) {
+  return jest.fn(async (season: number) => populated.has(season));
+}
+
+describe("shouldSkipSeasonSync", () => {
+  it("skips a historical season that already has rows", async () => {
+    const hasRows = makeHasRows(new Set([2023]));
+    const skip = await shouldSkipSeasonSync(2023, {
+      now: CURRENT,
+      hasRows,
+    });
+    expect(skip).toBe(true);
+    expect(hasRows).toHaveBeenCalledWith(2023);
+  });
+
+  it("does not skip a historical season with no rows yet", async () => {
+    const hasRows = makeHasRows(new Set());
+    const skip = await shouldSkipSeasonSync(2023, {
+      now: CURRENT,
+      hasRows,
+    });
+    expect(skip).toBe(false);
+  });
+
+  it("never skips the current season even if rows exist", async () => {
+    // This is the bug fix. Pre-fix, this returned true and silently dropped
+    // every subsequent week of in-progress data.
+    const hasRows = makeHasRows(new Set([CURRENT]));
+    const skip = await shouldSkipSeasonSync(CURRENT, {
+      now: CURRENT,
+      hasRows,
+    });
+    expect(skip).toBe(false);
+  });
+
+  it("never skips a future season even if rows exist", async () => {
+    // Defensive: if the clock somehow drifts or a season is queued early,
+    // err on the side of fetching.
+    const hasRows = makeHasRows(new Set([CURRENT + 1]));
+    const skip = await shouldSkipSeasonSync(CURRENT + 1, {
+      now: CURRENT,
+      hasRows,
+    });
+    expect(skip).toBe(false);
+  });
+
+  it("never skips when force is true, regardless of season age", async () => {
+    const hasRows = makeHasRows(new Set([2010]));
+    const skip = await shouldSkipSeasonSync(2010, {
+      force: true,
+      now: CURRENT,
+      hasRows,
+    });
+    expect(skip).toBe(false);
+    // Existence check should be short-circuited — no need to query.
+    expect(hasRows).not.toHaveBeenCalled();
+  });
+
+  it("does not call hasRows for the current season (avoids wasted query)", async () => {
+    const hasRows = makeHasRows(new Set([CURRENT]));
+    await shouldSkipSeasonSync(CURRENT, { now: CURRENT, hasRows });
+    expect(hasRows).not.toHaveBeenCalled();
+  });
+
+  it("handles boundary: prior season with rows is historical and skipped", async () => {
+    const hasRows = makeHasRows(new Set([CURRENT - 1]));
+    const skip = await shouldSkipSeasonSync(CURRENT - 1, {
+      now: CURRENT,
+      hasRows,
+    });
+    expect(skip).toBe(true);
+  });
+});

--- a/src/services/__tests__/nflverseWatermark.test.ts
+++ b/src/services/__tests__/nflverseWatermark.test.ts
@@ -7,7 +7,11 @@
  * the in-progress season. The new logic only skips _historical_ seasons.
  */
 
-import { shouldSkipSeasonSync } from "../nflverseWatermark";
+import {
+  currentSeason,
+  setNflverseWatermarkTx,
+  shouldSkipSeasonSync,
+} from "../nflverseWatermark";
 
 const CURRENT = 2026;
 
@@ -82,5 +86,162 @@ describe("shouldSkipSeasonSync", () => {
       hasRows,
     });
     expect(skip).toBe(true);
+  });
+});
+
+describe("currentSeason", () => {
+  // The NFL season N runs Sept of year N to early Feb of year N+1, so we
+  // treat months Aug-Dec as season=year and Jan-July as season=year-1.
+  // Pre-fix, `new Date().getFullYear()` returned year-roll on Jan 1 — which
+  // would prematurely flip the in-progress 2025 season to "historical" on
+  // Jan 1, 2026 and short-circuit playoff-week injury/roster fetches.
+  //
+  // Note: we construct dates with local-time fields (year, month, day)
+  // because `currentSeason()` reads `getMonth()` / `getFullYear()` in the
+  // local TZ. ISO-Z strings would shift to the runner's TZ and flip months
+  // at boundaries.
+
+  // Helper: noon local time on Y-M-D (M is 1-12 here for readability).
+  const local = (y: number, m: number, d: number) =>
+    new Date(y, m - 1, d, 12, 0, 0);
+
+  it("treats August 1 as the start of the new season", () => {
+    expect(currentSeason(local(2025, 8, 1))).toBe(2025);
+  });
+
+  it("treats December 31 as still inside the current season", () => {
+    expect(currentSeason(local(2025, 12, 31))).toBe(2025);
+  });
+
+  it("does NOT roll the season forward on January 1", () => {
+    // The Jan 1, 2026 case is the bug: pre-fix, the 2025 season would be
+    // labeled 2026 — making it >= currentSeason and forcing skip-if-rows.
+    expect(currentSeason(local(2026, 1, 1))).toBe(2025);
+  });
+
+  it("keeps mid-February inside the prior season (Super Bowl week)", () => {
+    expect(currentSeason(local(2026, 2, 15))).toBe(2025);
+  });
+
+  it("treats the end of July as still the prior season", () => {
+    // July 31 is the last day before training camps / preseason; the
+    // upcoming season hasn't started.
+    expect(currentSeason(local(2026, 7, 31))).toBe(2025);
+  });
+});
+
+describe("setNflverseWatermarkTx (transaction-scoped writes)", () => {
+  // The previous code wrote the watermark via getDb() AFTER the data
+  // transaction committed. That left two failure modes:
+  //   1. Data transaction rolls back, but the watermark write was never
+  //      reached — fine, but only because the post-commit ordering was
+  //      load-bearing.
+  //   2. Data transaction commits, then the watermark write fails — the
+  //      next run re-does the work because no watermark was stamped.
+  // Worse, if the order were ever flipped, a rolled-back data write could
+  // leave a stamped watermark that skips the season forever. Moving the
+  // watermark write inside the same transaction makes both writes atomic.
+
+  it("writes the watermark via the supplied tx (not getDb())", async () => {
+    const inserted: Array<Record<string, unknown>> = [];
+    const fakeTx = {
+      insert: jest.fn().mockReturnValue({
+        values: jest.fn().mockImplementation((v) => {
+          inserted.push(v);
+          return {
+            onConflictDoUpdate: jest.fn().mockResolvedValue(undefined),
+          };
+        }),
+      }),
+    };
+
+    // Cast through unknown — we deliberately don't depend on drizzle's
+    // PgTransaction generic surface; we only care that the tx's insert()
+    // path is the one used.
+    await setNflverseWatermarkTx(
+      fakeTx as unknown as Parameters<typeof setNflverseWatermarkTx>[0],
+      "injuries",
+      2025,
+      14
+    );
+
+    expect(fakeTx.insert).toHaveBeenCalledTimes(1);
+    expect(inserted).toEqual([
+      { source: "injuries", season: 2025, lastSyncedWeek: 14 },
+    ]);
+  });
+
+  it("propagates errors so the surrounding transaction rolls back", async () => {
+    // Verifies the rollback path: if the watermark insert throws, the
+    // caller's `await syncDb.transaction(async (tx) => { ... })` rejects
+    // and drizzle issues ROLLBACK — meaning a failed watermark write
+    // takes the data write down with it. Pre-fix this couldn't happen:
+    // the watermark was written on a separate connection after commit.
+    const boom = new Error("constraint violation");
+    const fakeTx = {
+      insert: jest.fn().mockReturnValue({
+        values: jest.fn().mockReturnValue({
+          onConflictDoUpdate: jest.fn().mockRejectedValue(boom),
+        }),
+      }),
+    };
+
+    await expect(
+      setNflverseWatermarkTx(
+        fakeTx as unknown as Parameters<typeof setNflverseWatermarkTx>[0],
+        "schedule",
+        2025,
+        18
+      )
+    ).rejects.toBe(boom);
+  });
+
+  it("a failed watermark write rejects the surrounding transaction callback", async () => {
+    // End-to-end shape: data inserts succeed, watermark insert throws,
+    // the surrounding `db.transaction(async tx => ...)` callback rejects
+    // — drizzle issues ROLLBACK on rejection, so neither write persists.
+    // Rejection IS rollback at the drizzle layer; we just need to verify
+    // the rejection propagates out of the callback.
+    let dataWritten = false;
+    let watermarkAttempted = false;
+
+    const fakeTx = {
+      insert: jest.fn().mockImplementation(() => ({
+        values: () => ({
+          onConflictDoNothing: jest.fn().mockImplementation(() => {
+            dataWritten = true;
+            return Promise.resolve(undefined);
+          }),
+          onConflictDoUpdate: jest.fn().mockImplementation(() => {
+            watermarkAttempted = true;
+            return Promise.reject(new Error("watermark conflict"));
+          }),
+        }),
+      })),
+    };
+
+    const fakeDb = {
+      transaction: async (
+        cb: (tx: typeof fakeTx) => Promise<unknown>
+      ): Promise<unknown> => cb(fakeTx),
+    };
+
+    const run = async () => {
+      await fakeDb.transaction(async (tx) => {
+        // Simulated data insert (succeeds in our mock).
+        await tx.insert({}).values().onConflictDoNothing();
+        // Watermark insert (rejects).
+        await setNflverseWatermarkTx(
+          tx as unknown as Parameters<typeof setNflverseWatermarkTx>[0],
+          "roster_status",
+          2025,
+          14
+        );
+      });
+    };
+
+    await expect(run()).rejects.toThrow("watermark conflict");
+    expect(dataWritten).toBe(true);
+    expect(watermarkAttempted).toBe(true);
   });
 });

--- a/src/services/injurySync.ts
+++ b/src/services/injurySync.ts
@@ -1,5 +1,9 @@
 import { getDb, getSyncDb, schema } from "@/db";
 import { sql, eq, and } from "drizzle-orm";
+import {
+  setNflverseWatermark,
+  shouldSkipSeasonSync,
+} from "@/services/nflverseWatermark";
 
 const NFLVERSE_INJURY_URL =
   "https://github.com/nflverse/nflverse-data/releases/download/injuries/injuries_";
@@ -80,8 +84,9 @@ function parseCSVLine(line: string): string[] {
 
 /**
  * Check if a season's injury data has already been synced.
+ * Used as the historical-season skip optimization.
  */
-async function isSeasonSynced(season: number): Promise<boolean> {
+async function hasInjuryRows(season: number): Promise<boolean> {
   const db = getDb();
   const result = await db
     .select({ count: sql<number>`count(*)` })
@@ -98,7 +103,11 @@ async function syncInjurySeason(
   season: number,
   force = false
 ): Promise<number> {
-  if (!force && (await isSeasonSynced(season))) {
+  const skip = await shouldSkipSeasonSync(season, {
+    force,
+    hasRows: hasInjuryRows,
+  });
+  if (skip) {
     return 0;
   }
 
@@ -160,6 +169,9 @@ async function syncInjurySeason(
       count += batch.length;
     }
   });
+
+  const maxWeek = allValues.reduce((m, r) => (r.week > m ? r.week : m), 0);
+  await setNflverseWatermark("injuries", season, maxWeek);
 
   return count;
 }

--- a/src/services/injurySync.ts
+++ b/src/services/injurySync.ts
@@ -1,7 +1,7 @@
 import { getDb, getSyncDb, schema } from "@/db";
 import { sql, eq, and } from "drizzle-orm";
 import {
-  setNflverseWatermark,
+  setNflverseWatermarkTx,
   shouldSkipSeasonSync,
 } from "@/services/nflverseWatermark";
 
@@ -155,6 +155,11 @@ async function syncInjurySeason(
   const BATCH_SIZE = 200;
   let count = 0;
 
+  const maxWeek = allValues.reduce((m, r) => (r.week > m ? r.week : m), 0);
+
+  // Watermark write lives inside the transaction so it commits atomically
+  // with the data write — if the inserts roll back, the watermark is not
+  // stamped, and vice versa.
   await syncDb.transaction(async (tx) => {
     await tx
       .delete(schema.nflInjuries)
@@ -168,10 +173,9 @@ async function syncInjurySeason(
         .onConflictDoNothing();
       count += batch.length;
     }
-  });
 
-  const maxWeek = allValues.reduce((m, r) => (r.week > m ? r.week : m), 0);
-  await setNflverseWatermark("injuries", season, maxWeek);
+    await setNflverseWatermarkTx(tx, "injuries", season, maxWeek);
+  });
 
   return count;
 }

--- a/src/services/nflverseWatermark.ts
+++ b/src/services/nflverseWatermark.ts
@@ -1,0 +1,94 @@
+import { getDb, schema } from "@/db";
+import { and, eq } from "drizzle-orm";
+
+/**
+ * Identifier for an nflverse data source. Used as the partition key in the
+ * nflverse_watermarks table so each source can track its own per-season
+ * progress independently.
+ */
+export type NflverseSource = "roster_status" | "injuries" | "schedule";
+
+/**
+ * Returns the current NFL season year. Extracted as a function so tests can
+ * stub it to exercise the current-vs-historical branch.
+ */
+export function currentSeason(): number {
+  return new Date().getFullYear();
+}
+
+/**
+ * Decide whether a season sync should be skipped.
+ *
+ * - If `force` is true: never skip.
+ * - Current season (or future): never skip — in-progress data needs to keep
+ *   flowing in week-over-week. (This is the bug fix for #146; the previous
+ *   implementation short-circuited as soon as any row existed for the season,
+ *   silently missing every subsequent week's data until someone manually
+ *   passed `force: true`.)
+ * - Historical seasons: skip if the destination table already has rows for
+ *   that season. Historical nflverse data is static, so re-fetching is wasted
+ *   work and unnecessary write amplification.
+ */
+export async function shouldSkipSeasonSync(
+  season: number,
+  opts: {
+    force?: boolean;
+    now?: number;
+    hasRows: (season: number) => Promise<boolean>;
+  }
+): Promise<boolean> {
+  if (opts.force) return false;
+
+  const current = opts.now ?? currentSeason();
+  if (season >= current) return false;
+
+  return opts.hasRows(season);
+}
+
+/**
+ * Record a successful season sync. `lastSyncedWeek` is the highest week
+ * ingested in this run; for sources without a meaningful week granularity
+ * (e.g. schedule), pass 0 — the row still serves as a "synced at least once"
+ * marker for the season.
+ */
+export async function setNflverseWatermark(
+  source: NflverseSource,
+  season: number,
+  lastSyncedWeek: number
+): Promise<void> {
+  const db = getDb();
+  await db
+    .insert(schema.nflverseWatermarks)
+    .values({ source, season, lastSyncedWeek })
+    .onConflictDoUpdate({
+      target: [
+        schema.nflverseWatermarks.source,
+        schema.nflverseWatermarks.season,
+      ],
+      set: { lastSyncedWeek, lastSyncedAt: new Date() },
+    });
+}
+
+/**
+ * Read the last synced week for a (source, season). Returns 0 if no
+ * watermark row exists yet. Currently informational — the per-season syncs
+ * still re-ingest the full season CSV — but exposed so callers can build
+ * "weeks past the watermark" logic later without another schema migration.
+ */
+export async function getNflverseWatermark(
+  source: NflverseSource,
+  season: number
+): Promise<number> {
+  const db = getDb();
+  const rows = await db
+    .select({ lastSyncedWeek: schema.nflverseWatermarks.lastSyncedWeek })
+    .from(schema.nflverseWatermarks)
+    .where(
+      and(
+        eq(schema.nflverseWatermarks.source, source),
+        eq(schema.nflverseWatermarks.season, season)
+      )
+    )
+    .limit(1);
+  return rows[0]?.lastSyncedWeek ?? 0;
+}

--- a/src/services/nflverseWatermark.ts
+++ b/src/services/nflverseWatermark.ts
@@ -1,4 +1,4 @@
-import { getDb, schema } from "@/db";
+import { getDb, getSyncDb, schema } from "@/db";
 import { and, eq } from "drizzle-orm";
 
 /**
@@ -10,10 +10,18 @@ export type NflverseSource = "roster_status" | "injuries" | "schedule";
 
 /**
  * Returns the current NFL season year. Extracted as a function so tests can
- * stub it to exercise the current-vs-historical branch.
+ * stub it (or pass `now`) to exercise the current-vs-historical branch.
+ *
+ * The NFL season `N` runs from September of year `N` through early February
+ * of year `N+1`. A naive `new Date().getFullYear()` would roll the label
+ * forward on Jan 1, prematurely classifying the in-progress
+ * playoff/Week-18 season as "historical" and short-circuiting weekly
+ * nflverse fetches for injuries, roster status, and schedule. We treat
+ * months Aug–Dec as season=year and Jan–July as season=year-1.
  */
-export function currentSeason(): number {
-  return new Date().getFullYear();
+export function currentSeason(now: Date = new Date()): number {
+  const month = now.getMonth(); // 0-indexed: 0 = Jan, 7 = Aug
+  return month >= 7 ? now.getFullYear() : now.getFullYear() - 1;
 }
 
 /**
@@ -46,10 +54,48 @@ export async function shouldSkipSeasonSync(
 }
 
 /**
- * Record a successful season sync. `lastSyncedWeek` is the highest week
- * ingested in this run; for sources without a meaningful week granularity
- * (e.g. schedule), pass 0 — the row still serves as a "synced at least once"
- * marker for the season.
+ * The argument passed to a `db.transaction(async (tx) => ...)` callback by
+ * the WebSocket-backed sync drizzle instance. Inferred from the actual
+ * transaction signature so we stay in sync with whatever drizzle exposes
+ * without hand-typing PgTransaction generics.
+ */
+type SyncTx = Parameters<
+  Parameters<ReturnType<typeof getSyncDb>["transaction"]>[0]
+>[0];
+
+/**
+ * Upsert a watermark row using a caller-supplied transaction handle. Call
+ * this from inside `db.transaction(async (tx) => ...)` so the watermark
+ * write commits atomically with the data write — if the data insert
+ * rolls back, the watermark is not stamped; if the watermark write fails,
+ * the data write rolls back. This closes the previous footgun where
+ * `setNflverseWatermark()` opened a separate connection after the
+ * transaction committed: a rolled-back data insert could leave a stamped
+ * watermark (skipping the season forever), and a post-commit watermark
+ * failure would silently re-do the work next run.
+ */
+export async function setNflverseWatermarkTx(
+  tx: SyncTx,
+  source: NflverseSource,
+  season: number,
+  lastSyncedWeek: number
+): Promise<void> {
+  await tx
+    .insert(schema.nflverseWatermarks)
+    .values({ source, season, lastSyncedWeek })
+    .onConflictDoUpdate({
+      target: [
+        schema.nflverseWatermarks.source,
+        schema.nflverseWatermarks.season,
+      ],
+      set: { lastSyncedWeek, lastSyncedAt: new Date() },
+    });
+}
+
+/**
+ * Record a successful season sync without a transaction context. Prefer
+ * `setNflverseWatermarkTx` from inside an existing transaction — this
+ * form is kept for callers (and tests) that don't have one.
  */
 export async function setNflverseWatermark(
   source: NflverseSource,

--- a/src/services/rosterStatusSync.ts
+++ b/src/services/rosterStatusSync.ts
@@ -1,5 +1,9 @@
 import { getDb, getSyncDb, schema } from "@/db";
 import { sql, eq, and } from "drizzle-orm";
+import {
+  setNflverseWatermark,
+  shouldSkipSeasonSync,
+} from "@/services/nflverseWatermark";
 
 const NFLVERSE_WEEKLY_ROSTER_URL =
   "https://github.com/nflverse/nflverse-data/releases/download/weekly_rosters/roster_weekly_";
@@ -48,8 +52,9 @@ interface RosterRow {
 
 /**
  * Check if a season's roster status data has already been synced.
+ * Used as the historical-season skip optimization.
  */
-async function isSeasonSynced(season: number): Promise<boolean> {
+async function hasRosterStatusRows(season: number): Promise<boolean> {
   const db = getDb();
   const result = await db
     .select({ count: sql<number>`count(*)` })
@@ -66,7 +71,11 @@ async function syncRosterStatusSeason(
   season: number,
   force = false
 ): Promise<number> {
-  if (!force && (await isSeasonSynced(season))) {
+  const skip = await shouldSkipSeasonSync(season, {
+    force,
+    hasRows: hasRosterStatusRows,
+  });
+  if (skip) {
     return 0;
   }
 
@@ -182,6 +191,9 @@ async function syncRosterStatusSeason(
       console.log(`  Backfilled gsis_id for ${backfilled} players from ${season} roster data`);
     }
   }
+
+  const maxWeek = rows.reduce((m, r) => (r.week > m ? r.week : m), 0);
+  await setNflverseWatermark("roster_status", season, maxWeek);
 
   return count;
 }

--- a/src/services/rosterStatusSync.ts
+++ b/src/services/rosterStatusSync.ts
@@ -1,7 +1,7 @@
 import { getDb, getSyncDb, schema } from "@/db";
 import { sql, eq, and } from "drizzle-orm";
 import {
-  setNflverseWatermark,
+  setNflverseWatermarkTx,
   shouldSkipSeasonSync,
 } from "@/services/nflverseWatermark";
 
@@ -146,6 +146,11 @@ async function syncRosterStatusSeason(
   const BATCH_SIZE = 200;
   let count = 0;
 
+  const maxWeek = rows.reduce((m, r) => (r.week > m ? r.week : m), 0);
+
+  // Watermark write lives inside the transaction so it commits atomically
+  // with the data write — if the inserts roll back, the watermark is not
+  // stamped, and vice versa.
   await syncDb.transaction(async (tx) => {
     await tx
       .delete(schema.nflWeeklyRosterStatus)
@@ -171,6 +176,8 @@ async function syncRosterStatusSeason(
 
       count += values.length;
     }
+
+    await setNflverseWatermarkTx(tx, "roster_status", season, maxWeek);
   });
 
   // Backfill gsis_id into players table using sleeper_id crosswalk
@@ -191,9 +198,6 @@ async function syncRosterStatusSeason(
       console.log(`  Backfilled gsis_id for ${backfilled} players from ${season} roster data`);
     }
   }
-
-  const maxWeek = rows.reduce((m, r) => (r.week > m ? r.week : m), 0);
-  await setNflverseWatermark("roster_status", season, maxWeek);
 
   return count;
 }

--- a/src/services/scheduleSync.ts
+++ b/src/services/scheduleSync.ts
@@ -1,5 +1,9 @@
 import { getDb, getSyncDb, schema } from "@/db";
 import { sql, eq } from "drizzle-orm";
+import {
+  setNflverseWatermark,
+  shouldSkipSeasonSync,
+} from "@/services/nflverseWatermark";
 
 const NFLVERSE_GAMES_URL =
   "https://github.com/nflverse/nfldata/raw/master/data/games.csv";
@@ -28,7 +32,7 @@ function parseCSVLine(line: string): string[] {
   return result;
 }
 
-async function isSeasonSynced(season: number): Promise<boolean> {
+async function hasScheduleRows(season: number): Promise<boolean> {
   const db = getDb();
   const result = await db
     .select({ count: sql<number>`count(*)` })
@@ -43,7 +47,11 @@ async function syncScheduleSeason(
   headers: string[],
   force = false
 ): Promise<number> {
-  if (!force && (await isSeasonSynced(season))) {
+  const skip = await shouldSkipSeasonSync(season, {
+    force,
+    hasRows: hasScheduleRows,
+  });
+  if (skip) {
     return 0;
   }
 
@@ -101,6 +109,12 @@ async function syncScheduleSeason(
       count += batch.length;
     }
   });
+
+  const maxWeek = rows.reduce(
+    (m, r) => ((r.week ?? 0) > m ? r.week ?? 0 : m),
+    0
+  );
+  await setNflverseWatermark("schedule", season, maxWeek);
 
   return count;
 }

--- a/src/services/scheduleSync.ts
+++ b/src/services/scheduleSync.ts
@@ -1,7 +1,7 @@
 import { getDb, getSyncDb, schema } from "@/db";
 import { sql, eq } from "drizzle-orm";
 import {
-  setNflverseWatermark,
+  setNflverseWatermarkTx,
   shouldSkipSeasonSync,
 } from "@/services/nflverseWatermark";
 
@@ -98,6 +98,14 @@ async function syncScheduleSeason(
   const BATCH_SIZE = 200;
   let count = 0;
 
+  const maxWeek = rows.reduce(
+    (m, r) => ((r.week ?? 0) > m ? r.week ?? 0 : m),
+    0
+  );
+
+  // Watermark write lives inside the transaction so it commits atomically
+  // with the data write — if the inserts roll back, the watermark is not
+  // stamped, and vice versa.
   await syncDb.transaction(async (tx) => {
     await tx
       .delete(schema.nflSchedule)
@@ -108,13 +116,9 @@ async function syncScheduleSeason(
       await tx.insert(schema.nflSchedule).values(batch).onConflictDoNothing();
       count += batch.length;
     }
-  });
 
-  const maxWeek = rows.reduce(
-    (m, r) => ((r.week ?? 0) > m ? r.week ?? 0 : m),
-    0
-  );
-  await setNflverseWatermark("schedule", season, maxWeek);
+    await setNflverseWatermarkTx(tx, "schedule", season, maxWeek);
+  });
 
   return count;
 }


### PR DESCRIPTION
## Summary
Closes part of #20 / fixes #146. Replaces the existence-only \`isSeasonSynced\` short-circuit with a per-(source, season) watermark so current-season nflverse data (injuries, roster status, schedule) re-fetches across weeks, while historical seasons keep the cheap skip-if-exists optimization.

(Author: agent ran to completion and pushed; opening PR after recovery.)

## Test plan
- [x] Existing unit tests pass
- [x] New tests cover: current-season re-fetch branch, historical skip branch, watermark advancement
- [ ] Manual: trigger \`/api/sync/roster-status\` against the dev DB once #144 lands; verify weekly rows accrue without \`force: true\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)