### PR TITLE
Sync 5: Vercel Cron for reference data (#148)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,32 @@ Leave the DSN env vars unset. Sync breadcrumbs print to the dev console as `[syn
 - Database errors: Verify DATABASE_URL is set in Vercel env vars
 - API timeouts: Configured for 30s max duration in vercel.json
 
+## Cron jobs
+
+Reference data refreshes run on Vercel Cron and are defined in `vercel.json` under the `crons` block. Every job is gated by `Authorization: Bearer $CRON_SECRET` (`CRON_SECRET` is set in Vercel for production + preview + development, mirrored in `.env.local`).
+
+| Path | Schedule (UTC) | What it does |
+|---|---|---|
+| `/api/cron/sleeper-players` | Daily `0 6 * * *` | `syncPlayers(force=true)` — refresh Sleeper player dictionary. |
+| `/api/cron/fantasycalc` | Daily `0 7 * * *` | Enumerate distinct `(SF, PPR, numTeams, numQbs)` combos via `getDistinctFantasyCalcConfigs()` and refresh each with `force: true`. Per-combo failures are isolated. |
+| `/api/cron/nflverse-current` | Daily `0 8 * * *` | Injuries + roster status + schedule for the current NFL season (from `currentSeason()`), all `force: true` so the watermark fast-path doesn't suppress weekly updates. |
+| `/api/cron/nflverse-historical` | Weekly `0 9 * * 0` (Sunday) | Loops 2002 → currentSeason-1 with `force: false` so the watermark/skip-if-rows-exist guard makes most seasons cheap no-ops. The handler self-gates to the **first Sunday of each month** because Vercel Hobby caps at daily granularity; off-month invocations return 200 with `summary.ranWork=false`. |
+
+All four routes:
+- Return 401 unless the bearer token matches `CRON_SECRET`
+- Wrap their body in `withSyncTransaction(name, op, fn)` so Sentry sees a single span per cron tick
+- Call `recordSyncBreadcrumb({ source, trigger: 'cron', ... })` on entry, success, partial, and failure (no-op when no Sentry DSN is set; falls back to `console.info`)
+- Emit one structured JSON line via `console.log` (e.g. `{"msg":"cron.sleeper-players.complete","durationMs":...}`) so Vercel function logs are searchable
+- Return `{ ok, durationMs, callsMade, summary }` on success, or 5xx with `{ ok: false, error }` on failure
+- Are idempotent — a re-fired tick is safe
+
+### Manual verification
+```bash
+# from your shell, with CRON_SECRET set (matches Vercel env)
+curl -i https://<deploy>/api/cron/sleeper-players                         # → 401
+curl -i -H "Authorization: Bearer $CRON_SECRET" https://<deploy>/api/cron/sleeper-players  # → 200
+```
+
 ## Dependencies Removed
 - Redis/ioredis - Removed for simplified deployment (no caching layer currently)
 

--- a/src/app/api/cron/_lib/auth.ts
+++ b/src/app/api/cron/_lib/auth.ts
@@ -1,0 +1,25 @@
+// Shared bearer-token auth for /api/cron/* routes.
+//
+// Vercel Cron forwards a request with `Authorization: Bearer $CRON_SECRET`
+// when configured via the `crons` block in vercel.json. We reject any caller
+// that does not present the matching token. This is the only thing standing
+// between the public internet and these endpoints, so it must be applied
+// uniformly across every cron route.
+
+import { NextRequest } from "next/server";
+
+/**
+ * Returns true when the request carries a valid bearer token matching
+ * `CRON_SECRET`. False otherwise — including when the env var is unset
+ * (fail closed, never fail open).
+ */
+export function isAuthorizedCron(req: NextRequest | Request): boolean {
+  const expected = process.env.CRON_SECRET;
+  if (!expected) return false;
+
+  const header = req.headers.get("authorization") ?? "";
+  if (!header.toLowerCase().startsWith("bearer ")) return false;
+
+  const token = header.slice(7).trim();
+  return token === expected;
+}

--- a/src/app/api/cron/_lib/cronSchedule.ts
+++ b/src/app/api/cron/_lib/cronSchedule.ts
@@ -1,0 +1,15 @@
+/**
+ * Helpers for cron schedule gating that can't be expressed in Vercel's
+ * cron syntax (Hobby plan caps at daily; we approximate monthly etc.
+ * inside the route).
+ */
+
+/**
+ * True on the first Sunday of any month (UTC). The nflverse-historical
+ * cron is registered as `0 9 * * 0` (every Sunday) and gates on this
+ * to approximate monthly cadence.
+ */
+export function isFirstSundayOfMonth(now: Date = new Date()): boolean {
+  if (now.getUTCDay() !== 0) return false; // 0 = Sunday in UTC
+  return now.getUTCDate() <= 7;
+}

--- a/src/app/api/cron/_lib/runCron.ts
+++ b/src/app/api/cron/_lib/runCron.ts
@@ -1,0 +1,174 @@
+// Shared cron-route runner.
+//
+// Every /api/cron/* route has the same outer shape:
+//   1. Reject unauthenticated callers (401)
+//   2. Record an entry breadcrumb so Sentry shows the run starting
+//   3. Execute the body inside a Sentry transaction
+//   4. Record a success/partial/failure breadcrumb with duration + apiCalls
+//   5. Emit one structured JSON log line for Vercel log searchability
+//   6. Return { ok, durationMs, callsMade, summary } / 5xx { ok: false, error }
+//
+// Wrapping it once removes ~60 lines of near-identical boilerplate per route
+// and guarantees the breadcrumb/log shape stays in lockstep across all crons.
+
+import { NextRequest, NextResponse } from "next/server";
+import {
+  recordSyncBreadcrumb,
+  type SyncSource,
+  type SyncOutcome,
+} from "@/lib/observability/syncBreadcrumb";
+import { withSyncTransaction } from "@/lib/observability/withSyncTransaction";
+import { isAuthorizedCron } from "./auth";
+
+export interface CronResult {
+  /** Number of upstream API calls made (Sleeper / FantasyCalc / nflverse). */
+  callsMade: number;
+  /** Per-route summary; serialized as `summary` in the response body. */
+  summary: Record<string, unknown>;
+  /**
+   * Outcome classification. Defaults to "success" when omitted; routes that
+   * iterate over multiple work units should return "partial" / "failed" so
+   * the breadcrumb level and HTTP status reflect reality.
+   */
+  outcome?: SyncOutcome;
+  /**
+   * Optional failure summary string. Surfaced on the breadcrumb and on the
+   * 500 response body when `outcome === "failed"`.
+   */
+  errorSummary?: string;
+}
+
+export interface RunCronOptions {
+  /** Cron route name — used in transaction names + log lines. */
+  name: string;
+  /** Sentry source tag; matches `recordSyncBreadcrumb({ source })`. */
+  source: SyncSource;
+  /** Free-form scope identifier, e.g. `"sleeper-players"` or `"nflverse-current:2025"`. */
+  scope: string;
+}
+
+/**
+ * Run a cron route handler. Handles auth, observability, and response shape;
+ * the caller's `body` only has to do the actual work and return a result.
+ */
+export async function runCron(
+  req: NextRequest | Request,
+  opts: RunCronOptions,
+  body: () => Promise<CronResult>
+): Promise<NextResponse> {
+  if (!isAuthorizedCron(req)) {
+    return NextResponse.json(
+      { ok: false, error: "unauthorized" },
+      { status: 401 }
+    );
+  }
+
+  const start = Date.now();
+
+  // Entry signal: classified as "success" because the SyncOutcome type has
+  // no "started" variant. This produces a Sentry breadcrumb at info level
+  // marking the run beginning; the final breadcrumb (below) carries the
+  // real durationMs/outcome.
+  recordSyncBreadcrumb({
+    source: opts.source,
+    trigger: "cron",
+    scope: opts.scope,
+    outcome: "success",
+    apiCalls: 0,
+  });
+
+  try {
+    const result = await withSyncTransaction(
+      `cron.${opts.name}`,
+      "cron.sync",
+      body
+    );
+
+    const durationMs = Date.now() - start;
+    const outcome: SyncOutcome = result.outcome ?? "success";
+
+    recordSyncBreadcrumb({
+      source: opts.source,
+      trigger: "cron",
+      scope: opts.scope,
+      outcome,
+      durationMs,
+      apiCalls: result.callsMade,
+      error: result.errorSummary,
+    });
+
+    // eslint-disable-next-line no-console
+    console.log(
+      JSON.stringify({
+        msg: `cron.${opts.name}.complete`,
+        durationMs,
+        callsMade: result.callsMade,
+        outcome,
+        ...result.summary,
+      })
+    );
+
+    if (outcome === "failed") {
+      return NextResponse.json(
+        {
+          ok: false,
+          error: result.errorSummary ?? `${opts.name} cron failed`,
+          durationMs,
+          callsMade: result.callsMade,
+          summary: result.summary,
+        },
+        { status: 500 }
+      );
+    }
+
+    return NextResponse.json({
+      ok: true,
+      durationMs,
+      callsMade: result.callsMade,
+      summary: result.summary,
+    });
+  } catch (err) {
+    const durationMs = Date.now() - start;
+    const message = err instanceof Error ? err.message : `${opts.name} cron failed`;
+
+    recordSyncBreadcrumb({
+      source: opts.source,
+      trigger: "cron",
+      scope: opts.scope,
+      outcome: "failed",
+      durationMs,
+      error: message,
+    });
+
+    // eslint-disable-next-line no-console
+    console.error(
+      JSON.stringify({
+        msg: `cron.${opts.name}.failed`,
+        durationMs,
+        error: message,
+      })
+    );
+
+    return NextResponse.json(
+      { ok: false, error: message, durationMs },
+      { status: 500 }
+    );
+  }
+}
+
+/**
+ * Classify outcome from a list of per-unit results (combos, sources, etc.).
+ * - All ok → "success"
+ * - All failed → "failed"
+ * - Mixed → "partial"
+ * Returns "success" for an empty list (nothing to do).
+ */
+export function classifyOutcome(
+  results: Array<{ ok: boolean }>
+): SyncOutcome {
+  if (results.length === 0) return "success";
+  const failures = results.filter((r) => !r.ok).length;
+  if (failures === 0) return "success";
+  if (failures === results.length) return "failed";
+  return "partial";
+}

--- a/src/app/api/cron/fantasycalc/__tests__/route.test.ts
+++ b/src/app/api/cron/fantasycalc/__tests__/route.test.ts
@@ -1,0 +1,134 @@
+/**
+ * @jest-environment node
+ *
+ * Auth + per-combo isolation coverage for /api/cron/fantasycalc.
+ */
+
+const getDistinctFantasyCalcConfigsMock = jest.fn();
+const syncFantasyCalcValuesForConfigMock = jest.fn();
+const recordSyncBreadcrumbMock = jest.fn();
+
+jest.mock("@/services/fantasyCalcSync", () => ({
+  getDistinctFantasyCalcConfigs: (...args: unknown[]) =>
+    getDistinctFantasyCalcConfigsMock(...args),
+  syncFantasyCalcValuesForConfig: (...args: unknown[]) =>
+    syncFantasyCalcValuesForConfigMock(...args),
+}));
+
+jest.mock("@/lib/observability/syncBreadcrumb", () => ({
+  recordSyncBreadcrumb: (...args: unknown[]) => recordSyncBreadcrumbMock(...args),
+}));
+
+import { GET } from "../route";
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/cron/fantasycalc", {
+    method: "GET",
+    headers,
+  }) as unknown as Parameters<typeof GET>[0];
+}
+
+const COMBO_A = { isSuperFlex: true, ppr: 1, numTeams: 12, numQbs: 2 };
+const COMBO_B = { isSuperFlex: false, ppr: 0.5, numTeams: 10, numQbs: 1 };
+
+beforeEach(() => {
+  getDistinctFantasyCalcConfigsMock.mockReset();
+  syncFantasyCalcValuesForConfigMock.mockReset();
+  recordSyncBreadcrumbMock.mockReset();
+  process.env.CRON_SECRET = "test-cron-secret";
+});
+
+afterAll(() => {
+  delete process.env.CRON_SECRET;
+});
+
+describe("GET /api/cron/fantasycalc", () => {
+  it("returns 401 without bearer token", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(getDistinctFantasyCalcConfigsMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 + summary with valid bearer (all combos succeed)", async () => {
+    getDistinctFantasyCalcConfigsMock.mockResolvedValueOnce([COMBO_A, COMBO_B]);
+    syncFantasyCalcValuesForConfigMock.mockResolvedValue(new Date("2026-01-01"));
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.callsMade).toBe(2);
+      expect(json.summary.combos).toBe(2);
+      expect(json.summary.failures).toBe(0);
+      // Force=true so the cron always re-fetches and the staleness gate
+      // doesn't suppress it on a fast re-run.
+      expect(syncFantasyCalcValuesForConfigMock).toHaveBeenCalledWith(
+        COMBO_A,
+        { force: true }
+      );
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("isolates per-combo failures and returns 200 partial", async () => {
+    getDistinctFantasyCalcConfigsMock.mockResolvedValueOnce([COMBO_A, COMBO_B]);
+    syncFantasyCalcValuesForConfigMock
+      .mockResolvedValueOnce(new Date("2026-01-01"))
+      .mockRejectedValueOnce(new Error("rate limited"));
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(200); // partial = still 200
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.summary.combos).toBe(2);
+      expect(json.summary.failures).toBe(1);
+      const failed = json.summary.results.find(
+        (r: { ok: boolean }) => !r.ok
+      );
+      expect(failed.error).toBe("rate limited");
+      // partial breadcrumb fires
+      const calls = recordSyncBreadcrumbMock.mock.calls.map((c) => c[0]);
+      expect(calls.some((c) => c.outcome === "partial")).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("returns 500 when every combo fails", async () => {
+    getDistinctFantasyCalcConfigsMock.mockResolvedValueOnce([COMBO_A]);
+    syncFantasyCalcValuesForConfigMock.mockRejectedValueOnce(
+      new Error("dead")
+    );
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.ok).toBe(false);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("fires entry + completion breadcrumbs", async () => {
+    getDistinctFantasyCalcConfigsMock.mockResolvedValueOnce([COMBO_A]);
+    syncFantasyCalcValuesForConfigMock.mockResolvedValueOnce(new Date());
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await GET(makeRequest({ authorization: "Bearer test-cron-secret" }));
+      const calls = recordSyncBreadcrumbMock.mock.calls.map((c) => c[0]);
+      expect(calls.some((c) => c.source === "fantasycalc" && c.trigger === "cron")).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/src/app/api/cron/fantasycalc/route.ts
+++ b/src/app/api/cron/fantasycalc/route.ts
@@ -1,0 +1,88 @@
+// Daily cron: refresh FantasyCalc dynasty trade values for every active
+// (isSuperFlex, ppr, numTeams, numQbs) combo across `leagues`.
+//
+// Schedule: 07:00 UTC daily.
+// Why per-combo (not per-league)? FantasyCalc returns the same values for
+// every league sharing a config, so one fetch per combo serves all of them.
+// `getDistinctFantasyCalcConfigs` extracts the unique set from the DB.
+//
+// Failure isolation: a single combo failing (network blip, rate limit,
+// FantasyCalc edge bug) must not abort the whole tick. We catch per combo,
+// continue sequentially (FantasyCalc is rate-limited — don't parallelize),
+// and surface the partial outcome at the end.
+
+import { NextRequest } from "next/server";
+import {
+  getDistinctFantasyCalcConfigs,
+  syncFantasyCalcValuesForConfig,
+  type FantasyCalcConfig,
+} from "@/services/fantasyCalcSync";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import { classifyOutcome, runCron } from "../_lib/runCron";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface ComboResult {
+  config: FantasyCalcConfig;
+  ok: boolean;
+  fetchedAt?: string | null;
+  error?: string;
+}
+
+export async function GET(req: NextRequest) {
+  return runCron(
+    req,
+    {
+      name: "fantasycalc",
+      source: "fantasycalc",
+      scope: "fantasycalc-all-combos",
+    },
+    async () => {
+      const combos = await getDistinctFantasyCalcConfigs();
+      const results: ComboResult[] = [];
+
+      for (const combo of combos) {
+        try {
+          const fetchedAt = await syncFantasyCalcValuesForConfig(combo, {
+            force: true,
+          });
+          results.push({
+            config: combo,
+            ok: true,
+            fetchedAt: fetchedAt?.toISOString() ?? null,
+          });
+        } catch (err) {
+          const message =
+            err instanceof Error ? err.message : "combo sync failed";
+          results.push({ config: combo, ok: false, error: message });
+
+          recordSyncBreadcrumb({
+            source: "fantasycalc",
+            trigger: "cron",
+            scope: `combo:sf=${combo.isSuperFlex},ppr=${combo.ppr},teams=${combo.numTeams},qbs=${combo.numQbs}`,
+            outcome: "failed",
+            error: message,
+          });
+        }
+      }
+
+      const outcome = classifyOutcome(results);
+      const failures = results.filter((r) => !r.ok).length;
+
+      return {
+        callsMade: combos.length,
+        outcome,
+        errorSummary:
+          failures > 0
+            ? `${failures}/${results.length} combos failed`
+            : undefined,
+        summary: {
+          combos: results.length,
+          failures,
+          results,
+        },
+      };
+    }
+  );
+}

--- a/src/app/api/cron/nflverse-current/__tests__/route.test.ts
+++ b/src/app/api/cron/nflverse-current/__tests__/route.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @jest-environment node
+ *
+ * Auth + per-source isolation for /api/cron/nflverse-current.
+ */
+
+const syncInjuriesMock = jest.fn();
+const syncRosterStatusMock = jest.fn();
+const syncScheduleMock = jest.fn();
+const recordSyncBreadcrumbMock = jest.fn();
+
+jest.mock("@/services/injurySync", () => ({
+  syncInjuries: (...args: unknown[]) => syncInjuriesMock(...args),
+}));
+jest.mock("@/services/rosterStatusSync", () => ({
+  syncRosterStatus: (...args: unknown[]) => syncRosterStatusMock(...args),
+}));
+jest.mock("@/services/scheduleSync", () => ({
+  syncSchedule: (...args: unknown[]) => syncScheduleMock(...args),
+}));
+jest.mock("@/services/nflverseWatermark", () => ({
+  currentSeason: () => 2025,
+}));
+jest.mock("@/lib/observability/syncBreadcrumb", () => ({
+  recordSyncBreadcrumb: (...args: unknown[]) => recordSyncBreadcrumbMock(...args),
+}));
+
+import { GET } from "../route";
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/cron/nflverse-current", {
+    method: "GET",
+    headers,
+  }) as unknown as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+  syncInjuriesMock.mockReset();
+  syncRosterStatusMock.mockReset();
+  syncScheduleMock.mockReset();
+  recordSyncBreadcrumbMock.mockReset();
+  process.env.CRON_SECRET = "test-cron-secret";
+});
+
+afterAll(() => {
+  delete process.env.CRON_SECRET;
+});
+
+describe("GET /api/cron/nflverse-current", () => {
+  it("returns 401 without bearer token", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(syncInjuriesMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 + summary with valid bearer (all sources succeed)", async () => {
+    syncInjuriesMock.mockResolvedValueOnce({ total: 100, seasonResults: { 2025: 100 } });
+    syncRosterStatusMock.mockResolvedValueOnce({ total: 200, seasonResults: { 2025: 200 } });
+    syncScheduleMock.mockResolvedValueOnce({ total: 17, seasonResults: { 2025: 17 } });
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.callsMade).toBe(3);
+      expect(json.summary.season).toBe(2025);
+      expect(json.summary.results).toHaveLength(3);
+
+      // Every source must be called with force=true so the new watermark
+      // logic doesn't short-circuit mid-season weekly updates.
+      expect(syncInjuriesMock).toHaveBeenCalledWith({ seasons: [2025], force: true });
+      expect(syncRosterStatusMock).toHaveBeenCalledWith({ seasons: [2025], force: true });
+      expect(syncScheduleMock).toHaveBeenCalledWith({ seasons: [2025], force: true });
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("isolates per-source failures (partial)", async () => {
+    syncInjuriesMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    syncRosterStatusMock.mockRejectedValueOnce(new Error("404 not yet"));
+    syncScheduleMock.mockResolvedValueOnce({ total: 17, seasonResults: { 2025: 17 } });
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      const failed = json.summary.results.find(
+        (r: { source: string; ok: boolean }) => r.source === "roster_status"
+      );
+      expect(failed.ok).toBe(false);
+      expect(failed.error).toContain("404");
+      const calls = recordSyncBreadcrumbMock.mock.calls.map((c) => c[0]);
+      expect(calls.some((c) => c.outcome === "partial")).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("returns 500 when every source fails", async () => {
+    syncInjuriesMock.mockRejectedValueOnce(new Error("a"));
+    syncRosterStatusMock.mockRejectedValueOnce(new Error("b"));
+    syncScheduleMock.mockRejectedValueOnce(new Error("c"));
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(500);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("fires entry breadcrumb on auth success", async () => {
+    syncInjuriesMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    syncRosterStatusMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    syncScheduleMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await GET(makeRequest({ authorization: "Bearer test-cron-secret" }));
+      const calls = recordSyncBreadcrumbMock.mock.calls.map((c) => c[0]);
+      expect(
+        calls.some((c) => c.source === "nflverse" && c.trigger === "cron")
+      ).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+});

--- a/src/app/api/cron/nflverse-current/route.ts
+++ b/src/app/api/cron/nflverse-current/route.ts
@@ -1,0 +1,100 @@
+// Daily cron: refresh nflverse data for the current NFL season.
+//
+// Schedule: 08:00 UTC daily.
+// Sources covered: injuries + weekly roster status + schedule.
+// All three are forced (`force: true`) so the new watermark logic
+// re-fetches week-over-week mid-season, regardless of whether rows already
+// exist for the season.
+//
+// Failure isolation: each source runs independently (Promise.allSettled).
+// One source erroring (404 from nflverse mid-week, transient GH outage)
+// does not block the other two from updating.
+
+import { NextRequest } from "next/server";
+import { syncInjuries } from "@/services/injurySync";
+import { syncRosterStatus } from "@/services/rosterStatusSync";
+import { syncSchedule } from "@/services/scheduleSync";
+import { currentSeason } from "@/services/nflverseWatermark";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import { classifyOutcome, runCron } from "../_lib/runCron";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+type NflverseSourceLabel = "injuries" | "roster_status" | "schedule";
+
+interface SourceResult {
+  source: NflverseSourceLabel;
+  ok: boolean;
+  total?: number;
+  seasonsTouched?: number;
+  error?: string;
+}
+
+interface SyncSummary {
+  total: number;
+  seasonResults: Record<number, number>;
+}
+
+/**
+ * Run a single nflverse sync source, recording a per-source failure
+ * breadcrumb on error so debugging knows which leg blew up.
+ */
+async function runSource(
+  label: NflverseSourceLabel,
+  scope: string,
+  fn: () => Promise<SyncSummary>
+): Promise<SourceResult> {
+  try {
+    const r = await fn();
+    const seasonsTouched = Object.values(r.seasonResults).filter(
+      (c) => c > 0
+    ).length;
+    return { source: label, ok: true, total: r.total, seasonsTouched };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : `${label} sync failed`;
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger: "cron",
+      scope: `${scope}:${label}`,
+      outcome: "failed",
+      error: message,
+    });
+    return { source: label, ok: false, error: message };
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const season = currentSeason();
+  const scope = `nflverse-current:${season}`;
+
+  return runCron(
+    req,
+    { name: "nflverse-current", source: "nflverse", scope },
+    async () => {
+      // Three sources are independent — run in parallel.
+      const results = await Promise.all([
+        runSource("injuries", scope, () =>
+          syncInjuries({ seasons: [season], force: true })
+        ),
+        runSource("roster_status", scope, () =>
+          syncRosterStatus({ seasons: [season], force: true })
+        ),
+        runSource("schedule", scope, () =>
+          syncSchedule({ seasons: [season], force: true })
+        ),
+      ]);
+
+      const failures = results.filter((r) => !r.ok).length;
+      return {
+        callsMade: results.length, // one HTTP fetch per source
+        outcome: classifyOutcome(results),
+        errorSummary:
+          failures > 0
+            ? `${failures}/${results.length} sources failed`
+            : undefined,
+        summary: { season, results },
+      };
+    }
+  );
+}

--- a/src/app/api/cron/nflverse-historical/__tests__/route.test.ts
+++ b/src/app/api/cron/nflverse-historical/__tests__/route.test.ts
@@ -1,0 +1,154 @@
+/**
+ * @jest-environment node
+ *
+ * Auth + first-Sunday-of-month gate for /api/cron/nflverse-historical.
+ *
+ * The route is registered as `0 9 * * 0` (every Sunday) on Vercel because
+ * the Hobby plan caps at daily granularity; the route gates internally so
+ * real work runs only on the first Sunday of each month.
+ */
+
+const syncInjuriesMock = jest.fn();
+const syncRosterStatusMock = jest.fn();
+const syncScheduleMock = jest.fn();
+const recordSyncBreadcrumbMock = jest.fn();
+
+jest.mock("@/services/injurySync", () => ({
+  syncInjuries: (...args: unknown[]) => syncInjuriesMock(...args),
+}));
+jest.mock("@/services/rosterStatusSync", () => ({
+  syncRosterStatus: (...args: unknown[]) => syncRosterStatusMock(...args),
+}));
+jest.mock("@/services/scheduleSync", () => ({
+  syncSchedule: (...args: unknown[]) => syncScheduleMock(...args),
+}));
+jest.mock("@/services/nflverseWatermark", () => ({
+  currentSeason: () => 2025,
+}));
+jest.mock("@/lib/observability/syncBreadcrumb", () => ({
+  recordSyncBreadcrumb: (...args: unknown[]) => recordSyncBreadcrumbMock(...args),
+}));
+
+import { GET, isFirstSundayOfMonth } from "../route";
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/cron/nflverse-historical", {
+    method: "GET",
+    headers,
+  }) as unknown as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+  syncInjuriesMock.mockReset();
+  syncRosterStatusMock.mockReset();
+  syncScheduleMock.mockReset();
+  recordSyncBreadcrumbMock.mockReset();
+  process.env.CRON_SECRET = "test-cron-secret";
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+afterAll(() => {
+  delete process.env.CRON_SECRET;
+});
+
+describe("isFirstSundayOfMonth", () => {
+  it("returns true for the 1st-7th of the month on a Sunday", () => {
+    // 2026-03-01 is a Sunday
+    expect(isFirstSundayOfMonth(new Date(Date.UTC(2026, 2, 1, 9)))).toBe(true);
+    // 2026-03-08 is a Sunday but not first-of-month
+    expect(isFirstSundayOfMonth(new Date(Date.UTC(2026, 2, 8, 9)))).toBe(false);
+  });
+
+  it("returns false on non-Sunday dates", () => {
+    // 2026-03-02 is a Monday
+    expect(isFirstSundayOfMonth(new Date(Date.UTC(2026, 2, 2, 9)))).toBe(false);
+  });
+});
+
+describe("GET /api/cron/nflverse-historical", () => {
+  it("returns 401 without bearer token", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(syncInjuriesMock).not.toHaveBeenCalled();
+  });
+
+  it("skips work when not first-Sunday-of-month and returns 200", async () => {
+    // 2026-03-15 is a Sunday but not first-of-month
+    jest.setSystemTime(new Date(Date.UTC(2026, 2, 15, 9)));
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.summary.ranWork).toBe(false);
+      expect(syncInjuriesMock).not.toHaveBeenCalled();
+      expect(syncRosterStatusMock).not.toHaveBeenCalled();
+      expect(syncScheduleMock).not.toHaveBeenCalled();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("runs all sources on first-Sunday-of-month with valid bearer", async () => {
+    // 2026-03-01 is the first Sunday of March 2026
+    jest.setSystemTime(new Date(Date.UTC(2026, 2, 1, 9)));
+    syncInjuriesMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    syncRosterStatusMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    syncScheduleMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.summary.ranWork).toBe(true);
+      expect(json.summary.seasonRange).toEqual([2002, 2024]);
+      expect(json.callsMade).toBe(3);
+
+      // Historical seasons must NOT be forced — the watermark fast-path
+      // is the entire point of running 23 seasons cheaply each month.
+      const injuriesCall = syncInjuriesMock.mock.calls[0][0];
+      expect(injuriesCall.force).toBeUndefined();
+      expect(injuriesCall.seasons).toHaveLength(23);
+      expect(injuriesCall.seasons[0]).toBe(2002);
+      expect(injuriesCall.seasons[injuriesCall.seasons.length - 1]).toBe(2024);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("fires entry breadcrumb when work runs", async () => {
+    jest.setSystemTime(new Date(Date.UTC(2026, 2, 1, 9)));
+    syncInjuriesMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    syncRosterStatusMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+    syncScheduleMock.mockResolvedValueOnce({ total: 0, seasonResults: {} });
+
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await GET(makeRequest({ authorization: "Bearer test-cron-secret" }));
+      const calls = recordSyncBreadcrumbMock.mock.calls.map((c) => c[0]);
+      expect(
+        calls.some((c) => c.source === "nflverse" && c.trigger === "cron")
+      ).toBe(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("does not call sync helpers on auth failure even on first-Sunday", async () => {
+    jest.setSystemTime(new Date(Date.UTC(2026, 2, 1, 9)));
+    const res = await GET(makeRequest({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    expect(syncInjuriesMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/cron/nflverse-historical/__tests__/route.test.ts
+++ b/src/app/api/cron/nflverse-historical/__tests__/route.test.ts
@@ -29,7 +29,8 @@ jest.mock("@/lib/observability/syncBreadcrumb", () => ({
   recordSyncBreadcrumb: (...args: unknown[]) => recordSyncBreadcrumbMock(...args),
 }));
 
-import { GET, isFirstSundayOfMonth } from "../route";
+import { GET } from "../route";
+import { isFirstSundayOfMonth } from "../../_lib/cronSchedule";
 
 function makeRequest(headers: Record<string, string> = {}) {
   return new Request("http://localhost/api/cron/nflverse-historical", {

--- a/src/app/api/cron/nflverse-historical/route.ts
+++ b/src/app/api/cron/nflverse-historical/route.ts
@@ -21,6 +21,7 @@ import { syncSchedule } from "@/services/scheduleSync";
 import { currentSeason } from "@/services/nflverseWatermark";
 import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
 import { classifyOutcome, runCron } from "../_lib/runCron";
+import { isFirstSundayOfMonth } from "../_lib/cronSchedule";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -40,16 +41,6 @@ interface SourceResult {
 interface SyncSummary {
   total: number;
   seasonResults: Record<number, number>;
-}
-
-/**
- * Returns true on the first Sunday of any month. Vercel Hobby supports
- * daily, not monthly cron, so we register `0 9 * * 0` (every Sunday) and
- * gate here to approximate monthly cadence. Visible for testing.
- */
-export function isFirstSundayOfMonth(now: Date = new Date()): boolean {
-  if (now.getUTCDay() !== 0) return false; // 0 = Sunday in UTC
-  return now.getUTCDate() <= 7;
 }
 
 async function runSource(

--- a/src/app/api/cron/nflverse-historical/route.ts
+++ b/src/app/api/cron/nflverse-historical/route.ts
@@ -1,0 +1,125 @@
+// Monthly cron: re-check historical nflverse seasons (2002 .. currentSeason-1)
+// for late corrections.
+//
+// Vercel Hobby plan caps cron frequency at daily, so we register this as a
+// weekly Sunday 09:00 UTC cron and gate inside the handler: we only do real
+// work on the first Sunday of each month. Off-month invocations short-circuit
+// and return 200 with `{ ranWork: false }` so they show up in logs as
+// healthy no-ops.
+//
+// `force: false` (default) for these helpers means the watermark fast-path
+// skips already-populated seasons. The point of this job is to catch the
+// rare nflverse correction (~10% of plays revised after the season ends)
+// without re-downloading every season every day. To intentionally re-pull
+// a historical season, hit `/api/sync/injuries` etc. with `{ force: true }`
+// (or wire a one-shot script).
+
+import { NextRequest } from "next/server";
+import { syncInjuries } from "@/services/injurySync";
+import { syncRosterStatus } from "@/services/rosterStatusSync";
+import { syncSchedule } from "@/services/scheduleSync";
+import { currentSeason } from "@/services/nflverseWatermark";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import { classifyOutcome, runCron } from "../_lib/runCron";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const FIRST_HISTORICAL_SEASON = 2002;
+
+type NflverseSourceLabel = "injuries" | "roster_status" | "schedule";
+
+interface SourceResult {
+  source: NflverseSourceLabel;
+  ok: boolean;
+  total?: number;
+  seasonsTouched?: number;
+  error?: string;
+}
+
+interface SyncSummary {
+  total: number;
+  seasonResults: Record<number, number>;
+}
+
+/**
+ * Returns true on the first Sunday of any month. Vercel Hobby supports
+ * daily, not monthly cron, so we register `0 9 * * 0` (every Sunday) and
+ * gate here to approximate monthly cadence. Visible for testing.
+ */
+export function isFirstSundayOfMonth(now: Date = new Date()): boolean {
+  if (now.getUTCDay() !== 0) return false; // 0 = Sunday in UTC
+  return now.getUTCDate() <= 7;
+}
+
+async function runSource(
+  label: NflverseSourceLabel,
+  scope: string,
+  fn: () => Promise<SyncSummary>
+): Promise<SourceResult> {
+  try {
+    const r = await fn();
+    const seasonsTouched = Object.values(r.seasonResults).filter(
+      (c) => c > 0
+    ).length;
+    return { source: label, ok: true, total: r.total, seasonsTouched };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : `${label} sync failed`;
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger: "cron",
+      scope: `${scope}:${label}`,
+      outcome: "failed",
+      error: message,
+    });
+    return { source: label, ok: false, error: message };
+  }
+}
+
+export async function GET(req: NextRequest) {
+  const lastHistorical = currentSeason() - 1;
+  const scope = `nflverse-historical:${FIRST_HISTORICAL_SEASON}-${lastHistorical}`;
+
+  return runCron(
+    req,
+    { name: "nflverse-historical", source: "nflverse", scope },
+    async () => {
+      // Off-month: no work. Auth + breadcrumb + log still happen via runCron.
+      if (!isFirstSundayOfMonth()) {
+        return {
+          callsMade: 0,
+          summary: { ranWork: false, reason: "not-first-sunday-of-month" },
+        };
+      }
+
+      const seasons: number[] = [];
+      for (let s = FIRST_HISTORICAL_SEASON; s <= lastHistorical; s++) {
+        seasons.push(s);
+      }
+
+      // Three sources are independent — run in parallel. The watermark
+      // fast-path makes most seasons cheap no-ops, so total wall time is
+      // dominated by whichever source has the most "first-sync" work.
+      const results = await Promise.all([
+        runSource("injuries", scope, () => syncInjuries({ seasons })),
+        runSource("roster_status", scope, () => syncRosterStatus({ seasons })),
+        runSource("schedule", scope, () => syncSchedule({ seasons })),
+      ]);
+
+      const failures = results.filter((r) => !r.ok).length;
+      return {
+        callsMade: results.length,
+        outcome: classifyOutcome(results),
+        errorSummary:
+          failures > 0
+            ? `${failures}/${results.length} sources failed`
+            : undefined,
+        summary: {
+          ranWork: true,
+          seasonRange: [FIRST_HISTORICAL_SEASON, lastHistorical],
+          results,
+        },
+      };
+    }
+  );
+}

--- a/src/app/api/cron/sleeper-players/__tests__/route.test.ts
+++ b/src/app/api/cron/sleeper-players/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+/**
+ * @jest-environment node
+ *
+ * Cron auth + happy-path coverage for /api/cron/sleeper-players. The sync
+ * service is mocked at the module boundary so tests are deterministic and
+ * don't touch Sleeper.
+ */
+
+const syncPlayersMock = jest.fn();
+const recordSyncBreadcrumbMock = jest.fn();
+
+jest.mock("@/services/playerSync", () => ({
+  syncPlayers: (...args: unknown[]) => syncPlayersMock(...args),
+}));
+
+jest.mock("@/lib/observability/syncBreadcrumb", () => ({
+  recordSyncBreadcrumb: (...args: unknown[]) => recordSyncBreadcrumbMock(...args),
+}));
+
+import { GET } from "../route";
+
+function makeRequest(headers: Record<string, string> = {}) {
+  return new Request("http://localhost/api/cron/sleeper-players", {
+    method: "GET",
+    headers,
+  }) as unknown as Parameters<typeof GET>[0];
+}
+
+beforeEach(() => {
+  syncPlayersMock.mockReset();
+  recordSyncBreadcrumbMock.mockReset();
+  process.env.CRON_SECRET = "test-cron-secret";
+});
+
+afterAll(() => {
+  delete process.env.CRON_SECRET;
+});
+
+describe("GET /api/cron/sleeper-players", () => {
+  it("returns 401 without bearer token", async () => {
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+    expect(syncPlayersMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 with wrong bearer token", async () => {
+    const res = await GET(makeRequest({ authorization: "Bearer wrong" }));
+    expect(res.status).toBe(401);
+    expect(syncPlayersMock).not.toHaveBeenCalled();
+  });
+
+  it("returns 401 when CRON_SECRET is unset (fail closed)", async () => {
+    delete process.env.CRON_SECRET;
+    const res = await GET(
+      makeRequest({ authorization: "Bearer test-cron-secret" })
+    );
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 200 + summary with valid bearer", async () => {
+    syncPlayersMock.mockResolvedValueOnce(123);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(200);
+      const json = await res.json();
+      expect(json.ok).toBe(true);
+      expect(json.summary).toEqual({ synced: 123 });
+      expect(json.callsMade).toBe(1);
+      expect(typeof json.durationMs).toBe("number");
+      // syncPlayers must be called with force=true so the daily refresh
+      // never gets short-circuited by the staleness gate.
+      expect(syncPlayersMock).toHaveBeenCalledWith(true);
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("fires breadcrumbs for entry + success", async () => {
+    syncPlayersMock.mockResolvedValueOnce(7);
+    const logSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    try {
+      await GET(makeRequest({ authorization: "Bearer test-cron-secret" }));
+      expect(recordSyncBreadcrumbMock).toHaveBeenCalled();
+      const calls = recordSyncBreadcrumbMock.mock.calls.map((c) => c[0]);
+      expect(calls.some((c) => c.source === "sleeper" && c.trigger === "cron")).toBe(true);
+      // Final breadcrumb should record success outcome with duration.
+      const successCall = calls.find(
+        (c) => c.outcome === "success" && typeof c.durationMs === "number"
+      );
+      expect(successCall).toBeDefined();
+    } finally {
+      logSpy.mockRestore();
+    }
+  });
+
+  it("returns 500 + failure breadcrumb when syncPlayers throws", async () => {
+    syncPlayersMock.mockRejectedValueOnce(new Error("sleeper down"));
+    const errSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const res = await GET(
+        makeRequest({ authorization: "Bearer test-cron-secret" })
+      );
+      expect(res.status).toBe(500);
+      const json = await res.json();
+      expect(json.ok).toBe(false);
+      expect(json.error).toBe("sleeper down");
+      const calls = recordSyncBreadcrumbMock.mock.calls.map((c) => c[0]);
+      expect(calls.some((c) => c.outcome === "failed" && c.error === "sleeper down")).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});

--- a/src/app/api/cron/sleeper-players/route.ts
+++ b/src/app/api/cron/sleeper-players/route.ts
@@ -1,0 +1,27 @@
+// Daily cron: refresh the Sleeper player dictionary.
+//
+// Schedule: 06:00 UTC daily (vercel.json crons).
+// Calls `syncPlayers(force: true)` so the staleness gate is bypassed and
+// late-day Sleeper updates always land. Idempotent: re-running the same
+// tick simply re-upserts the same rows.
+
+import { NextRequest } from "next/server";
+import { syncPlayers } from "@/services/playerSync";
+import { runCron } from "../_lib/runCron";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  return runCron(
+    req,
+    { name: "sleeper-players", source: "sleeper", scope: "sleeper-players" },
+    async () => {
+      const synced = await syncPlayers(true);
+      return {
+        callsMade: 1, // single Sleeper API call: GET /players/nfl
+        summary: { synced },
+      };
+    }
+  );
+}

--- a/vercel.json
+++ b/vercel.json
@@ -10,5 +10,23 @@
     "src/app/api/**/*.ts": {
       "maxDuration": 30
     }
-  }
+  },
+  "crons": [
+    {
+      "path": "/api/cron/sleeper-players",
+      "schedule": "0 6 * * *"
+    },
+    {
+      "path": "/api/cron/fantasycalc",
+      "schedule": "0 7 * * *"
+    },
+    {
+      "path": "/api/cron/nflverse-current",
+      "schedule": "0 8 * * *"
+    },
+    {
+      "path": "/api/cron/nflverse-historical",
+      "schedule": "0 9 * * 0"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Closes #148.

Adds four bearer-token-protected cron routes that refresh the global reference-data sources on Vercel Cron, plus the `crons` block in `vercel.json` that registers them.

| Cron | Schedule (UTC) | Route | What it does |
|---|---|---|---|
| Sleeper player dictionary | Daily `0 6 * * *` | `/api/cron/sleeper-players` | `syncPlayers(force=true)` |
| FantasyCalc | Daily `0 7 * * *` | `/api/cron/fantasycalc` | Enumerates distinct `(SF, PPR, numTeams, numQbs)` combos via `getDistinctFantasyCalcConfigs()`, syncs each with `force: true`, isolates per-combo failures |
| nflverse current | Daily `0 8 * * *` | `/api/cron/nflverse-current` | Injuries + roster status + schedule for `currentSeason()` with `force: true` so the new watermark logic re-fetches week-over-week |
| nflverse historical | Weekly `0 9 * * 0` (Sunday), gated to first Sunday of month | `/api/cron/nflverse-historical` | Loops 2002 → currentSeason-1 with `force: false` so the watermark fast-path keeps most seasons cheap. Vercel Hobby caps at daily granularity, so the route self-gates internally to approximate monthly cadence |

### Implementation notes

- All four routes share `src/app/api/cron/_lib/runCron.ts` for auth, Sentry transaction wrapping (`withSyncTransaction`), breadcrumb dispatch (`recordSyncBreadcrumb`), structured JSON logging, and response shape. The observability contract is guaranteed to stay in lockstep across crons.
- The two nflverse routes parallelize their three sources via `Promise.all` since they're independent.
- FantasyCalc stays sequential to respect upstream rate limits.
- Per-unit failures are isolated and surfaced as `partial` outcomes (HTTP 200 with details in `summary`) rather than aborting the entire tick. Full failure (every unit dead) returns 500 so Vercel/Sentry surface a real error.
- Routes are idempotent — re-fired ticks are safe (every helper either upserts or guards on a watermark/staleness check).
- 401 with no body modification when `Authorization: Bearer $CRON_SECRET` is missing or wrong; auth helper fails closed when `CRON_SECRET` is unset.

### Files

- `src/app/api/cron/_lib/auth.ts` — bearer-token verification
- `src/app/api/cron/_lib/runCron.ts` — shared runner + outcome classifier
- `src/app/api/cron/{sleeper-players,fantasycalc,nflverse-current,nflverse-historical}/route.ts` — the four routes
- `src/app/api/cron/**/__tests__/route.test.ts` — 23 tests covering auth, success, partial-failure isolation, full-failure 500, and the first-Sunday-of-month gate
- `vercel.json` — `crons` block
- `CLAUDE.md` — new "Cron jobs" section

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm test -- --testPathPatterns="cron|sleeper-players|fantasycalc|nflverse"` — 44 tests pass across 6 suites
- [x] Full `npm test` — 169 tests pass across 22 suites
- [ ] After merge: confirm Vercel dashboard shows the 4 scheduled crons
- [ ] After merge: `curl` with bearer token works against deployed URL; without bearer fails 401
- [ ] After merge: each cron logs success in Sentry on real run

🤖 Generated with [Claude Code](https://claude.com/claude-code)