### PR TITLE
Sync 9b: Observability integration into sync services (#152)

### DIFF
--- a/drizzle/0017_eminent_blue_blade.sql
+++ b/drizzle/0017_eminent_blue_blade.sql
@@ -1,0 +1,6 @@
+ALTER TABLE "sync_jobs" ADD COLUMN "trigger" text;--> statement-breakpoint
+ALTER TABLE "sync_jobs" ADD COLUMN "api_calls_made" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "sync_jobs" ADD COLUMN "stages_completed" integer DEFAULT 0;--> statement-breakpoint
+ALTER TABLE "sync_jobs" ADD COLUMN "stages_total" integer;--> statement-breakpoint
+ALTER TABLE "sync_jobs" ADD COLUMN "current_stage" text;--> statement-breakpoint
+CREATE INDEX "sync_jobs_started_at_idx" ON "sync_jobs" USING btree ("started_at");

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,2785 @@
+{
+  "id": "13643b48-83f4-485a-bee5-842929cf7d72",
+  "prevId": "0fb43303-4e8d-4145-a182-e25705e262f7",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.algorithm_config": {
+      "name": "algorithm_config",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "experiment_id": {
+          "name": "experiment_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "promoted_by": {
+          "name": "promoted_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notes": {
+          "name": "notes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "algorithm_config_active_idx": {
+          "name": "algorithm_config_active_idx",
+          "columns": [
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "algorithm_config_experiment_id_experiment_runs_id_fk": {
+          "name": "algorithm_config_experiment_id_experiment_runs_id_fk",
+          "tableFrom": "algorithm_config",
+          "tableTo": "experiment_runs",
+          "columnsFrom": [
+            "experiment_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.asset_events": {
+      "name": "asset_events",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "asset_kind": {
+          "name": "asset_kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_season": {
+          "name": "pick_season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_round": {
+          "name": "pick_round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pick_original_roster_id": {
+          "name": "pick_original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_roster_id": {
+          "name": "from_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_roster_id": {
+          "name": "to_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "from_user_id": {
+          "name": "from_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "to_user_id": {
+          "name": "to_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "details": {
+          "name": "details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "asset_events_player_idx": {
+          "name": "asset_events_player_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_tx_idx": {
+          "name": "asset_events_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "asset_events_pick_idx": {
+          "name": "asset_events_pick_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_round",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_original_roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_grades": {
+      "name": "draft_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_value": {
+          "name": "benchmark_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_production": {
+          "name": "player_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_production": {
+          "name": "benchmark_production",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "benchmark_size": {
+          "name": "benchmark_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "draft_grades_draft_idx": {
+          "name": "draft_grades_draft_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_player_idx": {
+          "name": "draft_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "draft_grades_unique_idx": {
+          "name": "draft_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "pick_no",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "draft_grades_draft_id_drafts_id_fk": {
+          "name": "draft_grades_draft_id_drafts_id_fk",
+          "tableFrom": "draft_grades",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.draft_picks": {
+      "name": "draft_picks",
+      "schema": "",
+      "columns": {
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "pick_no": {
+          "name": "pick_no",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_slot": {
+          "name": "draft_slot",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_keeper": {
+          "name": "is_keeper",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "draft_picks_draft_id_drafts_id_fk": {
+          "name": "draft_picks_draft_id_drafts_id_fk",
+          "tableFrom": "draft_picks",
+          "tableTo": "drafts",
+          "columnsFrom": [
+            "draft_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "draft_picks_draft_id_pick_no_pk": {
+          "name": "draft_picks_draft_id_pick_no_pk",
+          "columns": [
+            "draft_id",
+            "pick_no"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.drafts": {
+      "name": "drafts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "start_time": {
+          "name": "start_time",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "slot_to_roster_id": {
+          "name": "slot_to_roster_id",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "drafts_league_id_leagues_id_fk": {
+          "name": "drafts_league_id_leagues_id_fk",
+          "tableFrom": "drafts",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.experiment_runs": {
+      "name": "experiment_runs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "hypothesis": {
+          "name": "hypothesis",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "config": {
+          "name": "config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "metrics": {
+          "name": "metrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_data": {
+          "name": "raw_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "family_id": {
+          "name": "family_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "acceptance_criteria": {
+          "name": "acceptance_criteria",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict": {
+          "name": "verdict",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "verdict_reason": {
+          "name": "verdict_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scorecard": {
+          "name": "scorecard",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "experiment_runs_name_idx": {
+          "name": "experiment_runs_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.fantasy_calc_values": {
+      "name": "fantasy_calc_values",
+      "schema": "",
+      "columns": {
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_super_flex": {
+          "name": "is_super_flex",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "ppr": {
+          "name": "ppr",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0.5
+        },
+        "num_teams": {
+          "name": "num_teams",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "num_qbs": {
+          "name": "num_qbs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position_rank": {
+          "name": "position_rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "fantasy_calc_values_player_id_is_super_flex_ppr_num_teams_num_qbs_pk": {
+          "name": "fantasy_calc_values_player_id_is_super_flex_ppr_num_teams_num_qbs_pk",
+          "columns": [
+            "player_id",
+            "is_super_flex",
+            "ppr",
+            "num_teams",
+            "num_qbs"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_families": {
+      "name": "league_families",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "root_league_id": {
+          "name": "root_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "demo_eligible": {
+          "name": "demo_eligible",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "league_families_root_league_id_unique": {
+          "name": "league_families_root_league_id_unique",
+          "columns": [
+            {
+              "expression": "root_league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_family_members": {
+      "name": "league_family_members",
+      "schema": "",
+      "columns": {
+        "family_id": {
+          "name": "family_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "league_family_members_league_id_idx": {
+          "name": "league_family_members_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "league_family_members_family_id_league_families_id_fk": {
+          "name": "league_family_members_family_id_league_families_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "league_families",
+          "columnsFrom": [
+            "family_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "league_family_members_league_id_leagues_id_fk": {
+          "name": "league_family_members_league_id_leagues_id_fk",
+          "tableFrom": "league_family_members",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_family_members_family_id_league_id_pk": {
+          "name": "league_family_members_family_id_league_id_pk",
+          "columns": [
+            "family_id",
+            "league_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.league_users": {
+      "name": "league_users",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team_name": {
+          "name": "team_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar": {
+          "name": "avatar",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "league_users_league_id_leagues_id_fk": {
+          "name": "league_users_league_id_leagues_id_fk",
+          "tableFrom": "league_users",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "league_users_league_id_user_id_pk": {
+          "name": "league_users_league_id_user_id_pk",
+          "columns": [
+            "league_id",
+            "user_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.leagues": {
+      "name": "leagues",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_league_id": {
+          "name": "previous_league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scoring_settings": {
+          "name": "scoring_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "roster_positions": {
+          "name": "roster_positions",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_rosters": {
+          "name": "total_rosters",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "winners_bracket": {
+          "name": "winners_bracket",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.manager_metrics": {
+      "name": "manager_metrics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "manager_id": {
+          "name": "manager_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metric": {
+          "name": "metric",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "percentile": {
+          "name": "percentile",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "meta": {
+          "name": "meta",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "manager_metrics_unique_idx": {
+          "name": "manager_metrics_unique_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "manager_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "metric",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scope",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matchups": {
+      "name": "matchups",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matchup_id": {
+          "name": "matchup_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_points": {
+          "name": "starter_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_points": {
+          "name": "player_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "matchups_league_id_week_roster_id_pk": {
+          "name": "matchups_league_id_week_roster_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_injuries": {
+      "name": "nfl_injuries",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "game_type": {
+          "name": "game_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_status": {
+          "name": "report_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_primary_injury": {
+          "name": "report_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "report_secondary_injury": {
+          "name": "report_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_status": {
+          "name": "practice_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_primary_injury": {
+          "name": "practice_primary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "practice_secondary_injury": {
+          "name": "practice_secondary_injury",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "date_modified": {
+          "name": "date_modified",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_injuries_gsis_idx": {
+          "name": "nfl_injuries_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_injuries_season_week_gsis_id_pk": {
+          "name": "nfl_injuries_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_schedule": {
+      "name": "nfl_schedule",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_team": {
+          "name": "home_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "away_team": {
+          "name": "away_team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "home_score": {
+          "name": "home_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "away_score": {
+          "name": "away_score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "game_date": {
+          "name": "game_date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_schedule_season_week_home_team_pk": {
+          "name": "nfl_schedule_season_week_home_team_pk",
+          "columns": [
+            "season",
+            "week",
+            "home_team"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_state": {
+      "name": "nfl_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "'nfl'"
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season_type": {
+          "name": "season_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nfl_weekly_roster_status": {
+      "name": "nfl_weekly_roster_status",
+      "schema": "",
+      "columns": {
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status_abbr": {
+          "name": "status_abbr",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_name": {
+          "name": "player_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "nfl_roster_status_gsis_idx": {
+          "name": "nfl_roster_status_gsis_idx",
+          "columns": [
+            {
+              "expression": "gsis_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nfl_weekly_roster_status_season_week_gsis_id_pk": {
+          "name": "nfl_weekly_roster_status_season_week_gsis_id_pk",
+          "columns": [
+            "season",
+            "week",
+            "gsis_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.nflverse_watermarks": {
+      "name": "nflverse_watermarks",
+      "schema": "",
+      "columns": {
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_synced_week": {
+          "name": "last_synced_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "nflverse_watermarks_source_season_pk": {
+          "name": "nflverse_watermarks_source_season_pk",
+          "columns": [
+            "source",
+            "season"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.player_scores": {
+      "name": "player_scores",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "points": {
+          "name": "points",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_starter": {
+          "name": "is_starter",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "player_scores_league_id_week_roster_id_player_id_pk": {
+          "name": "player_scores_league_id_week_roster_id_player_id_pk",
+          "columns": [
+            "league_id",
+            "week",
+            "roster_id",
+            "player_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.players": {
+      "name": "players",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gsis_id": {
+          "name": "gsis_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "first_name": {
+          "name": "first_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_name": {
+          "name": "last_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "team": {
+          "name": "team",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "injury_status": {
+          "name": "injury_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "years_exp": {
+          "name": "years_exp",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.rosters": {
+      "name": "rosters",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "players": {
+          "name": "players",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starters": {
+          "name": "starters",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reserve": {
+          "name": "reserve",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "wins": {
+          "name": "wins",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "losses": {
+          "name": "losses",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "ties": {
+          "name": "ties",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts": {
+          "name": "fpts",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "fpts_against": {
+          "name": "fpts_against",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "rosters_owner_idx": {
+          "name": "rosters_owner_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "rosters_league_id_leagues_id_fk": {
+          "name": "rosters_league_id_leagues_id_fk",
+          "tableFrom": "rosters",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "rosters_league_id_roster_id_pk": {
+          "name": "rosters_league_id_roster_id_pk",
+          "columns": [
+            "league_id",
+            "roster_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_jobs": {
+      "name": "sync_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ref": {
+          "name": "ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'running'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "done": {
+          "name": "done",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "trigger": {
+          "name": "trigger",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "api_calls_made": {
+          "name": "api_calls_made",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "stages_completed": {
+          "name": "stages_completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "stages_total": {
+          "name": "stages_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "current_stage": {
+          "name": "current_stage",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sync_jobs_ref_status_idx": {
+          "name": "sync_jobs_ref_status_idx",
+          "columns": [
+            {
+              "expression": "ref",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_jobs_started_at_idx": {
+          "name": "sync_jobs_started_at_idx",
+          "columns": [
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_watermarks": {
+      "name": "sync_watermarks",
+      "schema": "",
+      "columns": {
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data_type": {
+          "name": "data_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_week": {
+          "name": "last_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_synced_at": {
+          "name": "last_synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "sync_watermarks_league_id_data_type_pk": {
+          "name": "sync_watermarks_league_id_data_type_pk",
+          "columns": [
+            "league_id",
+            "data_type"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trade_grades": {
+      "name": "trade_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fantasy_calc_value": {
+          "name": "fantasy_calc_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trade_grades_tx_idx": {
+          "name": "trade_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trade_grades_unique_idx": {
+          "name": "trade_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trade_grades_transaction_id_transactions_id_fk": {
+          "name": "trade_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "trade_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.traded_picks": {
+      "name": "traded_picks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "round": {
+          "name": "round",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_roster_id": {
+          "name": "original_roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_owner_id": {
+          "name": "current_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "previous_owner_id": {
+          "name": "previous_owner_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "traded_picks_league_season_idx": {
+          "name": "traded_picks_league_season_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "traded_picks_league_id_leagues_id_fk": {
+          "name": "traded_picks_league_id_leagues_id_fk",
+          "tableFrom": "traded_picks",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "week": {
+          "name": "week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_ids": {
+          "name": "roster_ids",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "adds": {
+          "name": "adds",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "drops": {
+          "name": "drops",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "draft_picks": {
+          "name": "draft_picks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "settings": {
+          "name": "settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "transactions_league_week_idx": {
+          "name": "transactions_league_week_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "transactions_league_id_leagues_id_fk": {
+          "name": "transactions_league_id_leagues_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "leagues",
+          "columnsFrom": [
+            "league_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waitlist": {
+      "name": "waitlist",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "league_id": {
+          "name": "league_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "notified_at": {
+          "name": "notified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "waitlist_email_league_unique": {
+          "name": "waitlist_email_league_unique",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_league_id_idx": {
+          "name": "waitlist_league_id_idx",
+          "columns": [
+            {
+              "expression": "league_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waitlist_status_idx": {
+          "name": "waitlist_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.waiver_grades": {
+      "name": "waiver_grades",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "roster_id": {
+          "name": "roster_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "player_id": {
+          "name": "player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_player_id": {
+          "name": "dropped_player_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value_score": {
+          "name": "value_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "player_value": {
+          "name": "player_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dropped_value": {
+          "name": "dropped_value",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_bid": {
+          "name": "faab_bid",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "faab_efficiency": {
+          "name": "faab_efficiency",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_score": {
+          "name": "production_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weeks": {
+          "name": "production_weeks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "raw_par": {
+          "name": "raw_par",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "blended_score": {
+          "name": "blended_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "production_weight": {
+          "name": "production_weight",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "computed_at": {
+          "name": "computed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "waiver_grades_tx_idx": {
+          "name": "waiver_grades_tx_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_player_idx": {
+          "name": "waiver_grades_player_idx",
+          "columns": [
+            {
+              "expression": "player_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "waiver_grades_unique_idx": {
+          "name": "waiver_grades_unique_idx",
+          "columns": [
+            {
+              "expression": "transaction_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "roster_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "waiver_grades_transaction_id_transactions_id_fk": {
+          "name": "waiver_grades_transaction_id_transactions_id_fk",
+          "tableFrom": "waiver_grades",
+          "tableTo": "transactions",
+          "columnsFrom": [
+            "transaction_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,13 @@
       "when": 1778326533213,
       "tag": "0016_fantasycalc_widen_cache_key",
       "breakpoints": true
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1778329365208,
+      "tag": "0017_eminent_blue_blade",
+      "breakpoints": true
     }
   ]
 }

--- a/src/app/api/sync/league/route.ts
+++ b/src/app/api/sync/league/route.ts
@@ -18,8 +18,10 @@ export async function POST(req: NextRequest) {
     // Ensure the league family exists (discovers all seasons via Sleeper API)
     const familyId = await ensureLeagueFamily(leagueId);
 
-    // Acquire sync lock — return 409 if already running
-    const jobId = await acquireSyncLock(leagueId);
+    // Acquire sync lock — return 409 if already running. The /api/sync/league
+    // route is the manual entry point (button click in UI / direct call), so
+    // we record trigger=manual on the audit row.
+    const jobId = await acquireSyncLock(leagueId, { trigger: "manual" });
     if (!jobId) {
       return NextResponse.json(
         { error: "A sync is already running for this league family" },
@@ -41,10 +43,14 @@ export async function POST(req: NextRequest) {
 
       if (allLeagueIds.length === 0) {
         // Fallback: sync just the requested league
-        await syncLeagueFamily([leagueId], undefined, familyId);
+        await syncLeagueFamily([leagueId], undefined, familyId, {
+          trigger: "manual",
+        });
       } else {
         // Sync all seasons in the family
-        await syncLeagueFamily(allLeagueIds, undefined, familyId);
+        await syncLeagueFamily(allLeagueIds, undefined, familyId, {
+          trigger: "manual",
+        });
       }
 
       await releaseSyncLock(jobId, "success");

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -543,11 +543,24 @@ export const syncJobs = pgTable(
     total: integer("total").default(0),
     done: integer("done").default(0),
     error: text("error"),
+    // Audit fields (Sync 9 / #152). `trigger` records what kicked off the
+    // sync (cron|lazy|manual) so dashboards can split success rate by
+    // origin. `apiCallsMade` is incremented during the run so we can
+    // correlate sync cost against the rolling Sleeper rate-limit gauge.
+    // `stagesCompleted` / `stagesTotal` / `currentStage` are placeholders
+    // for the chunked-stage executor (#151) — they default to NULL today
+    // and become meaningful once the executor lands.
+    trigger: text("trigger"), // cron | lazy | manual
+    apiCallsMade: integer("api_calls_made").default(0),
+    stagesCompleted: integer("stages_completed").default(0),
+    stagesTotal: integer("stages_total"),
+    currentStage: text("current_stage"),
     startedAt: timestamp("started_at", { mode: "date" }).defaultNow().notNull(),
     finishedAt: timestamp("finished_at", { mode: "date" }),
   },
   (sj) => ({
     refStatusIdx: index("sync_jobs_ref_status_idx").on(sj.ref, sj.status),
+    startedAtIdx: index("sync_jobs_started_at_idx").on(sj.startedAt),
   })
 );
 

--- a/src/lib/sleeper.ts
+++ b/src/lib/sleeper.ts
@@ -6,6 +6,8 @@
  * Auth: None required (public, read-only)
  */
 
+import { recordSleeperCall } from "@/lib/sleeper/rateLimit";
+
 const BASE_URL = "https://api.sleeper.app/v1";
 
 // Rate limiting: max 15 requests per second (~900/min, well under 1000 limit)
@@ -51,6 +53,9 @@ async function fetchWithRetry(
   backoff = 1000
 ): Promise<Response> {
   for (let attempt = 0; attempt <= retries; attempt++) {
+    // Record every outbound call (including retries) so the rate gauge
+    // reflects what Sleeper actually saw, not just what callers requested.
+    recordSleeperCall();
     const res = await fetch(url);
     if (res.ok) return res;
     if (res.status === 429 || res.status >= 500) {

--- a/src/lib/sleeper/__tests__/rateLimit.test.ts
+++ b/src/lib/sleeper/__tests__/rateLimit.test.ts
@@ -1,0 +1,175 @@
+/**
+ * @jest-environment node
+ *
+ * Verifies the Sleeper rate-limit utilization gauge:
+ *   - records each call into the rolling 60s window
+ *   - prunes timestamps older than 60s
+ *   - emits the gauge to the console when no DSN configured
+ *   - emits the gauge to Sentry.metrics when a DSN is set
+ *   - falls back to addBreadcrumb when Sentry.metrics is unavailable
+ *   - flushes once per 60s interval (not on every call)
+ */
+
+jest.mock("@sentry/nextjs", () => ({
+  metrics: {
+    gauge: jest.fn(),
+  },
+  addBreadcrumb: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+import * as Sentry from "@sentry/nextjs";
+import {
+  recordSleeperCall,
+  flushSleeperRateGauge,
+  getCurrentCallsPerMinute,
+  getCurrentUtilizationPct,
+  __resetSleeperRateState,
+  __getLastFlushAt,
+  SLEEPER_LIMIT_PER_MINUTE,
+} from "../rateLimit";
+
+const mockedSentry = Sentry as unknown as {
+  metrics: { gauge: jest.Mock };
+  addBreadcrumb: jest.Mock;
+  captureMessage: jest.Mock;
+};
+
+const ORIGINAL_DSN = process.env.SENTRY_DSN;
+const ORIGINAL_PUBLIC_DSN = process.env.NEXT_PUBLIC_SENTRY_DSN;
+
+function resetDsn() {
+  delete process.env.SENTRY_DSN;
+  delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+}
+
+function restoreDsn() {
+  if (ORIGINAL_DSN === undefined) delete process.env.SENTRY_DSN;
+  else process.env.SENTRY_DSN = ORIGINAL_DSN;
+  if (ORIGINAL_PUBLIC_DSN === undefined)
+    delete process.env.NEXT_PUBLIC_SENTRY_DSN;
+  else process.env.NEXT_PUBLIC_SENTRY_DSN = ORIGINAL_PUBLIC_DSN;
+}
+
+describe("Sleeper rate-limit gauge", () => {
+  let consoleSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    __resetSleeperRateState();
+    resetDsn();
+    consoleSpy = jest.spyOn(console, "info").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    restoreDsn();
+  });
+
+  it("records calls into the rolling window", () => {
+    const t0 = 1_700_000_000_000;
+    recordSleeperCall(t0);
+    recordSleeperCall(t0 + 100);
+    recordSleeperCall(t0 + 200);
+    expect(getCurrentCallsPerMinute(t0 + 300)).toBe(3);
+  });
+
+  it("prunes timestamps older than 60s", () => {
+    const t0 = 1_700_000_000_000;
+    recordSleeperCall(t0);
+    recordSleeperCall(t0 + 1000);
+    // Advance past the rolling window — earlier calls should be evicted.
+    expect(getCurrentCallsPerMinute(t0 + 60_000 + 1)).toBe(1);
+    expect(getCurrentCallsPerMinute(t0 + 120_000)).toBe(0);
+  });
+
+  it("computes utilization as percent of the 1000 RPM limit", () => {
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 100; i++) recordSleeperCall(t0 + i);
+    // 100 calls in window -> 10% of 1000 RPM
+    expect(getCurrentUtilizationPct(t0 + 200)).toBe(10);
+    expect(SLEEPER_LIMIT_PER_MINUTE).toBe(1000);
+  });
+
+  it("caps utilization at 100% when calls exceed the documented limit", () => {
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 1500; i++) recordSleeperCall(t0 + i);
+    expect(getCurrentUtilizationPct(t0 + 2000)).toBe(100);
+  });
+
+  it("emits to console.info when no DSN is configured", () => {
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 5; i++) recordSleeperCall(t0 + i);
+    flushSleeperRateGauge(t0 + 100);
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      "[sleeper.rate]",
+      expect.objectContaining({
+        callsPerMinute: 5,
+        utilizationPct: 1, // 5 / 1000 = 0.5%, rounded -> 1 (Math.round behavior on .5)
+        limit: 1000,
+      }),
+    );
+    expect(mockedSentry.metrics.gauge).not.toHaveBeenCalled();
+  });
+
+  it("emits to Sentry.metrics.gauge when DSN is set", () => {
+    process.env.SENTRY_DSN = "https://example@sentry.io/123";
+
+    const t0 = 1_700_000_000_000;
+    for (let i = 0; i < 50; i++) recordSleeperCall(t0 + i);
+    flushSleeperRateGauge(t0 + 100);
+
+    expect(mockedSentry.metrics.gauge).toHaveBeenCalledWith(
+      "sleeper.rate_utilization_pct",
+      5, // 50 calls / 1000 RPM = 5%
+      expect.objectContaining({ unit: "percent" }),
+    );
+    expect(mockedSentry.metrics.gauge).toHaveBeenCalledWith(
+      "sleeper.calls_per_minute",
+      50,
+      expect.any(Object),
+    );
+  });
+
+  it("only flushes once per 60s window from recordCall", () => {
+    process.env.SENTRY_DSN = "https://example@sentry.io/123";
+
+    const t0 = 1_700_000_000_000;
+    // First call triggers a flush (lastFlushAt was 0).
+    recordSleeperCall(t0);
+    expect(mockedSentry.metrics.gauge).toHaveBeenCalled();
+
+    mockedSentry.metrics.gauge.mockClear();
+
+    // 30 seconds later — still inside the flush window, no new flush.
+    recordSleeperCall(t0 + 30_000);
+    expect(mockedSentry.metrics.gauge).not.toHaveBeenCalled();
+
+    // 61 seconds in — past the window, flush again.
+    recordSleeperCall(t0 + 61_000);
+    expect(mockedSentry.metrics.gauge).toHaveBeenCalled();
+  });
+
+  it("updates lastFlushAt on every flush", () => {
+    process.env.SENTRY_DSN = "https://example@sentry.io/123";
+
+    const t0 = 1_700_000_000_000;
+    flushSleeperRateGauge(t0);
+    expect(__getLastFlushAt()).toBe(t0);
+
+    flushSleeperRateGauge(t0 + 100_000);
+    expect(__getLastFlushAt()).toBe(t0 + 100_000);
+  });
+
+  it("never throws if Sentry.metrics.gauge throws", () => {
+    process.env.SENTRY_DSN = "https://example@sentry.io/123";
+    mockedSentry.metrics.gauge.mockImplementationOnce(() => {
+      throw new Error("metrics boom");
+    });
+
+    expect(() => {
+      recordSleeperCall(1_700_000_000_000);
+    }).not.toThrow();
+  });
+});

--- a/src/lib/sleeper/rateLimit.ts
+++ b/src/lib/sleeper/rateLimit.ts
@@ -1,0 +1,136 @@
+// Sleeper API rolling rate-limit utilization gauge.
+//
+// Sleeper enforces ~1000 requests/minute. We pace requests at <=15 RPS in
+// the client, but actual utilization can dip well below that when callers
+// idle. To know whether we're brushing up against the ceiling — and to
+// alert before we get throttled — we keep a per-client rolling window of
+// request timestamps over the last 60 seconds and emit a gauge to Sentry
+// once a minute (or to the console when no DSN is set).
+//
+// The instrumentation is intentionally side-effect free until the first
+// request lands — no background timers, no module-level setInterval. The
+// minute-tick decision rides off `Date.now()` checked on every recordCall,
+// so unit tests can drive it deterministically without timer mocks.
+
+import * as Sentry from "@sentry/nextjs";
+
+/** Sleeper's documented limit: 1000 calls / minute. */
+export const SLEEPER_LIMIT_PER_MINUTE = 1000;
+/** Rolling window we sample for the gauge. */
+const WINDOW_MS = 60 * 1000;
+/** How often we flush the gauge. */
+const FLUSH_INTERVAL_MS = 60 * 1000;
+
+const callTimestamps: number[] = [];
+let lastFlushAt = 0;
+
+function isDsnConfigured(): boolean {
+  return Boolean(
+    process.env.SENTRY_DSN || process.env.NEXT_PUBLIC_SENTRY_DSN,
+  );
+}
+
+function pruneOldCalls(now: number): void {
+  const cutoff = now - WINDOW_MS;
+  while (callTimestamps.length > 0 && callTimestamps[0] < cutoff) {
+    callTimestamps.shift();
+  }
+}
+
+/** Returns the count of API calls in the rolling 60s window. */
+export function getCurrentCallsPerMinute(now: number = Date.now()): number {
+  pruneOldCalls(now);
+  return callTimestamps.length;
+}
+
+/** Returns utilization as a percentage of the documented Sleeper limit. */
+export function getCurrentUtilizationPct(now: number = Date.now()): number {
+  const callsInWindow = getCurrentCallsPerMinute(now);
+  return Math.min(
+    100,
+    Math.round((callsInWindow / SLEEPER_LIMIT_PER_MINUTE) * 100),
+  );
+}
+
+/**
+ * Forcibly emit the gauge regardless of when it was last flushed. Used by
+ * tests + diagnostic scripts.
+ */
+export function flushSleeperRateGauge(now: number = Date.now()): void {
+  const callsInWindow = getCurrentCallsPerMinute(now);
+  const utilizationPct = getCurrentUtilizationPct(now);
+  lastFlushAt = now;
+
+  const payload = {
+    callsPerMinute: callsInWindow,
+    utilizationPct,
+    limit: SLEEPER_LIMIT_PER_MINUTE,
+  };
+
+  if (!isDsnConfigured()) {
+    // eslint-disable-next-line no-console
+    console.info("[sleeper.rate]", payload);
+    return;
+  }
+
+  try {
+    type MetricsApi = {
+      gauge?: (
+        name: string,
+        value: number,
+        opts?: { unit?: string; tags?: Record<string, string> },
+      ) => void;
+    };
+    // Sentry's metrics API is namespaced under `Sentry.metrics`. It's
+    // available in newer SDK versions but we feature-detect rather than
+    // assume — falling back to a breadcrumb keeps the signal flowing on
+    // older runtimes.
+    const sentryWithMetrics = Sentry as typeof Sentry & {
+      metrics?: MetricsApi;
+    };
+    const metrics = sentryWithMetrics.metrics;
+    if (metrics && typeof metrics.gauge === "function") {
+      metrics.gauge("sleeper.rate_utilization_pct", utilizationPct, {
+        unit: "percent",
+      });
+      metrics.gauge("sleeper.calls_per_minute", callsInWindow, {
+        unit: "none",
+      });
+    } else {
+      Sentry.addBreadcrumb({
+        category: "sleeper.rate",
+        type: "info",
+        level: utilizationPct > 80 ? "warning" : "info",
+        message: `sleeper.rate ${utilizationPct}%`,
+        data: payload,
+      });
+    }
+  } catch {
+    // Never let observability break the caller.
+  }
+}
+
+/**
+ * Record a single Sleeper API call. Cheap and synchronous — keeps a small
+ * in-memory ring buffer pruned to the last 60 seconds. Once a minute
+ * (best-effort, sampled lazily on recordCall) we emit the rate gauge.
+ */
+export function recordSleeperCall(now: number = Date.now()): void {
+  callTimestamps.push(now);
+  pruneOldCalls(now);
+
+  if (now - lastFlushAt >= FLUSH_INTERVAL_MS) {
+    flushSleeperRateGauge(now);
+  }
+}
+
+/** Test-only: drop every retained call timestamp. */
+export function __resetSleeperRateState(): void {
+  callTimestamps.length = 0;
+  lastFlushAt = 0;
+}
+
+/** Test-only: read the lastFlushAt cursor. */
+export function __getLastFlushAt(): number {
+  return lastFlushAt;
+}

--- a/src/services/__tests__/breadcrumbIntegration.test.ts
+++ b/src/services/__tests__/breadcrumbIntegration.test.ts
@@ -1,0 +1,397 @@
+/**
+ * @jest-environment node
+ *
+ * Integration test for Sync 9b (#152): every top-level sync service must
+ * emit a structured breadcrumb on success and a `outcome: "failed"` one
+ * on error, then re-throw the original error so the caller still sees it.
+ *
+ * Strategy: mock @/db so the staleness gates immediately return "stale"
+ * (or in scheduleSync's case, drive the CSV fetch to fail), call the
+ * service, and inspect what was passed to recordSyncBreadcrumb.
+ */
+
+const recordSyncBreadcrumb = jest.fn();
+jest.mock("@/lib/observability/syncBreadcrumb", () => {
+  const actual = jest.requireActual("@/lib/observability/syncBreadcrumb");
+  return {
+    ...actual,
+    recordSyncBreadcrumb,
+  };
+});
+
+jest.mock("drizzle-orm", () => ({
+  eq: (col: { name: string }, value: unknown) => ({ op: "eq", col, value }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  isNull: (col: { name: string }) => ({ op: "isNull", col }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      op: "sql",
+      strings: Array.from(strings),
+      values,
+    }),
+    {
+      raw: (s: string) => s,
+    },
+  ),
+}));
+
+jest.mock("@/db", () => {
+  const stubColumn = (name: string) => ({ name });
+  return {
+    schema: {
+      players: {
+        id: stubColumn("id"),
+        name: stubColumn("name"),
+        gsisId: stubColumn("gsis_id"),
+        firstName: stubColumn("first_name"),
+        lastName: stubColumn("last_name"),
+        position: stubColumn("position"),
+        team: stubColumn("team"),
+        age: stubColumn("age"),
+        status: stubColumn("status"),
+        injuryStatus: stubColumn("injury_status"),
+        yearsExp: stubColumn("years_exp"),
+        updatedAt: stubColumn("updated_at"),
+      },
+      nflWeeklyRosterStatus: {
+        gsisId: stubColumn("gsis_id"),
+        playerName: stubColumn("player_name"),
+        position: stubColumn("position"),
+        season: stubColumn("season"),
+      },
+      nflInjuries: {
+        season: stubColumn("season"),
+        gsisId: stubColumn("gsis_id"),
+      },
+      nflSchedule: {
+        season: stubColumn("season"),
+      },
+      fantasyCalcValues: {
+        playerId: stubColumn("player_id"),
+        isSuperFlex: stubColumn("is_super_flex"),
+        ppr: stubColumn("ppr"),
+        numTeams: stubColumn("num_teams"),
+        numQbs: stubColumn("num_qbs"),
+        fetchedAt: stubColumn("fetched_at"),
+      },
+      leagues: {
+        id: stubColumn("id"),
+        scoringSettings: stubColumn("scoring_settings"),
+        rosterPositions: stubColumn("roster_positions"),
+        totalRosters: stubColumn("total_rosters"),
+      },
+    },
+    getDb: jest.fn(),
+    getSyncDb: jest.fn(),
+  };
+});
+
+jest.mock("@/services/nflverseWatermark", () => ({
+  setNflverseWatermarkTx: jest.fn(),
+  shouldSkipSeasonSync: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock("@/lib/sleeper", () => ({
+  Sleeper: {
+    getPlayers: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/fantasycalc", () => ({
+  getFantasyCalcValues: jest.fn(),
+}));
+
+import { getDb, getSyncDb } from "@/db";
+import { Sleeper } from "@/lib/sleeper";
+import { getFantasyCalcValues } from "@/lib/fantasycalc";
+import { syncPlayers } from "../playerSync";
+import { syncFantasyCalcValuesForConfig } from "../fantasyCalcSync";
+import {
+  syncSchedule,
+  __resetScheduleCsvCache,
+} from "../scheduleSync";
+import { syncInjuries } from "../injurySync";
+import { syncRosterStatus } from "../rosterStatusSync";
+
+const mockedGetDb = getDb as jest.MockedFunction<typeof getDb>;
+const mockedGetSyncDb = getSyncDb as jest.MockedFunction<typeof getSyncDb>;
+const mockedGetPlayers = Sleeper.getPlayers as jest.MockedFunction<
+  typeof Sleeper.getPlayers
+>;
+const mockedGetFantasyCalcValues = getFantasyCalcValues as jest.MockedFunction<
+  typeof getFantasyCalcValues
+>;
+
+function makeReadDb() {
+  return {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => Promise.resolve([{ count: 0 }])),
+      })),
+    })),
+    selectDistinct: jest.fn(() => ({
+      from: jest.fn(() => Promise.resolve([])),
+    })),
+    insert: jest.fn(() => ({
+      values: jest.fn(() => ({
+        onConflictDoUpdate: jest.fn(() => Promise.resolve()),
+      })),
+    })),
+    update: jest.fn(() => ({
+      set: jest.fn(() => ({
+        where: jest.fn(() => Promise.resolve()),
+      })),
+    })),
+  };
+}
+
+function makeSyncDb() {
+  return {
+    transaction: jest.fn(async (cb: (tx: unknown) => Promise<void>) => {
+      await cb({
+        delete: jest.fn(() => ({ where: jest.fn(() => Promise.resolve()) })),
+        insert: jest.fn(() => ({
+          values: jest.fn(() => ({
+            onConflictDoNothing: jest.fn(() => Promise.resolve()),
+            onConflictDoUpdate: jest.fn(() => Promise.resolve()),
+          })),
+        })),
+      });
+    }),
+  };
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  __resetScheduleCsvCache();
+});
+
+describe("syncPlayers breadcrumb", () => {
+  it("emits a success breadcrumb when fresh data lets it skip", async () => {
+    // Latest update is recent so isStale() returns false; we still want to
+    // see the breadcrumb so dashboards know syncPlayers was invoked.
+    mockedGetDb.mockReturnValue({
+      select: jest.fn(() => ({
+        from: jest.fn(() =>
+          Promise.resolve([{ latest: new Date().toISOString() }]),
+        ),
+      })),
+    } as unknown as ReturnType<typeof getDb>);
+
+    await syncPlayers(false, { trigger: "cron", scope: "test-scope" });
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "sleeper",
+        trigger: "cron",
+        scope: "test-scope",
+        outcome: "success",
+        apiCalls: 0,
+      }),
+    );
+  });
+
+  it("emits failed breadcrumb and re-throws on Sleeper error", async () => {
+    // Force the staleness check to claim "stale" so we proceed to fetch.
+    mockedGetDb.mockReturnValue({
+      select: jest.fn(() => ({
+        from: jest.fn(() => Promise.resolve([{ latest: null }])),
+      })),
+    } as unknown as ReturnType<typeof getDb>);
+    mockedGetPlayers.mockRejectedValueOnce(new Error("Sleeper down"));
+
+    await expect(
+      syncPlayers(true, { trigger: "manual", scope: "fail-test" }),
+    ).rejects.toThrow("Sleeper down");
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "sleeper",
+        trigger: "manual",
+        scope: "fail-test",
+        outcome: "failed",
+        error: "Sleeper down",
+      }),
+    );
+  });
+});
+
+describe("syncFantasyCalcValuesForConfig breadcrumb", () => {
+  function setupDb() {
+    mockedGetDb.mockReturnValue({
+      select: jest.fn(() => ({
+        from: jest.fn(() => ({
+          where: jest.fn(() => ({
+            limit: jest.fn(() => Promise.resolve([])),
+            // Staleness fall-through (no .latest, so not fresh)
+            then: (resolve: (v: unknown) => void) => {
+              resolve([{}]);
+              return Promise.resolve(undefined);
+            },
+          })),
+        })),
+      })),
+      insert: jest.fn(() => ({
+        values: jest.fn(() => ({
+          onConflictDoUpdate: jest.fn(() => Promise.resolve()),
+        })),
+      })),
+    } as unknown as ReturnType<typeof getDb>);
+  }
+
+  it("emits a success breadcrumb with apiCalls=1 on a real run", async () => {
+    setupDb();
+    mockedGetFantasyCalcValues.mockResolvedValueOnce([
+      {
+        player: {
+          name: "Player",
+          position: "QB",
+          maybeTeam: "KC",
+          maybeBirthDate: null,
+          espnId: null,
+          yahooId: null,
+          sleeperId: "p1",
+        },
+        value: 9000,
+        overallRank: 1,
+        positionRank: 1,
+        redraftValue: 9000,
+        combinedValue: 9000,
+        trend30Day: 0,
+      },
+    ]);
+
+    await syncFantasyCalcValuesForConfig(
+      { isSuperFlex: false, ppr: 0.5, numTeams: 12, numQbs: 1 },
+      { trigger: "cron" },
+    );
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "fantasycalc",
+        trigger: "cron",
+        outcome: "success",
+        apiCalls: 1,
+      }),
+    );
+  });
+
+  it("emits failed breadcrumb on FantasyCalc error", async () => {
+    setupDb();
+    mockedGetFantasyCalcValues.mockRejectedValueOnce(new Error("FC 503"));
+
+    await expect(
+      syncFantasyCalcValuesForConfig(
+        { isSuperFlex: false, ppr: 0.5, numTeams: 12, numQbs: 1 },
+        { trigger: "manual" },
+      ),
+    ).rejects.toThrow("FC 503");
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "fantasycalc",
+        trigger: "manual",
+        outcome: "failed",
+        error: "FC 503",
+      }),
+    );
+  });
+});
+
+describe("syncSchedule breadcrumb", () => {
+  it("emits success breadcrumb after a clean run", async () => {
+    mockedGetDb.mockReturnValue(
+      makeReadDb() as unknown as ReturnType<typeof getDb>,
+    );
+    mockedGetSyncDb.mockReturnValue(
+      makeSyncDb() as unknown as ReturnType<typeof getSyncDb>,
+    );
+
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response(
+        "season,game_type,week,home_team,away_team,home_score,away_score,gameday\n2024,REG,1,KC,BAL,27,20,2024-09-05",
+        { status: 200 },
+      ) as unknown as Response,
+    );
+
+    await syncSchedule({ seasons: [2024], trigger: "cron" });
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "nflverse",
+        trigger: "cron",
+        outcome: "success",
+        apiCalls: 1,
+      }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+
+  it("emits failed breadcrumb when CSV fetch fails", async () => {
+    mockedGetDb.mockReturnValue(
+      makeReadDb() as unknown as ReturnType<typeof getDb>,
+    );
+    mockedGetSyncDb.mockReturnValue(
+      makeSyncDb() as unknown as ReturnType<typeof getSyncDb>,
+    );
+
+    const fetchSpy = jest.spyOn(global, "fetch").mockResolvedValueOnce(
+      new Response("oops", { status: 500 }) as unknown as Response,
+    );
+
+    await expect(
+      syncSchedule({ seasons: [2024], trigger: "cron" }),
+    ).rejects.toThrow(/Failed to fetch schedule data/);
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "nflverse",
+        trigger: "cron",
+        outcome: "failed",
+      }),
+    );
+
+    fetchSpy.mockRestore();
+  });
+});
+
+describe("syncInjuries breadcrumb", () => {
+  it("emits success breadcrumb (zero seasons -> zero api calls)", async () => {
+    mockedGetDb.mockReturnValue(
+      makeReadDb() as unknown as ReturnType<typeof getDb>,
+    );
+
+    // No seasons means we don't actually fetch — but the breadcrumb still
+    // fires so the audit trail shows the call site was hit.
+    await syncInjuries({ seasons: [], trigger: "cron" });
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "nflverse",
+        trigger: "cron",
+        scope: expect.stringContaining("injuries"),
+        outcome: "success",
+      }),
+    );
+  });
+});
+
+describe("syncRosterStatus breadcrumb", () => {
+  it("emits success breadcrumb (zero seasons -> zero api calls)", async () => {
+    mockedGetDb.mockReturnValue(
+      makeReadDb() as unknown as ReturnType<typeof getDb>,
+    );
+
+    await syncRosterStatus({ seasons: [], trigger: "cron" });
+
+    expect(recordSyncBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        source: "nflverse",
+        trigger: "cron",
+        scope: expect.stringContaining("roster-status"),
+        outcome: "success",
+      }),
+    );
+  });
+});

--- a/src/services/__tests__/syncLock.test.ts
+++ b/src/services/__tests__/syncLock.test.ts
@@ -1,0 +1,406 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the family-scoped sync lock (acquireSyncLock / releaseSyncLock).
+ *
+ * Coverage targets:
+ *   - acquire returns null when a non-stale running job exists (collision)
+ *   - acquire inserts a new running job + returns its id when none exists
+ *   - acquire marks stale running jobs as failed before inserting
+ *   - release flips a job to success or failed with the supplied error
+ */
+
+jest.mock("@/db", () => {
+  const stubColumn = (name: string) => ({ name });
+  return {
+    schema: {
+      syncJobs: {
+        id: stubColumn("id"),
+        ref: stubColumn("ref"),
+        status: stubColumn("status"),
+        startedAt: stubColumn("started_at"),
+        finishedAt: stubColumn("finished_at"),
+        error: stubColumn("error"),
+        type: stubColumn("type"),
+      },
+    },
+    getDb: jest.fn(),
+  };
+});
+
+jest.mock("drizzle-orm", () => ({
+  eq: (col: { name: string }, value: unknown) => ({ op: "eq", col, value }),
+  and: (...args: unknown[]) => ({ op: "and", args }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      op: "sql",
+      strings: Array.from(strings),
+      values,
+    }),
+    {
+      raw: (s: string) => s,
+    }
+  ),
+}));
+
+import { getDb } from "@/db";
+import {
+  acquireSyncLock,
+  releaseSyncLock,
+  incrementSyncJobApiCalls,
+  updateSyncJobStage,
+} from "../syncLock";
+
+const mockedGetDb = getDb as jest.MockedFunction<typeof getDb>;
+
+interface DbCalls {
+  selectResults: Array<{ id: string }>;
+  updateSets: Array<Record<string, unknown>>;
+  insertedValues: Array<Record<string, unknown>>;
+  insertReturning: Array<{ id: string }>;
+}
+
+function buildDb(calls: DbCalls) {
+  return {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(() => ({
+          limit: jest.fn(() => Promise.resolve(calls.selectResults)),
+        })),
+      })),
+    })),
+    update: jest.fn(() => ({
+      set: jest.fn((s: Record<string, unknown>) => {
+        calls.updateSets.push(s);
+        return {
+          where: jest.fn(() => Promise.resolve()),
+        };
+      }),
+    })),
+    insert: jest.fn(() => ({
+      values: jest.fn((v: Record<string, unknown>) => {
+        calls.insertedValues.push(v);
+        return {
+          returning: jest.fn(() => Promise.resolve(calls.insertReturning)),
+        };
+      }),
+    })),
+  };
+}
+
+describe("acquireSyncLock", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns null when a non-stale running job already exists", async () => {
+    const calls: DbCalls = {
+      selectResults: [{ id: "existing_job" }],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    const result = await acquireSyncLock("family_root_1");
+    expect(result).toBeNull();
+    // Insert path must not have been touched.
+    expect(db.insert).not.toHaveBeenCalled();
+  });
+
+  it("inserts a new running job and returns its id when no running job exists", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [{ id: "new_job_id" }],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    const result = await acquireSyncLock("family_root_2");
+    expect(result).toBe("new_job_id");
+    expect(calls.insertedValues).toHaveLength(1);
+    expect(calls.insertedValues[0]).toMatchObject({
+      type: "league_sync",
+      ref: "family_root_2",
+      status: "running",
+    });
+  });
+
+  it("marks stale running jobs as failed before inserting a new one", async () => {
+    // No collision -> select returns empty -> we still issue the cleanup
+    // update for any rows older than the stale threshold.
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [{ id: "fresh_job" }],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await acquireSyncLock("family_root_3");
+
+    // The cleanup write set status=failed with a "stale job" error string.
+    expect(calls.updateSets).toHaveLength(1);
+    const set = calls.updateSets[0];
+    expect(set.status).toBe("failed");
+    expect(typeof set.error).toBe("string");
+    expect((set.error as string).toLowerCase()).toContain("stale");
+    expect(set.finishedAt).toBeInstanceOf(Date);
+  });
+});
+
+describe("releaseSyncLock", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("updates the job to success and clears error", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await releaseSyncLock("job_1", "success");
+
+    expect(calls.updateSets).toHaveLength(1);
+    const set = calls.updateSets[0];
+    expect(set.status).toBe("success");
+    expect(set.error).toBeNull();
+    expect(set.finishedAt).toBeInstanceOf(Date);
+  });
+
+  it("updates the job to failed with the supplied error message", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await releaseSyncLock("job_2", "failed", "kaboom");
+
+    expect(calls.updateSets).toHaveLength(1);
+    const set = calls.updateSets[0];
+    expect(set.status).toBe("failed");
+    expect(set.error).toBe("kaboom");
+  });
+
+  it("normalizes a missing error to null", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await releaseSyncLock("job_3", "failed");
+
+    expect(calls.updateSets[0].error).toBeNull();
+  });
+
+  it("records audit fields (apiCallsMade, stagesCompleted) when provided", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await releaseSyncLock("job_x", "success", undefined, {
+      apiCallsMade: 17,
+      stagesCompleted: 3,
+    });
+
+    const set = calls.updateSets[0];
+    expect(set.apiCallsMade).toBe(17);
+    expect(set.stagesCompleted).toBe(3);
+  });
+
+  it("omits audit fields from the update when not provided", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await releaseSyncLock("job_y", "success");
+
+    const set = calls.updateSets[0];
+    expect("apiCallsMade" in set).toBe(false);
+    expect("stagesCompleted" in set).toBe(false);
+  });
+});
+
+describe("acquireSyncLock — trigger + stagesTotal options", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("defaults trigger to 'manual' and stagesTotal to null", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [{ id: "j1" }],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await acquireSyncLock("family");
+    expect(calls.insertedValues[0]).toMatchObject({
+      trigger: "manual",
+      stagesTotal: null,
+    });
+  });
+
+  it("propagates trigger and stagesTotal when provided", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [{ id: "j2" }],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await acquireSyncLock("family", { trigger: "cron", stagesTotal: 7 });
+    expect(calls.insertedValues[0]).toMatchObject({
+      trigger: "cron",
+      stagesTotal: 7,
+    });
+  });
+});
+
+describe("incrementSyncJobApiCalls", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("issues an UPDATE with a sql expression bumping the counter", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await incrementSyncJobApiCalls("job_a", 3);
+    expect(db.update).toHaveBeenCalledTimes(1);
+    expect(calls.updateSets[0]).toHaveProperty("apiCallsMade");
+  });
+
+  it("noops on an empty jobId", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await incrementSyncJobApiCalls("");
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("swallows db errors so observability never breaks the caller", async () => {
+    const failingDb = {
+      update: jest.fn(() => ({
+        set: jest.fn(() => ({
+          where: jest.fn(() => Promise.reject(new Error("db down"))),
+        })),
+      })),
+    };
+    mockedGetDb.mockReturnValue(
+      failingDb as unknown as ReturnType<typeof getDb>
+    );
+
+    await expect(incrementSyncJobApiCalls("job_x", 1)).resolves.toBeUndefined();
+  });
+});
+
+describe("updateSyncJobStage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("records the new currentStage", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await updateSyncJobStage("job_a", "matchups");
+    expect(calls.updateSets[0].currentStage).toBe("matchups");
+    expect("stagesCompleted" in calls.updateSets[0]).toBe(false);
+  });
+
+  it("records stagesCompleted alongside currentStage when provided", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await updateSyncJobStage("job_a", "complete", 5);
+    expect(calls.updateSets[0]).toMatchObject({
+      currentStage: "complete",
+      stagesCompleted: 5,
+    });
+  });
+
+  it("noops on an empty jobId", async () => {
+    const calls: DbCalls = {
+      selectResults: [],
+      updateSets: [],
+      insertedValues: [],
+      insertReturning: [],
+    };
+    const db = buildDb(calls);
+    mockedGetDb.mockReturnValue(db as unknown as ReturnType<typeof getDb>);
+
+    await updateSyncJobStage("", "matchups");
+    expect(db.update).not.toHaveBeenCalled();
+  });
+
+  it("swallows db errors", async () => {
+    const failingDb = {
+      update: jest.fn(() => ({
+        set: jest.fn(() => ({
+          where: jest.fn(() => Promise.reject(new Error("db down"))),
+        })),
+      })),
+    };
+    mockedGetDb.mockReturnValue(
+      failingDb as unknown as ReturnType<typeof getDb>
+    );
+
+    await expect(updateSyncJobStage("job_x", "stage")).resolves.toBeUndefined();
+  });
+});

--- a/src/services/fantasyCalcSync.ts
+++ b/src/services/fantasyCalcSync.ts
@@ -1,6 +1,8 @@
 import { getDb, schema } from "@/db";
 import { eq, and, sql } from "drizzle-orm";
 import { getFantasyCalcValues } from "@/lib/fantasycalc";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
 
 const STALENESS_MS = 12 * 60 * 60 * 1000; // 12 hours
 
@@ -9,6 +11,11 @@ export interface FantasyCalcConfig {
   ppr: number;
   numTeams: number;
   numQbs: number;
+}
+
+interface FantasyCalcSyncOpts {
+  force?: boolean;
+  trigger?: SyncTrigger;
 }
 
 /**
@@ -21,7 +28,42 @@ export interface FantasyCalcConfig {
  */
 export async function syncFantasyCalcValuesForConfig(
   config: FantasyCalcConfig,
-  opts?: { force?: boolean },
+  opts?: FantasyCalcSyncOpts,
+): Promise<Date | null> {
+  const { isSuperFlex, ppr, numTeams, numQbs } = config;
+  const db = getDb();
+  const trigger = opts?.trigger ?? "manual";
+  const scope = `sf=${isSuperFlex}|ppr=${ppr}|teams=${numTeams}|qbs=${numQbs}`;
+  const startedAt = Date.now();
+  let apiCalls = 0;
+  let outcome: "success" | "failed" = "success";
+  let errorMessage: string | undefined;
+
+  try {
+    return await runSyncFantasyCalcForConfig(config, opts, () => {
+      apiCalls += 1;
+    });
+  } catch (err) {
+    outcome = "failed";
+    errorMessage = err instanceof Error ? err.message : String(err);
+    throw err;
+  } finally {
+    recordSyncBreadcrumb({
+      source: "fantasycalc",
+      trigger,
+      scope,
+      outcome,
+      durationMs: Date.now() - startedAt,
+      apiCalls,
+      error: errorMessage,
+    });
+  }
+}
+
+async function runSyncFantasyCalcForConfig(
+  config: FantasyCalcConfig,
+  opts: FantasyCalcSyncOpts | undefined,
+  onApiCall: () => void,
 ): Promise<Date | null> {
   const { isSuperFlex, ppr, numTeams, numQbs } = config;
   const db = getDb();
@@ -49,6 +91,7 @@ export async function syncFantasyCalcValuesForConfig(
   }
 
   // Fetch from FantasyCalc API
+  onApiCall();
   const values = await getFantasyCalcValues({
     isDynasty: true,
     numQbs,
@@ -166,7 +209,7 @@ export async function syncFantasyCalcValuesForConfig(
  */
 export async function syncFantasyCalcValues(
   leagueId: string,
-  opts?: { force?: boolean },
+  opts?: FantasyCalcSyncOpts,
 ): Promise<Date | null> {
   const db = getDb();
 

--- a/src/services/injurySync.ts
+++ b/src/services/injurySync.ts
@@ -4,6 +4,8 @@ import {
   setNflverseWatermarkTx,
   shouldSkipSeasonSync,
 } from "@/services/nflverseWatermark";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
 
 const NFLVERSE_INJURY_URL =
   "https://github.com/nflverse/nflverse-data/releases/download/injuries/injuries_";
@@ -101,7 +103,8 @@ async function hasInjuryRows(season: number): Promise<boolean> {
  */
 async function syncInjurySeason(
   season: number,
-  force = false
+  force = false,
+  onApiCall?: () => void,
 ): Promise<number> {
   const skip = await shouldSkipSeasonSync(season, {
     force,
@@ -112,6 +115,7 @@ async function syncInjurySeason(
   }
 
   const url = `${NFLVERSE_INJURY_URL}${season}.csv`;
+  onApiCall?.();
   const response = await fetch(url);
 
   if (!response.ok) {
@@ -190,7 +194,46 @@ async function syncInjurySeason(
 export async function syncInjuries(options?: {
   seasons?: number[];
   force?: boolean;
+  trigger?: SyncTrigger;
 }): Promise<{ total: number; seasonResults: Record<number, number> }> {
+  const trigger = options?.trigger ?? "manual";
+  const seasonScope = options?.seasons?.length
+    ? `seasons=${options.seasons.join(",")}`
+    : "seasons=all";
+  const startedAt = Date.now();
+  let apiCalls = 0;
+
+  try {
+    const result = await runSyncInjuries(options, () => {
+      apiCalls += 1;
+    });
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger,
+      scope: `injuries|${seasonScope}`,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+      apiCalls,
+    });
+    return result;
+  } catch (err) {
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger,
+      scope: `injuries|${seasonScope}`,
+      outcome: "failed",
+      durationMs: Date.now() - startedAt,
+      apiCalls,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+async function runSyncInjuries(
+  options: { seasons?: number[]; force?: boolean } | undefined,
+  onApiCall: () => void,
+): Promise<{ total: number; seasonResults: Record<number, number> }> {
   const force = options?.force ?? false;
   const seasons =
     options?.seasons ??
@@ -208,7 +251,7 @@ export async function syncInjuries(options?: {
       continue;
     }
 
-    const count = await syncInjurySeason(season, force);
+    const count = await syncInjurySeason(season, force, onApiCall);
     seasonResults[season] = count;
     total += count;
   }

--- a/src/services/playerSync.ts
+++ b/src/services/playerSync.ts
@@ -1,6 +1,8 @@
 import { Sleeper } from "@/lib/sleeper";
 import { getDb, schema } from "@/db";
 import { sql, isNull } from "drizzle-orm";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
 
 const FANTASY_POSITIONS = new Set(["QB", "RB", "WR", "TE", "K", "DEF"]);
 const STALENESS_MS = 24 * 60 * 60 * 1000; // 24 hours
@@ -24,11 +26,55 @@ async function isStale(): Promise<boolean> {
  * Skips if data is less than 24 hours old.
  * Returns the number of players synced, or 0 if skipped.
  */
-export async function syncPlayers(force = false): Promise<number> {
+export async function syncPlayers(
+  force = false,
+  opts?: { trigger?: SyncTrigger; scope?: string },
+): Promise<number> {
+  const trigger = opts?.trigger ?? "manual";
+  const scope = opts?.scope ?? "all-players";
+  const startedAt = Date.now();
+
   if (!force && !(await isStale())) {
+    // Even when we skip, emit the breadcrumb so we can see "syncPlayers
+    // was invoked but skipped fresh data" — that's a real signal when
+    // debugging cold starts.
+    recordSyncBreadcrumb({
+      source: "sleeper",
+      trigger,
+      scope,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+      apiCalls: 0,
+    });
     return 0;
   }
 
+  try {
+    const result = await runSyncPlayers();
+    recordSyncBreadcrumb({
+      source: "sleeper",
+      trigger,
+      scope,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+      apiCalls: 1, // single getPlayers() call
+    });
+    return result;
+  } catch (err) {
+    recordSyncBreadcrumb({
+      source: "sleeper",
+      trigger,
+      scope,
+      outcome: "failed",
+      durationMs: Date.now() - startedAt,
+      apiCalls: 1,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+async function runSyncPlayers(): Promise<number> {
   const db = getDb();
   const playerMap = await Sleeper.getPlayers();
 

--- a/src/services/rosterStatusSync.ts
+++ b/src/services/rosterStatusSync.ts
@@ -4,6 +4,8 @@ import {
   setNflverseWatermarkTx,
   shouldSkipSeasonSync,
 } from "@/services/nflverseWatermark";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
 
 const NFLVERSE_WEEKLY_ROSTER_URL =
   "https://github.com/nflverse/nflverse-data/releases/download/weekly_rosters/roster_weekly_";
@@ -69,7 +71,8 @@ async function hasRosterStatusRows(season: number): Promise<boolean> {
  */
 async function syncRosterStatusSeason(
   season: number,
-  force = false
+  force = false,
+  onApiCall?: () => void,
 ): Promise<number> {
   const skip = await shouldSkipSeasonSync(season, {
     force,
@@ -80,6 +83,7 @@ async function syncRosterStatusSeason(
   }
 
   const url = `${NFLVERSE_WEEKLY_ROSTER_URL}${season}.csv`;
+  onApiCall?.();
   const response = await fetch(url);
 
   if (!response.ok) {
@@ -210,7 +214,46 @@ async function syncRosterStatusSeason(
 export async function syncRosterStatus(options?: {
   seasons?: number[];
   force?: boolean;
+  trigger?: SyncTrigger;
 }): Promise<{ total: number; seasonResults: Record<number, number> }> {
+  const trigger = options?.trigger ?? "manual";
+  const seasonScope = options?.seasons?.length
+    ? `seasons=${options.seasons.join(",")}`
+    : "seasons=all";
+  const startedAt = Date.now();
+  let apiCalls = 0;
+
+  try {
+    const result = await runSyncRosterStatus(options, () => {
+      apiCalls += 1;
+    });
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger,
+      scope: `roster-status|${seasonScope}`,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+      apiCalls,
+    });
+    return result;
+  } catch (err) {
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger,
+      scope: `roster-status|${seasonScope}`,
+      outcome: "failed",
+      durationMs: Date.now() - startedAt,
+      apiCalls,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+async function runSyncRosterStatus(
+  options: { seasons?: number[]; force?: boolean } | undefined,
+  onApiCall: () => void,
+): Promise<{ total: number; seasonResults: Record<number, number> }> {
   const force = options?.force ?? false;
   const currentYear = new Date().getFullYear();
   const seasons =
@@ -229,7 +272,7 @@ export async function syncRosterStatus(options?: {
       continue;
     }
 
-    const count = await syncRosterStatusSeason(season, force);
+    const count = await syncRosterStatusSeason(season, force, onApiCall);
     seasonResults[season] = count;
     total += count;
   }

--- a/src/services/scheduleSync.ts
+++ b/src/services/scheduleSync.ts
@@ -4,6 +4,8 @@ import {
   setNflverseWatermarkTx,
   shouldSkipSeasonSync,
 } from "@/services/nflverseWatermark";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
 
 const NFLVERSE_GAMES_URL =
   "https://github.com/nflverse/nfldata/raw/master/data/games.csv";
@@ -189,6 +191,42 @@ async function syncScheduleSeason(
  * Downloads the full games CSV once and extracts requested seasons.
  */
 export async function syncSchedule(options?: {
+  seasons?: number[];
+  force?: boolean;
+  trigger?: SyncTrigger;
+}): Promise<{ total: number; seasonResults: Record<number, number> }> {
+  const trigger = options?.trigger ?? "manual";
+  const seasonScope = options?.seasons?.length
+    ? `seasons=${options.seasons.join(",")}`
+    : "seasons=all";
+  const startedAt = Date.now();
+
+  try {
+    const result = await runSyncSchedule(options);
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger,
+      scope: `schedule|${seasonScope}`,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+      apiCalls: 1, // single CSV fetch (memoized across seasons)
+    });
+    return result;
+  } catch (err) {
+    recordSyncBreadcrumb({
+      source: "nflverse",
+      trigger,
+      scope: `schedule|${seasonScope}`,
+      outcome: "failed",
+      durationMs: Date.now() - startedAt,
+      apiCalls: 1,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+async function runSyncSchedule(options?: {
   seasons?: number[];
   force?: boolean;
 }): Promise<{ total: number; seasonResults: Record<number, number> }> {

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -14,6 +14,9 @@ import { gradeLeagueWaivers } from "@/services/waiverGrading";
 import { rollupManagerGrades } from "@/services/managerGrades";
 import { batchInsert, BATCH_SIZE } from "@/services/batchHelper";
 import { pMapSettled } from "@/lib/concurrency";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
+import { withSyncTransaction } from "@/lib/observability/withSyncTransaction";
 
 /**
  * Per-week fetch concurrency for transactions/matchups within a single season.
@@ -74,15 +77,51 @@ export async function syncLeague(
   leagueId: string,
   onProgress?: ProgressCallback,
   familyId?: string,
-  opts?: { skipGlobalSyncs?: boolean }
+  opts?: { skipGlobalSyncs?: boolean; trigger?: SyncTrigger }
+): Promise<void> {
+  const trigger = opts?.trigger ?? "manual";
+  const startedAt = Date.now();
+
+  try {
+    await withSyncTransaction(
+      `syncLeague:${leagueId}`,
+      "sync.league",
+      () => runSyncLeague(leagueId, onProgress, familyId, opts),
+    );
+    recordSyncBreadcrumb({
+      source: "league-family",
+      trigger,
+      scope: `league=${leagueId}${familyId ? `|family=${familyId}` : ""}`,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (err) {
+    recordSyncBreadcrumb({
+      source: "league-family",
+      trigger,
+      scope: `league=${leagueId}${familyId ? `|family=${familyId}` : ""}`,
+      outcome: "failed",
+      durationMs: Date.now() - startedAt,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+async function runSyncLeague(
+  leagueId: string,
+  onProgress?: ProgressCallback,
+  familyId?: string,
+  opts?: { skipGlobalSyncs?: boolean; trigger?: SyncTrigger }
 ): Promise<void> {
   const db = getDb();
   const skipGlobal = opts?.skipGlobalSyncs ?? false;
+  const trigger = opts?.trigger ?? "manual";
 
   // Ensure player metadata is available (skips if fresh)
   if (!skipGlobal) {
     onProgress?.({ step: "players", detail: "Checking player data freshness" });
-    await syncPlayers();
+    await syncPlayers(false, { trigger, scope: `league=${leagueId}` });
   }
 
   onProgress?.({ step: "league", detail: "Fetching league info" });
@@ -465,14 +504,14 @@ export async function syncLeague(
         step: "nfl_data",
         detail: `Syncing NFL roster status, injuries & schedule (${seasons.length} seasons)`,
       });
-      await syncRosterStatus({ seasons });
-      await syncInjuries({ seasons });
-      await syncSchedule({ seasons });
+      await syncRosterStatus({ seasons, trigger });
+      await syncInjuries({ seasons, trigger });
+      await syncSchedule({ seasons, trigger });
     }
 
     // Sync FantasyCalc dynasty trade values
     onProgress?.({ step: "values", detail: "Syncing dynasty trade values" });
-    await syncFantasyCalcValues(leagueId);
+    await syncFantasyCalcValues(leagueId, { trigger });
   }
 
   // Grade trades + drafts (requires familyId)
@@ -536,13 +575,55 @@ const PARALLEL_CONCURRENCY = 1;
 export async function syncLeagueFamily(
   leagueIds: string[],
   onProgress?: ProgressCallback,
-  familyId?: string
+  familyId?: string,
+  opts?: { trigger?: SyncTrigger }
+): Promise<void> {
+  const trigger = opts?.trigger ?? "manual";
+  const scope = familyId
+    ? `family=${familyId}`
+    : `leagues=${leagueIds.join(",") || "(none)"}`;
+  const startedAt = Date.now();
+
+  try {
+    await withSyncTransaction(
+      "syncLeagueFamily",
+      "sync.family",
+      () => runSyncLeagueFamily(leagueIds, onProgress, familyId, trigger),
+    );
+    recordSyncBreadcrumb({
+      source: "league-family",
+      trigger,
+      scope,
+      outcome: "success",
+      durationMs: Date.now() - startedAt,
+    });
+  } catch (err) {
+    recordSyncBreadcrumb({
+      source: "league-family",
+      trigger,
+      scope,
+      outcome: "failed",
+      durationMs: Date.now() - startedAt,
+      error: err instanceof Error ? err.message : String(err),
+    });
+    throw err;
+  }
+}
+
+async function runSyncLeagueFamily(
+  leagueIds: string[],
+  onProgress: ProgressCallback | undefined,
+  familyId: string | undefined,
+  trigger: SyncTrigger,
 ): Promise<void> {
   const db = getDb();
 
   // --- Hoisted global syncs: run once for the whole family ---
   onProgress?.({ step: "players", detail: "Checking player data freshness" });
-  await syncPlayers();
+  await syncPlayers(false, {
+    trigger,
+    scope: familyId ? `family=${familyId}` : "manual",
+  });
 
   // Gather all family seasons for nflverse sync
   const familySeasons: number[] = [];
@@ -563,15 +644,15 @@ export async function syncLeagueFamily(
       step: "nfl_data",
       detail: `Syncing NFL data (${uniqueSeasons.length} seasons)`,
     });
-    await syncRosterStatus({ seasons: uniqueSeasons });
-    await syncInjuries({ seasons: uniqueSeasons });
-    await syncSchedule({ seasons: uniqueSeasons });
+    await syncRosterStatus({ seasons: uniqueSeasons, trigger });
+    await syncInjuries({ seasons: uniqueSeasons, trigger });
+    await syncSchedule({ seasons: uniqueSeasons, trigger });
   }
 
   // FantasyCalc: sync once using the most recent league's settings
   const mostRecentLeagueId = leagueIds[leagueIds.length - 1];
   onProgress?.({ step: "values", detail: "Syncing dynasty trade values" });
-  await syncFantasyCalcValues(mostRecentLeagueId);
+  await syncFantasyCalcValues(mostRecentLeagueId, { trigger });
 
   // --- Partition into completed (parallelizable) vs in-progress (sequential) ---
   // Single batched query instead of N individual queries
@@ -633,7 +714,10 @@ export async function syncLeagueFamily(
       const batch = completedIds.slice(i, i + PARALLEL_CONCURRENCY);
       const settled = await Promise.allSettled(
         batch.map((id) =>
-          syncLeague(id, undefined, familyId, { skipGlobalSyncs: true })
+          syncLeague(id, undefined, familyId, {
+            skipGlobalSyncs: true,
+            trigger,
+          })
         )
       );
       for (let j = 0; j < settled.length; j++) {
@@ -658,6 +742,7 @@ export async function syncLeagueFamily(
     try {
       await syncLeague(activeIds[i], onProgress, familyId, {
         skipGlobalSyncs: true,
+        trigger,
       });
     } catch (err) {
       console.warn(

--- a/src/services/syncLock.ts
+++ b/src/services/syncLock.ts
@@ -1,14 +1,23 @@
 import { getDb, schema } from "@/db";
 import { eq, and, sql } from "drizzle-orm";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
 
 const STALE_JOB_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+interface AcquireSyncLockOpts {
+  /** What kicked off this run. Defaults to "manual" when omitted. */
+  trigger?: SyncTrigger;
+  /** Total stages this run will execute (chunked-stage executor — #151). */
+  stagesTotal?: number;
+}
 
 /**
  * Attempt to acquire a sync lock for a family root league ID.
  * Returns the job ID if acquired, or null if a sync is already running.
  */
 export async function acquireSyncLock(
-  familyRootId: string
+  familyRootId: string,
+  opts?: AcquireSyncLockOpts
 ): Promise<string | null> {
   const db = getDb();
 
@@ -47,13 +56,18 @@ export async function acquireSyncLock(
       )
     );
 
-  // Insert a new running job
+  // Insert a new running job. Default `trigger` to "manual" so the audit
+  // column is always populated even when a caller forgets to pass it.
   const [job] = await db
     .insert(schema.syncJobs)
     .values({
       type: "league_sync",
       ref: familyRootId,
       status: "running",
+      trigger: opts?.trigger ?? "manual",
+      apiCallsMade: 0,
+      stagesCompleted: 0,
+      stagesTotal: opts?.stagesTotal ?? null,
     })
     .returning({ id: schema.syncJobs.id });
 
@@ -61,21 +75,75 @@ export async function acquireSyncLock(
 }
 
 /**
- * Release a sync lock by updating the job status.
+ * Release a sync lock by updating the job status. Optionally records the
+ * total `apiCallsMade` and the final `stagesCompleted` for the run so the
+ * audit row reflects what the sync actually did.
  */
 export async function releaseSyncLock(
   jobId: string,
   status: "success" | "failed",
-  error?: string
+  error?: string,
+  audit?: {
+    apiCallsMade?: number;
+    stagesCompleted?: number;
+  }
 ): Promise<void> {
   const db = getDb();
 
-  await db
-    .update(schema.syncJobs)
-    .set({
-      status,
-      error: error ?? null,
-      finishedAt: new Date(),
-    })
-    .where(eq(schema.syncJobs.id, jobId));
+  const set: Record<string, unknown> = {
+    status,
+    error: error ?? null,
+    finishedAt: new Date(),
+  };
+  if (audit?.apiCallsMade != null) set.apiCallsMade = audit.apiCallsMade;
+  if (audit?.stagesCompleted != null)
+    set.stagesCompleted = audit.stagesCompleted;
+
+  await db.update(schema.syncJobs).set(set).where(eq(schema.syncJobs.id, jobId));
+}
+
+/**
+ * Increment the running tally of Sleeper API calls on a sync_jobs row.
+ * Best-effort — never throws if the update fails (we don't want
+ * observability to break the underlying sync).
+ */
+export async function incrementSyncJobApiCalls(
+  jobId: string,
+  by = 1
+): Promise<void> {
+  if (!jobId) return;
+  try {
+    const db = getDb();
+    await db
+      .update(schema.syncJobs)
+      .set({
+        apiCallsMade: sql`coalesce(${schema.syncJobs.apiCallsMade}, 0) + ${by}`,
+      })
+      .where(eq(schema.syncJobs.id, jobId));
+  } catch {
+    // Swallow — observability must never break the caller.
+  }
+}
+
+/**
+ * Update the current_stage / stages_completed audit fields. Used by the
+ * chunked-stage executor (#151) to record progress as each stage finishes.
+ */
+export async function updateSyncJobStage(
+  jobId: string,
+  currentStage: string | null,
+  stagesCompleted?: number
+): Promise<void> {
+  if (!jobId) return;
+  try {
+    const db = getDb();
+    const set: Record<string, unknown> = { currentStage };
+    if (stagesCompleted != null) set.stagesCompleted = stagesCompleted;
+    await db
+      .update(schema.syncJobs)
+      .set(set)
+      .where(eq(schema.syncJobs.id, jobId));
+  } catch {
+    // Swallow — observability must never break the caller.
+  }
 }


### PR DESCRIPTION
## Summary

Wires the Sentry breadcrumb + transaction helpers from PR #161 into every top-level sync service, extends `syncJobs` with audit columns, and adds a rolling Sleeper rate-limit utilization gauge.

Closes most of #152 (cron observability tied off in #148).

## What landed

### Breadcrumbs at every sync entry point

Every service now records a structured breadcrumb on success and `outcome: 'failed'` on error (then re-throws so callers still see the original error). All breadcrumbs gracefully no-op when no Sentry DSN is set, falling back to `console.info` for local dev legibility.

| Service | `source` | Notes |
|---|---|---|
| `syncLeagueFamily` | `league-family` | also wrapped in `withSyncTransaction` (`sync.family`) |
| `syncLeague` | `league-family` | also wrapped in `withSyncTransaction` (`sync.league`) |
| `syncPlayers` | `sleeper` | breadcrumb even on staleness-skip (audits invocation) |
| `syncFantasyCalcValuesForConfig` + `syncFantasyCalcValues` | `fantasycalc` | scope encodes the (sf, ppr, teams, qbs) combo |
| `syncSchedule` | `nflverse` | scope `schedule\|seasons=...` |
| `syncInjuries` | `nflverse` | scope `injuries\|seasons=...` |
| `syncRosterStatus` | `nflverse` | scope `roster-status\|seasons=...` |

`trigger` defaults to `manual` and propagates through `syncLeagueFamily` -> `syncLeague` -> all nested service calls. The `/api/sync/league` route (the manual UI/API entry point) explicitly stamps `trigger: 'manual'`.

### `syncJobs` audit columns (migration `0017_eminent_blue_blade.sql`)

```
trigger          TEXT             -- cron | lazy | manual
api_calls_made   INTEGER DEFAULT 0
stages_completed INTEGER DEFAULT 0
stages_total     INTEGER          -- placeholder for chunked executor (#151)
current_stage    TEXT
+ new sync_jobs_started_at_idx for 30-day retention queries
```

`acquireSyncLock` now accepts `{trigger, stagesTotal}`; `releaseSyncLock` accepts `{apiCallsMade, stagesCompleted}` for run-end audit fields. New `incrementSyncJobApiCalls(jobId, by)` and `updateSyncJobStage(jobId, currentStage, stagesCompleted?)` helpers — both swallow DB errors so observability never breaks the underlying sync.

**DO NOT run `npm run db:migrate`** — per project memory, that hits prod. The user controls when to apply this.

### Sleeper rate-limit utilization gauge (`src/lib/sleeper/rateLimit.ts`)

- `recordSleeperCall()` invoked inside `fetchWithRetry` so the gauge reflects every actual outbound call (including retries).
- Rolling 60s window of timestamps; minute-tick flush is sampled lazily on `recordSleeperCall` so there's no module-level `setInterval`.
- When DSN is set: emits `sleeper.rate_utilization_pct` + `sleeper.calls_per_minute` via `Sentry.metrics.gauge`, with a breadcrumb fallback when the metrics API isn't available.
- When DSN is unset: prints to `console.info` so local dev still sees the signal.

### Tests

- `src/services/__tests__/breadcrumbIntegration.test.ts` — every service emits success + failed breadcrumbs (and re-throws).
- `src/lib/sleeper/__tests__/rateLimit.test.ts` — rolling-window math, console + Sentry emission paths, flush cadence, error tolerance.
- `src/services/__tests__/syncLock.test.ts` — covers `trigger` defaulting, `stagesTotal` propagation, `apiCallsMade`/`stagesCompleted` audit writes, and the new `incrementSyncJobApiCalls` / `updateSyncJobStage` helpers.

## Coordination

- This PR will likely conflict with #150 (sync.ts coverage hygiene); rebase at merge time.
- Cron-route breadcrumbs land in #148 (Cron schedules); routes already use the same `recordSyncBreadcrumb` + `withSyncTransaction` helpers.

References: #152, #161

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npx jest --testPathPatterns="observability|sync|sleeper|fantasyCalc|schedule|injury|roster|player"` — 144 tests passing
- [x] `npx jest` (full suite) — 255 tests passing
- [ ] Apply migration `0017_eminent_blue_blade.sql` against prod (manual, user-controlled)
- [ ] Spot-check Sentry dashboard after merge for `sync.*` breadcrumbs + `sleeper.rate_utilization_pct` gauge

🤖 Generated with [Claude Code](https://claude.com/claude-code)