### PR TITLE
Lineage Tracer: preserve manual positions across thread expansions

### DIFF
--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -363,15 +363,33 @@ export default function GraphPage() {
     setManualPositions((prev) => (prev.size === 0 ? prev : new Map()));
   }, []);
   const seedKey = seed.join(",");
-  // Sorted so insertion order doesn't trigger spurious resets.
-  const visibleNodeHash = useMemo(() => {
-    const ids = visibility.visibleNodes.map((n) => n.id);
-    ids.sort();
-    return ids.join(",");
-  }, [visibility.visibleNodes]);
+  // Wipe manualPositions ONLY on a fresh seed (different player/pick traced).
+  // Previously this also fired whenever the visible-node set changed (thread
+  // expand/collapse), which had the user-visible side effect of snapping any
+  // dragged card back to auto-layout in a single frame — read as a flash. Now
+  // we keep the Map across expansions and just prune ids that no longer exist
+  // in the visible graph (orphaned entries are harmless but waste memory).
   useEffect(() => {
     setManualPositions((prev) => (prev.size === 0 ? prev : new Map()));
-  }, [seedKey, visibleNodeHash]);
+  }, [seedKey]);
+
+  const visibleNodeIds = useMemo(
+    () => new Set(visibility.visibleNodes.map((n) => n.id)),
+    [visibility.visibleNodes],
+  );
+  useEffect(() => {
+    setManualPositions((prev) => {
+      if (prev.size === 0) return prev;
+      let pruned: Map<string, Pos> | null = null;
+      for (const id of prev.keys()) {
+        if (!visibleNodeIds.has(id)) {
+          if (!pruned) pruned = new Map(prev);
+          pruned.delete(id);
+        }
+      }
+      return pruned ?? prev;
+    });
+  }, [visibleNodeIds]);
 
   const hasSeed = seed.length > 0;
   const selectedNodeId =


### PR DESCRIPTION
## Summary

- The page-level effect wiped `manualPositions` whenever the visible-node set changed (every thread expand/collapse), which made any dragged card snap back to its auto-layout position in a single frame — read by users as a "flash."
- Now the full wipe only fires on a fresh seed (different player/pick traced). Visible-set changes just prune ids that no longer exist; manual positions for cards still on screen survive expand/collapse cycles.

Carved out of the abandoned #74 work as a clean standalone fix. The rest of #74 is staying shelved pending a perf trace and a different drag-handling architecture (see issue comment).

## Test plan

- [ ] Open the Lineage Tracer for any seeded player.
- [ ] Drag a card to a non-default position.
- [ ] Click "+" on an asset row to trace a new thread.
- [ ] Confirm the dragged card stays where you put it (previously: snapped back to auto-layout).
- [ ] Untrace the same thread — dragged card still in place.
- [ ] Click "Reset" or seed a different player → dragged card resets to auto-layout (the intentional wipe path still works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)