### PR TITLE
Sync 8: Chunked executor + DNA helix loading screen (#151)

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -7,8 +7,19 @@ const customJestConfig = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1',
   },
+  // ts-jest needs JSX overridden to "react-jsx" because the project's
+  // tsconfig is set to "preserve" (Next.js handles JSX itself in prod).
+  // Without this override, .test.tsx files fail to parse.
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', {
+      tsconfig: {
+        jsx: 'react-jsx',
+      },
+    }],
+  },
   testMatch: [
     '<rootDir>/src/**/__tests__/**/*.test.ts',
+    '<rootDir>/src/**/__tests__/**/*.test.tsx',
     '<rootDir>/scripts/**/__tests__/**/*.test.ts',
   ],
   // Coverage gate for the sync pipeline. Each listed file must clear 80%

--- a/src/app/(app)/league/[familyId]/layout.tsx
+++ b/src/app/(app)/league/[familyId]/layout.tsx
@@ -1,4 +1,5 @@
 import { ensureLeagueFresh } from "@/lib/freshness";
+import { ColdSyncLoadingScreen } from "@/components/loading/ColdSyncLoadingScreen";
 
 /**
  * Server-component layout for every page under `/league/[familyId]/...`.
@@ -9,16 +10,17 @@ import { ensureLeagueFresh } from "@/lib/freshness";
  *   - Fresh (within window) -> renders children immediately, no sync.
  *   - Stale (past window)   -> blocks on a watermark-incremental sync, then
  *                              renders children with fresh data.
- *   - Cold (never synced)   -> renders a minimal placeholder with the
- *                              `jobId`. The DNA-themed loading screen lives
- *                              behind #151 (Wave 3). Until it ships, the
- *                              placeholder gives the cold-visitor a stable
- *                              "we're syncing" surface; #151 will swap this
- *                              for the real chunked-progress UI.
+ *   - Cold (never synced)   -> renders the DNA-themed cold-sync loading
+ *                              screen (#151), which polls
+ *                              `/api/sync/jobs/[jobId]/tick` every 1s and
+ *                              navigates to the dashboard when the chunked
+ *                              executor reports `completed`.
  *
  * The gate is single-pass per request — `ensureLeagueFresh` short-circuits
  * cheaply when data is fresh, and concurrency is enforced by the existing
- * `syncJobs` lock.
+ * `syncJobs` lock. When the same family is being indexed by another
+ * visitor, `ensureLeagueFresh` returns the in-flight `jobId`, so both
+ * tabs share one chunked run.
  */
 export default async function LeagueFamilyLayout({
   children,
@@ -30,44 +32,15 @@ export default async function LeagueFamilyLayout({
   const result = await ensureLeagueFresh(params.familyId);
 
   if (!result.ready) {
+    // `result.familyId` is guaranteed when `ready === false` — the cold
+    // path resolves the family before deciding to lazy-sync.
     return (
-      <ColdSyncPlaceholder familyId={result.familyId} jobId={result.jobId} />
+      <ColdSyncLoadingScreen
+        familyId={result.familyId ?? params.familyId}
+        initialJobId={result.jobId}
+      />
     );
   }
 
   return <>{children}</>;
-}
-
-/**
- * Minimal placeholder shown to first-time visitors while the cold sync is
- * being kicked off. #151 (cold-start chunked executor) will replace this
- * with a polling, progress-bar UI keyed off the same `jobId`.
- *
- * Until #151 lands, we render a stable, accessible "Preparing your league"
- * surface. The `data-job-id` attribute is left for #151 to wire up.
- */
-function ColdSyncPlaceholder({
-  familyId,
-  jobId,
-}: {
-  familyId: string | null;
-  jobId?: string;
-}) {
-  return (
-    <div
-      className="min-h-[60vh] flex items-center justify-center"
-      data-family-id={familyId ?? ""}
-      data-job-id={jobId ?? ""}
-    >
-      <div className="text-center max-w-md px-6">
-        <div className="animate-pulse text-foreground text-lg font-medium mb-2">
-          Preparing your league
-        </div>
-        <p className="text-sm text-muted-foreground">
-          We&apos;re pulling in the latest data from Sleeper. This usually
-          takes 10-30 seconds for new leagues.
-        </p>
-      </div>
-    </div>
-  );
 }

--- a/src/app/api/sync/jobs/[jobId]/tick/__tests__/route.test.ts
+++ b/src/app/api/sync/jobs/[jobId]/tick/__tests__/route.test.ts
@@ -43,6 +43,11 @@ jest.mock("@/db", () => ({
 
 jest.mock("drizzle-orm", () => ({
   eq: (col: { name: string }, value: unknown) => ({ op: "eq", col, value }),
+  inArray: (col: { name: string }, values: unknown[]) => ({
+    op: "inArray",
+    col,
+    values,
+  }),
   sql: Object.assign(
     (strings: TemplateStringsArray, ...values: unknown[]) => ({
       op: "sql",
@@ -285,6 +290,53 @@ describe("POST /api/sync/jobs/[jobId]/tick", () => {
       "success",
       undefined,
       { stagesCompleted: 8 }
+    );
+  });
+
+  test("completed tick with empty leagueIds (orphan family) skips the leagues UPDATE without crashing", async () => {
+    // Reachable when a leagueFamilies row exists but leagueFamilyMembers is
+    // empty (interrupted family creation). Pre-fix this rendered
+    // `WHERE leagues.id IN ()` and Postgres rejected it as a parser error.
+    const state = makeMockDb({
+      selectResponses: [
+        [
+          {
+            id: "j-orphan",
+            ref: "root",
+            status: "running",
+            stagesCompleted: 0,
+            stagesTotal: 4,
+            currentStage: null,
+            trigger: "lazy",
+          },
+        ],
+        [{ id: "fam-orphan" }],
+        [], // empty members -> family.leagueIds is empty
+      ],
+    });
+    buildFamilyStagesMock.mockResolvedValue([
+      { key: "x", label: "x", run: jest.fn() },
+    ]);
+    runChunkMock.mockResolvedValue({
+      status: "completed",
+      stagesCompleted: 4,
+      stagesTotal: 4,
+      currentStageKey: null,
+      currentStageLabel: null,
+    });
+
+    const res = await POST(makeRequest() as never, ctx("j-orphan"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("completed");
+    // The bug was: db.update(leagues).where(IN ()) -> SQL error -> failed.
+    // After the fix, we skip the UPDATE entirely on empty leagueIds.
+    expect(state.update).not.toHaveBeenCalled();
+    expect(releaseSyncLockMock).toHaveBeenCalledWith(
+      "j-orphan",
+      "success",
+      undefined,
+      { stagesCompleted: 4 }
     );
   });
 

--- a/src/app/api/sync/jobs/[jobId]/tick/__tests__/route.test.ts
+++ b/src/app/api/sync/jobs/[jobId]/tick/__tests__/route.test.ts
@@ -1,0 +1,381 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `POST /api/sync/jobs/[jobId]/tick` (#151).
+ *
+ * Coverage:
+ *   - 404 when the job doesn't exist
+ *   - returns terminal status when the job is already success/failed
+ *   - in-progress -> drives runChunk and surfaces its result
+ *   - completed   -> releases the lock + touches lastSyncedAt
+ *   - stage failure caught -> 200 + status: "failed" + error string
+ */
+
+const stubColumn = (name: string) => ({ name });
+
+jest.mock("@/db", () => ({
+  schema: {
+    syncJobs: {
+      id: stubColumn("id"),
+      ref: stubColumn("ref"),
+      status: stubColumn("status"),
+      stagesCompleted: stubColumn("stages_completed"),
+      stagesTotal: stubColumn("stages_total"),
+      currentStage: stubColumn("current_stage"),
+      trigger: stubColumn("trigger"),
+    },
+    leagueFamilies: {
+      id: stubColumn("id"),
+      rootLeagueId: stubColumn("root_league_id"),
+    },
+    leagueFamilyMembers: {
+      familyId: stubColumn("family_id"),
+      leagueId: stubColumn("league_id"),
+      season: stubColumn("season"),
+    },
+    leagues: {
+      id: stubColumn("id"),
+      lastSyncedAt: stubColumn("last_synced_at"),
+    },
+  },
+  getDb: jest.fn(),
+}));
+
+jest.mock("drizzle-orm", () => ({
+  eq: (col: { name: string }, value: unknown) => ({ op: "eq", col, value }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      op: "sql",
+      strings: Array.from(strings),
+      values,
+    }),
+    {
+      raw: (s: string) => s,
+      join: (parts: unknown[], sep: unknown) => ({
+        op: "join",
+        parts,
+        sep,
+      }),
+    }
+  ),
+}));
+
+const releaseSyncLockMock = jest.fn();
+jest.mock("@/services/syncLock", () => ({
+  releaseSyncLock: (...args: unknown[]) => releaseSyncLockMock(...args),
+}));
+
+const buildFamilyStagesMock = jest.fn();
+const runChunkMock = jest.fn();
+jest.mock("@/services/chunkedSync", () => ({
+  buildFamilyStages: (...args: unknown[]) => buildFamilyStagesMock(...args),
+  runChunk: (...args: unknown[]) => runChunkMock(...args),
+}));
+
+jest.mock("@/lib/observability/syncBreadcrumb", () => ({
+  recordSyncBreadcrumb: jest.fn(),
+}));
+
+jest.mock("@/lib/observability/withSyncTransaction", () => ({
+  withSyncTransaction: (
+    _name: string,
+    _op: string,
+    fn: () => unknown
+  ) => fn(),
+}));
+
+import { getDb } from "@/db";
+import { POST } from "../route";
+
+const mockedGetDb = getDb as jest.MockedFunction<typeof getDb>;
+
+interface DbScript {
+  selectResponses: unknown[][];
+  /** Whether `update(...)` should resolve OK (default true). */
+  updateOk?: boolean;
+}
+
+function makeMockDb(script: DbScript) {
+  const queue = [...script.selectResponses];
+  /**
+   * Build a `where(...)` result that is BOTH a thenable (drizzle queries
+   * are awaitable directly) AND exposes a `.limit()` for the chains that
+   * need it. Each consumed chain pulls the next response off the queue.
+   */
+  const makeWhereResult = () => {
+    const result: Record<string, unknown> = {
+      then: (resolve: (v: unknown) => void) =>
+        resolve(queue.shift() ?? []),
+      limit: () => Promise.resolve(queue.shift() ?? []),
+    };
+    return result;
+  };
+  const dbStub = {
+    select: jest.fn(() => ({
+      from: () => ({
+        where: () => makeWhereResult(),
+      }),
+    })),
+    update: jest.fn(() => ({
+      set: () => ({
+        where: () => Promise.resolve(undefined),
+      }),
+    })),
+  };
+  mockedGetDb.mockReturnValue(dbStub as unknown as ReturnType<typeof getDb>);
+  return dbStub;
+}
+
+function makeRequest(): Request {
+  return new Request("http://localhost/api/sync/jobs/job-1/tick", {
+    method: "POST",
+  });
+}
+
+const ctx = (jobId: string) => ({ params: { jobId } });
+
+describe("POST /api/sync/jobs/[jobId]/tick", () => {
+  beforeEach(() => {
+    releaseSyncLockMock.mockReset();
+    buildFamilyStagesMock.mockReset();
+    runChunkMock.mockReset();
+    mockedGetDb.mockReset();
+  });
+
+  test("404 when job doesn't exist", async () => {
+    makeMockDb({ selectResponses: [[]] });
+    const res = await POST(makeRequest() as never, ctx("missing"));
+    expect(res.status).toBe(404);
+  });
+
+  test("returns completed when job already succeeded", async () => {
+    makeMockDb({
+      selectResponses: [
+        [
+          {
+            id: "j1",
+            ref: "root",
+            status: "success",
+            stagesCompleted: 8,
+            stagesTotal: 8,
+            currentStage: null,
+            trigger: "lazy",
+          },
+        ],
+      ],
+    });
+    const res = await POST(makeRequest() as never, ctx("j1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      status: "completed",
+      stagesCompleted: 8,
+      stagesTotal: 8,
+    });
+    // Should not have rebuilt stages or kicked off chunked work.
+    expect(buildFamilyStagesMock).not.toHaveBeenCalled();
+  });
+
+  test("returns failed when the job is already in failed state", async () => {
+    makeMockDb({
+      selectResponses: [
+        [
+          {
+            id: "j1",
+            ref: "root",
+            status: "failed",
+            stagesCompleted: 2,
+            stagesTotal: 8,
+            currentStage: "season 2 of 5",
+            trigger: "lazy",
+          },
+        ],
+      ],
+    });
+    const res = await POST(makeRequest() as never, ctx("j1"));
+    const body = await res.json();
+    expect(body.status).toBe("failed");
+    expect(body.stagesCompleted).toBe(2);
+  });
+
+  test("happy in-progress tick -> surfaces runChunk progress", async () => {
+    makeMockDb({
+      selectResponses: [
+        // job lookup
+        [
+          {
+            id: "j1",
+            ref: "root",
+            status: "running",
+            stagesCompleted: 0,
+            stagesTotal: null,
+            currentStage: null,
+            trigger: "lazy",
+          },
+        ],
+        // family-by-rootLeagueId
+        [{ id: "fam-1" }],
+        // members
+        [
+          { leagueId: "l-2022", season: "2022" },
+          { leagueId: "l-2023", season: "2023" },
+        ],
+      ],
+    });
+    buildFamilyStagesMock.mockResolvedValue([
+      { key: "players", label: "Refreshing player metadata", run: jest.fn() },
+      { key: "season:2022", label: "season 1 of 2", run: jest.fn() },
+    ]);
+    runChunkMock.mockResolvedValue({
+      status: "in_progress",
+      stagesCompleted: 1,
+      stagesTotal: 2,
+      currentStageKey: "season:2022",
+      currentStageLabel: "season 1 of 2",
+    });
+
+    const res = await POST(makeRequest() as never, ctx("j1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      status: "in_progress",
+      stagesCompleted: 1,
+      stagesTotal: 2,
+      currentStageLabel: "season 1 of 2",
+    });
+    expect(releaseSyncLockMock).not.toHaveBeenCalled();
+  });
+
+  test("completed tick -> releases lock and returns completed status", async () => {
+    makeMockDb({
+      selectResponses: [
+        [
+          {
+            id: "j1",
+            ref: "root",
+            status: "running",
+            stagesCompleted: 7,
+            stagesTotal: 8,
+            currentStage: "manager-grades",
+            trigger: "lazy",
+          },
+        ],
+        [{ id: "fam-1" }],
+        [
+          { leagueId: "l-1", season: "2022" },
+          { leagueId: "l-2", season: "2023" },
+        ],
+      ],
+    });
+    buildFamilyStagesMock.mockResolvedValue([{ key: "x", label: "x", run: jest.fn() }]);
+    runChunkMock.mockResolvedValue({
+      status: "completed",
+      stagesCompleted: 8,
+      stagesTotal: 8,
+      currentStageKey: null,
+      currentStageLabel: null,
+    });
+
+    const res = await POST(makeRequest() as never, ctx("j1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("completed");
+    expect(releaseSyncLockMock).toHaveBeenCalledWith(
+      "j1",
+      "success",
+      undefined,
+      { stagesCompleted: 8 }
+    );
+  });
+
+  test("stage failure -> caught, lock released as failed, 200 with error", async () => {
+    makeMockDb({
+      selectResponses: [
+        [
+          {
+            id: "j1",
+            ref: "root",
+            status: "running",
+            stagesCompleted: 0,
+            stagesTotal: null,
+            currentStage: null,
+            trigger: "lazy",
+          },
+        ],
+        [{ id: "fam-1" }],
+        [{ leagueId: "l-1", season: "2022" }],
+        // After failure: re-read for accurate progress.
+        [
+          {
+            stagesCompleted: 1,
+            stagesTotal: 8,
+            currentStage: "season 2 of 2",
+          },
+        ],
+      ],
+    });
+    buildFamilyStagesMock.mockResolvedValue([{ key: "x", label: "x", run: jest.fn() }]);
+    runChunkMock.mockRejectedValue(new Error("Sleeper rate limit exceeded"));
+
+    const res = await POST(makeRequest() as never, ctx("j1"));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.status).toBe("failed");
+    expect(body.error).toMatch(/Sleeper/);
+    expect(releaseSyncLockMock).toHaveBeenCalledWith(
+      "j1",
+      "failed",
+      "Sleeper rate limit exceeded"
+    );
+  });
+
+  test("missing ref -> fails fast and releases lock", async () => {
+    makeMockDb({
+      selectResponses: [
+        [
+          {
+            id: "j1",
+            ref: null,
+            status: "running",
+            stagesCompleted: 0,
+            stagesTotal: null,
+            currentStage: null,
+            trigger: "lazy",
+          },
+        ],
+      ],
+    });
+    const res = await POST(makeRequest() as never, ctx("j1"));
+    const body = await res.json();
+    expect(body.status).toBe("failed");
+    expect(releaseSyncLockMock).toHaveBeenCalledWith(
+      "j1",
+      "failed",
+      expect.stringMatching(/missing ref/i)
+    );
+  });
+
+  test("family not found -> fails fast and releases lock", async () => {
+    makeMockDb({
+      selectResponses: [
+        [
+          {
+            id: "j1",
+            ref: "root",
+            status: "running",
+            stagesCompleted: 0,
+            stagesTotal: null,
+            currentStage: null,
+            trigger: "lazy",
+          },
+        ],
+        [], // family-by-rootLeagueId returns nothing
+        [], // member fallback also returns nothing
+      ],
+    });
+    const res = await POST(makeRequest() as never, ctx("j1"));
+    const body = await res.json();
+    expect(body.status).toBe("failed");
+    expect(releaseSyncLockMock).toHaveBeenCalled();
+  });
+});

--- a/src/app/api/sync/jobs/[jobId]/tick/route.ts
+++ b/src/app/api/sync/jobs/[jobId]/tick/route.ts
@@ -1,0 +1,274 @@
+/**
+ * POST /api/sync/jobs/[jobId]/tick (#151)
+ *
+ * Cold-start chunked executor entry point. The cold-sync loading screen
+ * (#151) hits this every ~1s. Each call:
+ *
+ *   1. Looks up the job + its family (`syncJobs.ref` is the root league
+ *      id; we resolve back to the family from there).
+ *   2. Builds the chunked stage list (deterministic — same shape every
+ *      tick).
+ *   3. Runs stages until the 25s budget is exhausted, then returns the
+ *      current cursor + label so the client can update the helix copy.
+ *   4. On the final stage, releases the sync lock + returns
+ *      `status: "completed"`.
+ *
+ * Why 25s budget when Vercel allows 30s: we leave a 5s safety margin so a
+ * stage that overruns its expected duration still has time to record its
+ * watermark / progress before the function is killed. The next tick picks
+ * up cleanly.
+ *
+ * Idempotency: every chunked stage is gated on its own watermark or
+ * upsert-on-conflict path. Re-running a stage after a partial completion
+ * is a no-op once data is in. Closing the tab and coming back resumes
+ * from the persisted cursor.
+ *
+ * Errors:
+ *   - 404 if the job doesn't exist
+ *   - 410 if the job already completed / failed (the client should stop
+ *     polling and route to the dashboard)
+ *   - 200 with `status: "failed"` on a soft failure during stage
+ *     execution — we record the error on the audit row and surface a
+ *     non-throwing payload so the loading screen can render an inline
+ *     retry hint.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { eq, sql } from "drizzle-orm";
+import { getDb, schema } from "@/db";
+import { releaseSyncLock } from "@/services/syncLock";
+import { buildFamilyStages, runChunk } from "@/services/chunkedSync";
+import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
+import { withSyncTransaction } from "@/lib/observability/withSyncTransaction";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+export const maxDuration = 30;
+
+/**
+ * Per-tick wallclock budget. 25s leaves a 5s safety margin under the
+ * Vercel 30s function cap. Stages are checked between executions so we
+ * never abort mid-stage.
+ */
+const TICK_BUDGET_MS = 25_000;
+
+interface TickResponse {
+  status: "in_progress" | "completed" | "failed";
+  stagesCompleted: number;
+  stagesTotal: number;
+  currentStageLabel: string | null;
+  error?: string | null;
+}
+
+/** Resolve the family that owns this `syncJobs.ref` (== family root league id). */
+async function getFamilyForRef(
+  ref: string
+): Promise<{ familyId: string; leagueIds: string[] } | null> {
+  const db = getDb();
+
+  // 1) Family lookup by rootLeagueId.
+  const familyRow = await db
+    .select({ id: schema.leagueFamilies.id })
+    .from(schema.leagueFamilies)
+    .where(eq(schema.leagueFamilies.rootLeagueId, ref))
+    .limit(1);
+
+  let familyId = familyRow[0]?.id ?? null;
+
+  // 2) Fallback: the ref is itself a member league id (rare but possible
+  //    when a family was created without a populated rootLeagueId).
+  if (!familyId) {
+    const memberRow = await db
+      .select({ familyId: schema.leagueFamilyMembers.familyId })
+      .from(schema.leagueFamilyMembers)
+      .where(eq(schema.leagueFamilyMembers.leagueId, ref))
+      .limit(1);
+    familyId = memberRow[0]?.familyId ?? null;
+  }
+
+  if (!familyId) return null;
+
+  const members = await db
+    .select({
+      leagueId: schema.leagueFamilyMembers.leagueId,
+      season: schema.leagueFamilyMembers.season,
+    })
+    .from(schema.leagueFamilyMembers)
+    .where(eq(schema.leagueFamilyMembers.familyId, familyId));
+
+  const leagueIds = members
+    .sort((a, b) => Number(a.season) - Number(b.season))
+    .map((m) => m.leagueId);
+
+  return { familyId, leagueIds };
+}
+
+export async function POST(
+  _req: NextRequest,
+  { params }: { params: { jobId: string } }
+) {
+  const { jobId } = params;
+  if (!jobId) {
+    return NextResponse.json(
+      { error: "jobId is required" },
+      { status: 400 }
+    );
+  }
+
+  const db = getDb();
+  const [job] = await db
+    .select({
+      id: schema.syncJobs.id,
+      ref: schema.syncJobs.ref,
+      status: schema.syncJobs.status,
+      stagesCompleted: schema.syncJobs.stagesCompleted,
+      stagesTotal: schema.syncJobs.stagesTotal,
+      currentStage: schema.syncJobs.currentStage,
+      trigger: schema.syncJobs.trigger,
+    })
+    .from(schema.syncJobs)
+    .where(eq(schema.syncJobs.id, jobId))
+    .limit(1);
+
+  if (!job) {
+    return NextResponse.json({ error: "Unknown job" }, { status: 404 });
+  }
+
+  // If the job already completed or failed, return the terminal state so
+  // the client stops polling. We use 200 + status field rather than 410
+  // so the loading screen can render the final label without a special
+  // error code path.
+  if (job.status !== "running") {
+    const payload: TickResponse = {
+      status: job.status === "success" ? "completed" : "failed",
+      stagesCompleted: job.stagesCompleted ?? 0,
+      stagesTotal: job.stagesTotal ?? 0,
+      currentStageLabel: job.currentStage ?? null,
+    };
+    return NextResponse.json(payload);
+  }
+
+  if (!job.ref) {
+    await releaseSyncLock(jobId, "failed", "syncJobs row missing ref");
+    return NextResponse.json(
+      {
+        status: "failed",
+        stagesCompleted: 0,
+        stagesTotal: 0,
+        currentStageLabel: null,
+        error: "Job is missing its family ref",
+      } satisfies TickResponse,
+      { status: 200 }
+    );
+  }
+
+  const family = await getFamilyForRef(job.ref);
+  if (!family) {
+    await releaseSyncLock(jobId, "failed", "Family not found for job ref");
+    return NextResponse.json(
+      {
+        status: "failed",
+        stagesCompleted: job.stagesCompleted ?? 0,
+        stagesTotal: job.stagesTotal ?? 0,
+        currentStageLabel: null,
+        error: "Family not found",
+      } satisfies TickResponse,
+      { status: 200 }
+    );
+  }
+
+  const startedAt = Date.now();
+  const stages = await buildFamilyStages(family.familyId, family.leagueIds, {
+    trigger: "lazy",
+  });
+
+  const deadlineAt = startedAt + TICK_BUDGET_MS;
+
+  recordSyncBreadcrumb({
+    source: "league-family",
+    trigger: "lazy",
+    scope: `chunked-tick:${family.familyId}`,
+    outcome: "success",
+  });
+
+  try {
+    const result = await withSyncTransaction(
+      "chunked-tick",
+      "sync.family",
+      () => runChunk(jobId, stages, { deadlineAt })
+    );
+
+    if (result.status === "completed") {
+      // Touch each league's lastSyncedAt so the freshness gate sees a
+      // fresh family on the very next request. The per-stage syncLeague
+      // call already does this for seasons it visits, but on a fully-
+      // resumed family every stage may have been a watermark no-op — in
+      // that case we still want the row marked fresh.
+      await db
+        .update(schema.leagues)
+        .set({ lastSyncedAt: new Date() })
+        .where(sql`${schema.leagues.id} IN (${sql.join(family.leagueIds.map((id) => sql`${id}`), sql`, `)})`);
+
+      await releaseSyncLock(jobId, "success", undefined, {
+        stagesCompleted: result.stagesCompleted,
+      });
+
+      recordSyncBreadcrumb({
+        source: "league-family",
+        trigger: "lazy",
+        scope: `chunked-complete:${family.familyId}`,
+        durationMs: Date.now() - startedAt,
+        outcome: "success",
+      });
+
+      return NextResponse.json({
+        status: "completed",
+        stagesCompleted: result.stagesCompleted,
+        stagesTotal: result.stagesTotal,
+        currentStageLabel: null,
+      } satisfies TickResponse);
+    }
+
+    return NextResponse.json({
+      status: "in_progress",
+      stagesCompleted: result.stagesCompleted,
+      stagesTotal: result.stagesTotal,
+      currentStageLabel: result.currentStageLabel,
+    } satisfies TickResponse);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    await releaseSyncLock(jobId, "failed", message);
+
+    recordSyncBreadcrumb({
+      source: "league-family",
+      trigger: "lazy",
+      scope: `chunked-failed:${family.familyId}`,
+      durationMs: Date.now() - startedAt,
+      outcome: "failed",
+      error: message,
+    });
+
+    // Re-read the cursor so the client gets accurate progress on the
+    // failed payload (release didn't bump it).
+    const [after] = await db
+      .select({
+        stagesCompleted: schema.syncJobs.stagesCompleted,
+        stagesTotal: schema.syncJobs.stagesTotal,
+        currentStage: schema.syncJobs.currentStage,
+      })
+      .from(schema.syncJobs)
+      .where(eq(schema.syncJobs.id, jobId))
+      .limit(1);
+
+    return NextResponse.json(
+      {
+        status: "failed",
+        stagesCompleted: after?.stagesCompleted ?? 0,
+        stagesTotal: after?.stagesTotal ?? stages.length,
+        currentStageLabel: after?.currentStage ?? null,
+        error: message,
+      } satisfies TickResponse,
+      { status: 200 }
+    );
+  }
+}

--- a/src/app/api/sync/jobs/[jobId]/tick/route.ts
+++ b/src/app/api/sync/jobs/[jobId]/tick/route.ts
@@ -34,7 +34,7 @@
  */
 
 import { NextRequest, NextResponse } from "next/server";
-import { eq, sql } from "drizzle-orm";
+import { eq, inArray, sql } from "drizzle-orm";
 import { getDb, schema } from "@/db";
 import { releaseSyncLock } from "@/services/syncLock";
 import { buildFamilyStages, runChunk } from "@/services/chunkedSync";
@@ -184,12 +184,11 @@ export async function POST(
 
   const deadlineAt = startedAt + TICK_BUDGET_MS;
 
-  recordSyncBreadcrumb({
-    source: "league-family",
-    trigger: "lazy",
-    scope: `chunked-tick:${family.familyId}`,
-    outcome: "success",
-  });
+  // No "tick started" breadcrumb here — `withSyncTransaction` records the
+  // start signal natively, and the chunked-complete / chunked-failed
+  // breadcrumbs below capture the terminal outcome. A leading
+  // outcome:"success" breadcrumb (per the SyncOutcome contract) would
+  // misrepresent unfinished work as complete.
 
   try {
     const result = await withSyncTransaction(
@@ -203,11 +202,16 @@ export async function POST(
       // fresh family on the very next request. The per-stage syncLeague
       // call already does this for seasons it visits, but on a fully-
       // resumed family every stage may have been a watermark no-op — in
-      // that case we still want the row marked fresh.
-      await db
-        .update(schema.leagues)
-        .set({ lastSyncedAt: new Date() })
-        .where(sql`${schema.leagues.id} IN (${sql.join(family.leagueIds.map((id) => sql`${id}`), sql`, `)})`);
+      // that case we still want the row marked fresh. `inArray` short-
+      // circuits to a no-op predicate on an empty list, which protects
+      // against an orphan family (members table empty) producing
+      // `WHERE id IN ()` — a Postgres parser error.
+      if (family.leagueIds.length > 0) {
+        await db
+          .update(schema.leagues)
+          .set({ lastSyncedAt: new Date() })
+          .where(inArray(schema.leagues.id, family.leagueIds));
+      }
 
       await releaseSyncLock(jobId, "success", undefined, {
         stagesCompleted: result.stagesCompleted,

--- a/src/app/api/sync/start/__tests__/route.test.ts
+++ b/src/app/api/sync/start/__tests__/route.test.ts
@@ -1,0 +1,211 @@
+/**
+ * @jest-environment node
+ *
+ * Tests for `POST /api/sync/start` (#151).
+ *
+ * The route is a thin idempotent wrapper around the existing
+ * `acquireSyncLock` helper — it just makes sure a `syncJobs` row exists
+ * for the family so the cold-sync loading screen has something to poll.
+ *
+ * Coverage:
+ *   - 400 on missing / invalid body
+ *   - 404 on unknown familyId
+ *   - 200 + new jobId on success
+ *   - 200 + existing jobId on a non-stale running job (reuse semantics)
+ */
+
+const stubColumn = (name: string) => ({ name });
+
+jest.mock("@/db", () => ({
+  schema: {
+    syncJobs: {
+      id: stubColumn("id"),
+      ref: stubColumn("ref"),
+      status: stubColumn("status"),
+      startedAt: stubColumn("started_at"),
+    },
+    leagueFamilies: {
+      id: stubColumn("id"),
+      rootLeagueId: stubColumn("root_league_id"),
+    },
+    leagueFamilyMembers: {
+      familyId: stubColumn("family_id"),
+      leagueId: stubColumn("league_id"),
+      season: stubColumn("season"),
+    },
+  },
+  getDb: jest.fn(),
+}));
+
+jest.mock("drizzle-orm", () => ({
+  eq: (col: { name: string }, value: unknown) => ({ op: "eq", col, value }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      op: "sql",
+      strings: Array.from(strings),
+      values,
+    }),
+    {
+      raw: (s: string) => s,
+    }
+  ),
+}));
+
+const resolveFamilyMock = jest.fn();
+jest.mock("@/lib/familyResolution", () => ({
+  resolveFamily: (id: string) => resolveFamilyMock(id),
+}));
+
+const acquireSyncLockMock = jest.fn();
+jest.mock("@/services/syncLock", () => ({
+  acquireSyncLock: (...args: unknown[]) => acquireSyncLockMock(...args),
+}));
+
+import { getDb } from "@/db";
+import { POST } from "../route";
+
+const mockedGetDb = getDb as jest.MockedFunction<typeof getDb>;
+
+interface DbScript {
+  /** Sequential responses for `select(...).from(...).where(...).limit(...)` chains. */
+  selectResponses: unknown[][];
+}
+
+function makeMockDb(script: DbScript) {
+  const queue = [...script.selectResponses];
+  const dbStub = {
+    select: jest.fn(() => ({
+      from: () => ({
+        where: () => {
+          const limitFn = () => Promise.resolve(queue.shift() ?? []);
+          return {
+            limit: limitFn,
+            orderBy: () => ({ limit: limitFn }),
+          };
+        },
+      }),
+    })),
+  };
+  mockedGetDb.mockReturnValue(dbStub as unknown as ReturnType<typeof getDb>);
+}
+
+function makeRequest(body: unknown): Request {
+  return new Request("http://localhost/api/sync/start", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: typeof body === "string" ? body : JSON.stringify(body),
+  });
+}
+
+describe("POST /api/sync/start", () => {
+  beforeEach(() => {
+    resolveFamilyMock.mockReset();
+    acquireSyncLockMock.mockReset();
+    mockedGetDb.mockReset();
+  });
+
+  test("400 when body is missing familyId", async () => {
+    const res = await POST(makeRequest({}) as never);
+    expect(res.status).toBe(400);
+  });
+
+  test("400 when body is invalid JSON", async () => {
+    const res = await POST(makeRequest("not-json{") as never);
+    expect(res.status).toBe(400);
+  });
+
+  test("404 when family cannot be resolved", async () => {
+    resolveFamilyMock.mockResolvedValue(null);
+    const res = await POST(
+      makeRequest({ familyId: "unknown-id" }) as never
+    );
+    expect(res.status).toBe(404);
+  });
+
+  test("200 + new jobId on cold path", async () => {
+    resolveFamilyMock.mockResolvedValue("fam-uuid");
+    makeMockDb({
+      selectResponses: [
+        // getFamilyRootRef -> family lookup returns rootLeagueId
+        [{ rootLeagueId: "root-league-1" }],
+        // findRunningJobId -> no in-flight job
+        [],
+      ],
+    });
+    acquireSyncLockMock.mockResolvedValue("new-job-id");
+
+    const res = await POST(
+      makeRequest({ familyId: "root-league-1" }) as never
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      jobId: "new-job-id",
+      familyId: "fam-uuid",
+      reused: false,
+    });
+    expect(acquireSyncLockMock).toHaveBeenCalledWith("root-league-1", {
+      trigger: "lazy",
+    });
+  });
+
+  test("200 + existing jobId when an in-flight job is found (reuse)", async () => {
+    resolveFamilyMock.mockResolvedValue("fam-uuid");
+    makeMockDb({
+      selectResponses: [
+        [{ rootLeagueId: "root-league-2" }],
+        [{ id: "in-flight-job" }],
+      ],
+    });
+
+    const res = await POST(
+      makeRequest({ familyId: "root-league-2" }) as never
+    );
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({
+      jobId: "in-flight-job",
+      familyId: "fam-uuid",
+      reused: true,
+    });
+    // Did NOT acquire a fresh lock — we reused.
+    expect(acquireSyncLockMock).not.toHaveBeenCalled();
+  });
+
+  test("falls back to most-recent member when family has no rootLeagueId", async () => {
+    resolveFamilyMock.mockResolvedValue("fam-uuid");
+    makeMockDb({
+      selectResponses: [
+        // family row exists but rootLeagueId is null
+        [{ rootLeagueId: null }],
+        // member fallback returns the most-recent league
+        [{ leagueId: "most-recent-league", season: "2024" }],
+        // findRunningJobId
+        [],
+      ],
+    });
+    acquireSyncLockMock.mockResolvedValue("job-from-fallback");
+
+    const res = await POST(
+      makeRequest({ familyId: "fam-uuid" }) as never
+    );
+    expect(res.status).toBe(200);
+    expect(acquireSyncLockMock).toHaveBeenCalledWith("most-recent-league", {
+      trigger: "lazy",
+    });
+  });
+
+  test("404 when family has no member leagues at all", async () => {
+    resolveFamilyMock.mockResolvedValue("fam-uuid");
+    makeMockDb({
+      selectResponses: [
+        [{ rootLeagueId: null }],
+        [], // no members
+      ],
+    });
+    const res = await POST(
+      makeRequest({ familyId: "fam-uuid" }) as never
+    );
+    expect(res.status).toBe(404);
+  });
+});

--- a/src/app/api/sync/start/route.ts
+++ b/src/app/api/sync/start/route.ts
@@ -1,0 +1,130 @@
+/**
+ * POST /api/sync/start (#151)
+ *
+ * Allocates (or reuses) a `syncJobs` row for a family so the cold-start
+ * loading screen can poll a stable `jobId`. Idempotent by design:
+ *
+ *   - If a non-stale `running` job already exists for the family root,
+ *     return its id. Two visitors hitting `/league/[familyId]` at the
+ *     same time share one job; both get the same progress.
+ *   - Otherwise, acquire a new lock with `trigger: "lazy"` and hand back
+ *     the new id.
+ *
+ * The actual chunked work happens in `/api/sync/jobs/[jobId]/tick` — this
+ * route just guarantees the row exists so the client has something to
+ * poll.
+ *
+ * Body: `{ familyId: string }` — accepts any of the forms understood by
+ * `resolveFamily` (uuid, root league id, member league id).
+ *
+ * Errors:
+ *   - 400: missing or unresolvable familyId
+ *   - 500: unexpected — never expose stack traces
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { eq, sql } from "drizzle-orm";
+import { resolveFamily } from "@/lib/familyResolution";
+import { getDb, schema } from "@/db";
+import { acquireSyncLock } from "@/services/syncLock";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const STALE_MS = 10 * 60 * 1000;
+
+async function findRunningJobId(ref: string): Promise<string | null> {
+  const db = getDb();
+  const staleThreshold = new Date(Date.now() - STALE_MS);
+  const rows = await db
+    .select({ id: schema.syncJobs.id })
+    .from(schema.syncJobs)
+    .where(
+      sql`${schema.syncJobs.ref} = ${ref} AND ${schema.syncJobs.status} = 'running' AND ${schema.syncJobs.startedAt} > ${staleThreshold}`
+    )
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+async function getFamilyRootRef(familyId: string): Promise<string | null> {
+  const db = getDb();
+  const family = await db
+    .select({ rootLeagueId: schema.leagueFamilies.rootLeagueId })
+    .from(schema.leagueFamilies)
+    .where(eq(schema.leagueFamilies.id, familyId))
+    .limit(1);
+  if (family.length > 0 && family[0].rootLeagueId) {
+    return family[0].rootLeagueId;
+  }
+  // Fallback: use the most-recent member league.
+  const members = await db
+    .select({
+      leagueId: schema.leagueFamilyMembers.leagueId,
+      season: schema.leagueFamilyMembers.season,
+    })
+    .from(schema.leagueFamilyMembers)
+    .where(eq(schema.leagueFamilyMembers.familyId, familyId))
+    .orderBy(sql`${schema.leagueFamilyMembers.season} DESC`)
+    .limit(1);
+  return members[0]?.leagueId ?? null;
+}
+
+export async function POST(req: NextRequest) {
+  let body: { familyId?: string } = {};
+  try {
+    body = (await req.json()) as { familyId?: string };
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON body" },
+      { status: 400 }
+    );
+  }
+
+  const { familyId: input } = body;
+  if (!input || typeof input !== "string") {
+    return NextResponse.json(
+      { error: "familyId is required" },
+      { status: 400 }
+    );
+  }
+
+  const familyId = await resolveFamily(input);
+  if (!familyId) {
+    return NextResponse.json(
+      { error: "Unknown family" },
+      { status: 404 }
+    );
+  }
+
+  const ref = await getFamilyRootRef(familyId);
+  if (!ref) {
+    return NextResponse.json(
+      { error: "Family has no member leagues" },
+      { status: 404 }
+    );
+  }
+
+  // Reuse an in-flight job if one exists. The chunked tick route is
+  // idempotent on resume, so two callers polling the same jobId is fine.
+  const existing = await findRunningJobId(ref);
+  if (existing) {
+    return NextResponse.json({ jobId: existing, familyId, reused: true });
+  }
+
+  const jobId = await acquireSyncLock(ref, { trigger: "lazy" });
+  if (!jobId) {
+    // Race: someone else acquired between our find + acquire. Look it up
+    // again so the client never sees a 409 here — the tick loop will
+    // resume the in-flight job.
+    const racy = await findRunningJobId(ref);
+    if (racy) {
+      return NextResponse.json({ jobId: racy, familyId, reused: true });
+    }
+    return NextResponse.json(
+      { error: "Failed to acquire sync lock" },
+      { status: 500 }
+    );
+  }
+
+  return NextResponse.json({ jobId, familyId, reused: false });
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -178,6 +178,44 @@
     }
   }
 
+  /* DNA helix loading animation (#151).
+     The container slowly rotates around its Y axis to suggest the helix's
+     3D twist. Reduced-motion stops rotation; only the base-pair pulse remains.
+     12s linear infinite is intentionally calm — this is a "we're working"
+     surface, not a progress spinner. */
+  .dna-helix-3d {
+    perspective: 800px;
+  }
+  .dna-helix-rotor {
+    transform-style: preserve-3d;
+    animation: dna-helix-rotate 12s linear infinite;
+    will-change: transform;
+  }
+  .dna-helix-pulse {
+    animation: dna-helix-pulse 3.6s ease-in-out infinite;
+  }
+  @keyframes dna-helix-rotate {
+    from {
+      transform: rotateY(0deg);
+    }
+    to {
+      transform: rotateY(360deg);
+    }
+  }
+  @keyframes dna-helix-pulse {
+    0%, 100% {
+      opacity: 0.55;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .dna-helix-rotor {
+      animation: none;
+    }
+  }
+
   /* Soft sage shimmer for tip text. Uses background-clip:text so the
      gradient animates across the glyph fills rather than the box. */
   .tip-shimmer {

--- a/src/components/loading/ColdSyncLoadingScreen.tsx
+++ b/src/components/loading/ColdSyncLoadingScreen.tsx
@@ -1,0 +1,276 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { DnaHelix } from "./DnaHelix";
+
+/**
+ * Cold-sync loading screen (#151).
+ *
+ * Drives the chunked-tick polling loop that turns first-time indexing into
+ * a brand moment:
+ *
+ *   1. Mount: kick off `POST /api/sync/start` with `{ familyId }` to make
+ *      sure a `syncJobs` row exists. The route returns the canonical
+ *      `jobId` (whether brand-new or already in flight).
+ *   2. Every `POLL_MS` ms, call `POST /api/sync/jobs/[jobId]/tick`. The
+ *      tick route enforces its own 25s execution budget and is idempotent
+ *      via watermarks — closing the tab and coming back picks up cleanly.
+ *   3. When the tick reports `status: "completed"` we navigate to the
+ *      league dashboard. On `failed` we surface the error inline (the
+ *      route still returns 200; the user can manually retry by reloading).
+ *
+ * Accessibility:
+ *   - `role="status"` + `aria-live="polite"` on the progress wrapper so the
+ *     stage label is announced as it changes.
+ *   - The helix itself is decorative — its `role="img"` is set inside
+ *     `DnaHelix`.
+ *   - Reduced-motion is respected by the helix component itself.
+ *
+ * The component never throws — network failures during polling are
+ * collapsed into "unable to reach the server" copy and the loop continues
+ * with a small backoff. Cold sync is the user's first impression; we'd
+ * rather absorb a transient error than blank-screen them.
+ */
+
+interface ColdSyncLoadingScreenProps {
+  familyId: string;
+  /**
+   * Optional jobId hint from the server (when the layout already had one).
+   * If omitted we'll let the start route allocate one.
+   */
+  initialJobId?: string;
+}
+
+interface TickResponse {
+  status: "in_progress" | "completed" | "failed";
+  stagesCompleted: number;
+  stagesTotal: number;
+  currentStageLabel: string | null;
+  error?: string | null;
+}
+
+const POLL_MS = 1000;
+const ERROR_BACKOFF_MS = 3000;
+const DEFAULT_TOTAL_STAGES = 8; // optimistic placeholder until first tick
+
+/**
+ * Convert a stage key like `"2024:transactions"` into a friendly label.
+ * The tick route is the source of truth — this is just the on-mount /
+ * idle-stage fallback before we have a label.
+ */
+function defaultStageLabel(): string {
+  return "Sequencing seasons";
+}
+
+export function ColdSyncLoadingScreen({
+  familyId,
+  initialJobId,
+}: ColdSyncLoadingScreenProps) {
+  const router = useRouter();
+  const [jobId, setJobId] = useState<string | undefined>(initialJobId);
+  const [status, setStatus] = useState<TickResponse["status"]>("in_progress");
+  const [stagesCompleted, setStagesCompleted] = useState(0);
+  const [stagesTotal, setStagesTotal] = useState(DEFAULT_TOTAL_STAGES);
+  const [currentStage, setCurrentStage] = useState<string | null>(
+    defaultStageLabel()
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [transientError, setTransientError] = useState(false);
+
+  // Refs to keep the polling loop closure stable.
+  const stoppedRef = useRef(false);
+  const tickInFlightRef = useRef(false);
+
+  // Step 1: ensure we have a jobId. Either the layout already passed one in
+  // (preferred — no extra round-trip), or we allocate via /api/sync/start.
+  useEffect(() => {
+    if (jobId || stoppedRef.current) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/sync/start", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ familyId }),
+        });
+        if (!res.ok) {
+          // Surface the error but let the polling loop run on the next
+          // mount — this is recoverable by reload.
+          const body = (await res.json().catch(() => ({}))) as {
+            error?: string;
+          };
+          throw new Error(
+            body.error ?? `Failed to start sync (HTTP ${res.status})`
+          );
+        }
+        const body = (await res.json()) as { jobId: string };
+        if (!cancelled) setJobId(body.jobId);
+      } catch (err) {
+        if (cancelled) return;
+        setErrorMessage(
+          err instanceof Error
+            ? err.message
+            : "Couldn't start sync — please reload."
+        );
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [familyId, jobId]);
+
+  // Step 2: polling loop. Owns its own setTimeout chain so we don't
+  // double-tick if React StrictMode mounts the effect twice in dev.
+  useEffect(() => {
+    if (!jobId) return;
+    stoppedRef.current = false;
+
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      if (stoppedRef.current) return;
+      if (tickInFlightRef.current) {
+        // Reschedule if a previous tick is still in flight (long sleeper).
+        timer = setTimeout(tick, POLL_MS);
+        return;
+      }
+      tickInFlightRef.current = true;
+      try {
+        const res = await fetch(`/api/sync/jobs/${jobId}/tick`, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+        });
+        if (!res.ok) {
+          throw new Error(`Tick failed with HTTP ${res.status}`);
+        }
+        const body = (await res.json()) as TickResponse;
+        setStatus(body.status);
+        setStagesCompleted(body.stagesCompleted);
+        if (body.stagesTotal > 0) setStagesTotal(body.stagesTotal);
+        if (body.currentStageLabel) setCurrentStage(body.currentStageLabel);
+        if (body.error) setErrorMessage(body.error);
+        setTransientError(false);
+
+        if (body.status === "completed") {
+          stoppedRef.current = true;
+          // Hard refresh + navigate so the layout's freshness gate re-runs
+          // with the now-fresh data.
+          router.replace(`/league/${familyId}`);
+          router.refresh();
+          return;
+        }
+
+        if (body.status === "failed") {
+          stoppedRef.current = true;
+          return;
+        }
+
+        timer = setTimeout(tick, POLL_MS);
+      } catch (err) {
+        if (stoppedRef.current) return;
+        setTransientError(true);
+        // Keep the user informed but don't surface every blip.
+        if (err instanceof Error && process.env.NODE_ENV !== "production") {
+          // eslint-disable-next-line no-console
+          console.warn("[ColdSyncLoadingScreen] tick failed:", err);
+        }
+        timer = setTimeout(tick, ERROR_BACKOFF_MS);
+      } finally {
+        tickInFlightRef.current = false;
+      }
+    };
+
+    // Kick off immediately rather than waiting POLL_MS.
+    timer = setTimeout(tick, 0);
+
+    return () => {
+      stoppedRef.current = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [jobId, familyId, router]);
+
+  // Derive UI: per the locked design, the suffix is `season {current} of
+  // {total}` once a per-season stage is in flight. When we don't have a
+  // season-prefixed stage yet, fall back to the raw label.
+  const seasonHint = currentStage ? extractSeasonHint(currentStage) : null;
+  const progressPct = stagesTotal > 0
+    ? Math.min(100, Math.round((stagesCompleted / stagesTotal) * 100))
+    : 0;
+
+  return (
+    <div
+      className="min-h-[60vh] flex items-center justify-center bg-background"
+      data-family-id={familyId}
+      data-job-id={jobId ?? ""}
+      data-testid="cold-sync-loading"
+    >
+      <div className="flex flex-col items-center text-center max-w-md px-6 gap-6">
+        <DnaHelix />
+
+        <div role="status" aria-live="polite" className="space-y-2">
+          <p className="font-serif text-2xl text-foreground">
+            Sequencing your league&rsquo;s DNA&hellip;
+          </p>
+          {status === "failed" ? (
+            <p className="font-mono text-sm text-destructive">
+              {errorMessage ?? "Sync failed. Please reload to retry."}
+            </p>
+          ) : seasonHint ? (
+            <p
+              className="font-mono text-sm text-muted-foreground"
+              data-testid="cold-sync-suffix"
+            >
+              season {seasonHint.current} of {seasonHint.total}
+            </p>
+          ) : (
+            <p
+              className="font-mono text-sm text-muted-foreground"
+              data-testid="cold-sync-suffix"
+            >
+              {currentStage ?? defaultStageLabel()}
+            </p>
+          )}
+        </div>
+
+        {/* Progress strip — sage on muted, no raw Tailwind colors */}
+        <div
+          className="w-full h-1 rounded-full bg-muted overflow-hidden"
+          aria-hidden="true"
+        >
+          <div
+            className="h-full bg-primary transition-all duration-500 ease-out"
+            style={{ width: `${progressPct}%` }}
+            data-testid="cold-sync-progress-bar"
+          />
+        </div>
+
+        {transientError && status !== "failed" && (
+          <p className="font-mono text-xs text-muted-foreground/80">
+            Reconnecting&hellip;
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Pull `(current, total)` out of a stage label like
+ * `"2024:transactions"`. We surface the season number not the stage name
+ * because it's the unit users actually grok — "season 3 of 5" reads as
+ * progress; "2024:transactions" reads as jargon.
+ *
+ * Returns null when the label doesn't carry a year prefix.
+ */
+function extractSeasonHint(
+  label: string
+): { current: number; total: number } | null {
+  const match = label.match(/^season (\d+)\s+of\s+(\d+)/i);
+  if (match) {
+    return { current: Number(match[1]), total: Number(match[2]) };
+  }
+  return null;
+}
+
+export default ColdSyncLoadingScreen;

--- a/src/components/loading/ColdSyncLoadingScreen.tsx
+++ b/src/components/loading/ColdSyncLoadingScreen.tsx
@@ -154,9 +154,14 @@ export function ColdSyncLoadingScreen({
 
         if (body.status === "completed") {
           stoppedRef.current = true;
-          // Hard refresh + navigate so the layout's freshness gate re-runs
-          // with the now-fresh data.
-          router.replace(`/league/${familyId}`);
+          // `router.refresh()` re-runs the route tree (including this
+          // layout's `ensureLeagueFresh`) for the CURRENT URL — which
+          // preserves any sub-route the visitor deep-linked to (e.g.
+          // /league/X/graph from a share link). Do NOT call
+          // `router.replace(/league/${familyId})` here; that would strip
+          // /graph, /transactions, /manager/... and silently drop the
+          // visitor on the dashboard root. The layout's gate now returns
+          // ready=true so the original route's children render.
           router.refresh();
           return;
         }

--- a/src/components/loading/DnaHelix.tsx
+++ b/src/components/loading/DnaHelix.tsx
@@ -1,0 +1,163 @@
+/**
+ * DNA Helix loading mark (#151).
+ *
+ * Pure SVG + CSS — no JS animation libs. The two sinusoidal strands sit
+ * inside a container that slowly rotates around its Y axis (12s linear
+ * infinite) to suggest the 3D twist of a real helix; connecting "base
+ * pairs" between the strands give the eye anchor points to track the
+ * rotation. When the user prefers reduced motion we drop the rotation
+ * entirely and keep only a soft pulse on the bases — calm, but still
+ * communicates that work is happening.
+ *
+ * Design tokens only:
+ *   - Strand A (sage): `text-primary` via `stroke-current`
+ *   - Strand B (slate): `text-muted-foreground` via `stroke-current`
+ *
+ * Sized via the `width` / `height` props on the wrapping `<svg>`-parent.
+ * Default (180x240) fits the cold-sync loading screen at all breakpoints
+ * without layout shift.
+ */
+
+interface DnaHelixProps {
+  /** Width of the helix in CSS px. Default 180. */
+  width?: number;
+  /** Height of the helix in CSS px. Default 240. */
+  height?: number;
+  /** Optional class name applied to the outermost wrapper. */
+  className?: string;
+  /** Optional aria-label override. */
+  ariaLabel?: string;
+}
+
+/**
+ * Geometry constants. The helix is constructed analytically so the two
+ * strands meet at every base-pair anchor — this lets the connecting
+ * segments sit pixel-perfect on the strand path even as the SVG is
+ * rescaled.
+ */
+const VIEWBOX_WIDTH = 180;
+const VIEWBOX_HEIGHT = 240;
+const STRAND_AMPLITUDE = 50; // px from centerline to strand peak
+const STRAND_TWIST_HEIGHT = 120; // px per full sine wavelength
+const STRAND_SAMPLES = 80; // resolution of each strand path
+const BASE_PAIR_COUNT = 8; // connecting "rungs" along the helix
+const STRAND_STROKE_WIDTH = 3.25;
+const BASE_PAIR_STROKE_WIDTH = 2;
+
+/** Build a smooth sinusoidal `d` attribute for one strand. */
+function buildStrandPath(phaseOffset: number): string {
+  const cx = VIEWBOX_WIDTH / 2;
+  const top = 8;
+  const bottom = VIEWBOX_HEIGHT - 8;
+  const totalHeight = bottom - top;
+  const omega = (2 * Math.PI) / STRAND_TWIST_HEIGHT;
+
+  const points: string[] = [];
+  for (let i = 0; i <= STRAND_SAMPLES; i++) {
+    const t = i / STRAND_SAMPLES;
+    const y = top + t * totalHeight;
+    const x = cx + STRAND_AMPLITUDE * Math.sin(omega * (y - top) + phaseOffset);
+    points.push(`${i === 0 ? "M" : "L"}${x.toFixed(2)},${y.toFixed(2)}`);
+  }
+  return points.join(" ");
+}
+
+/** Compute the (x, y) coordinates for one base pair anchor on a strand. */
+function basePairPoint(t: number, phaseOffset: number): { x: number; y: number } {
+  const cx = VIEWBOX_WIDTH / 2;
+  const top = 8;
+  const bottom = VIEWBOX_HEIGHT - 8;
+  const totalHeight = bottom - top;
+  const omega = (2 * Math.PI) / STRAND_TWIST_HEIGHT;
+  const y = top + t * totalHeight;
+  const x = cx + STRAND_AMPLITUDE * Math.sin(omega * (y - top) + phaseOffset);
+  return { x, y };
+}
+
+/**
+ * Renders the DNA helix mark. Stateless and side-effect free — safe to
+ * server-render. The animation lives entirely in CSS keyframes (see
+ * `.dna-helix-rotor` / `.dna-helix-pulse` in `globals.css`).
+ */
+export function DnaHelix({
+  width = 180,
+  height = 240,
+  className,
+  ariaLabel = "Loading helix",
+}: DnaHelixProps) {
+  // Two strands offset by half a wavelength (pi rad) so the helix looks
+  // genuinely paired rather than like two parallel sine waves.
+  const strandA = buildStrandPath(0);
+  const strandB = buildStrandPath(Math.PI);
+
+  // Base pair rungs: one connector every (1 / BASE_PAIR_COUNT) of the way
+  // down the helix, drawn from strand A to strand B at that y.
+  const basePairs: Array<{ x1: number; y1: number; x2: number; y2: number }> =
+    [];
+  for (let i = 1; i <= BASE_PAIR_COUNT; i++) {
+    const t = i / (BASE_PAIR_COUNT + 1); // skip very top + very bottom
+    const a = basePairPoint(t, 0);
+    const b = basePairPoint(t, Math.PI);
+    basePairs.push({ x1: a.x, y1: a.y, x2: b.x, y2: b.y });
+  }
+
+  return (
+    <div
+      className={`dna-helix-3d inline-block ${className ?? ""}`.trim()}
+      style={{ width, height }}
+      role="img"
+      aria-label={ariaLabel}
+      data-testid="dna-helix"
+    >
+      <div
+        className="dna-helix-rotor h-full w-full"
+        data-testid="dna-helix-rotor"
+      >
+        <svg
+          viewBox={`0 0 ${VIEWBOX_WIDTH} ${VIEWBOX_HEIGHT}`}
+          width="100%"
+          height="100%"
+          fill="none"
+          xmlns="http://www.w3.org/2000/svg"
+          aria-hidden="true"
+        >
+          {/* Strand A — sage */}
+          <path
+            d={strandA}
+            className="stroke-current text-primary"
+            strokeWidth={STRAND_STROKE_WIDTH}
+            strokeLinecap="round"
+            data-testid="dna-helix-strand-a"
+          />
+          {/* Strand B — slate */}
+          <path
+            d={strandB}
+            className="stroke-current text-muted-foreground"
+            strokeWidth={STRAND_STROKE_WIDTH}
+            strokeLinecap="round"
+            data-testid="dna-helix-strand-b"
+          />
+          {/* Base pairs — pulse softly so reduced-motion users still see motion */}
+          <g
+            className="dna-helix-pulse stroke-current text-muted-foreground"
+            strokeWidth={BASE_PAIR_STROKE_WIDTH}
+            strokeLinecap="round"
+            data-testid="dna-helix-bases"
+          >
+            {basePairs.map((bp, i) => (
+              <line
+                key={i}
+                x1={bp.x1}
+                y1={bp.y1}
+                x2={bp.x2}
+                y2={bp.y2}
+              />
+            ))}
+          </g>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+export default DnaHelix;

--- a/src/components/loading/__tests__/DnaHelix.test.tsx
+++ b/src/components/loading/__tests__/DnaHelix.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * @jest-environment node
+ *
+ * Snapshot + structural tests for the DNA helix loading mark (#151).
+ *
+ * The helix is pure SVG + CSS — there's no internal state to drive, so we
+ * lock in:
+ *   - The structural shape (two strands + N base pairs)
+ *   - The token classes that the design system enforces
+ *   - The wrapper class that triggers the rotateY keyframes (so a future
+ *     refactor that drops the rotor div fails loud rather than silent)
+ *
+ * Reduced-motion is enforced by `globals.css`'s media query — we don't
+ * need to JSDOM-render to verify it; an integration check would just
+ * exercise the CSS engine. We assert the component still renders the
+ * pulse-target group so the reduced-motion fallback (pulse-only) keeps
+ * working.
+ */
+
+import { renderToStaticMarkup } from "react-dom/server";
+import { DnaHelix } from "../DnaHelix";
+
+describe("DnaHelix", () => {
+  test("renders both strands with token classes", () => {
+    const html = renderToStaticMarkup(<DnaHelix />);
+    expect(html).toMatch(/data-testid="dna-helix-strand-a"/);
+    expect(html).toMatch(/data-testid="dna-helix-strand-b"/);
+    expect(html).toMatch(/text-primary/);
+    expect(html).toMatch(/text-muted-foreground/);
+    // Sanity: no raw Tailwind palette classes leaked in.
+    expect(html).not.toMatch(
+      /\b(text|bg|stroke|fill)-(blue|red|green|yellow|purple|pink|gray)-\d/
+    );
+  });
+
+  test("renders the rotor wrapper that drives the rotateY keyframes", () => {
+    const html = renderToStaticMarkup(<DnaHelix />);
+    expect(html).toMatch(/dna-helix-3d/);
+    expect(html).toMatch(/dna-helix-rotor/);
+    expect(html).toMatch(/data-testid="dna-helix-rotor"/);
+  });
+
+  test("renders the base-pair pulse group (reduced-motion fallback)", () => {
+    const html = renderToStaticMarkup(<DnaHelix />);
+    // 8 base pair lines per the geometry constants.
+    const lineMatches = html.match(/<line\s/g) ?? [];
+    expect(lineMatches.length).toBeGreaterThanOrEqual(6);
+    expect(html).toMatch(/dna-helix-pulse/);
+    expect(html).toMatch(/data-testid="dna-helix-bases"/);
+  });
+
+  test("uses default 180x240 sizing when props omitted", () => {
+    const html = renderToStaticMarkup(<DnaHelix />);
+    expect(html).toMatch(/width:180px/);
+    expect(html).toMatch(/height:240px/);
+  });
+
+  test("exposes role=img + aria-label for assistive tech", () => {
+    const html = renderToStaticMarkup(
+      <DnaHelix ariaLabel="Loading your league" />
+    );
+    expect(html).toMatch(/role="img"/);
+    expect(html).toMatch(/aria-label="Loading your league"/);
+  });
+
+  test("two strands have offset paths (not identical)", () => {
+    // Strand B is phase-shifted by pi from strand A — if they ever match
+    // exactly we've collapsed back to a single sine wave.
+    const html = renderToStaticMarkup(<DnaHelix />);
+    // Pull every <path d="..."> in document order; first is strand A,
+    // second is strand B (no other paths exist in the markup).
+    const paths = Array.from(html.matchAll(/<path[^>]*d="([^"]+)"/g)).map(
+      (m) => m[1]
+    );
+    expect(paths.length).toBeGreaterThanOrEqual(2);
+    expect(paths[0]).not.toEqual(paths[1]);
+  });
+});

--- a/src/services/__tests__/chunkedSync.test.ts
+++ b/src/services/__tests__/chunkedSync.test.ts
@@ -1,0 +1,244 @@
+/**
+ * @jest-environment node
+ *
+ * Unit tests for the chunked sync executor (#151).
+ *
+ * Coverage targets:
+ *   - `runChunk` advances stages until the deadline, then yields
+ *   - `runChunk` resumes from `stagesCompleted` cursor (idempotent)
+ *   - Stage failures throw — the cursor stays put so the next tick retries
+ *   - When every stage has run, returns `status: "completed"`
+ *   - On the very first tick we persist `stages_total` before any work
+ */
+
+const stubColumn = (name: string) => ({ name });
+
+jest.mock("@/db", () => ({
+  schema: {
+    syncJobs: {
+      id: stubColumn("id"),
+      stagesCompleted: stubColumn("stages_completed"),
+      stagesTotal: stubColumn("stages_total"),
+      currentStage: stubColumn("current_stage"),
+    },
+    leagueFamilyMembers: {
+      leagueId: stubColumn("league_id"),
+      season: stubColumn("season"),
+    },
+  },
+  getDb: jest.fn(),
+}));
+
+jest.mock("drizzle-orm", () => ({
+  eq: (col: { name: string }, value: unknown) => ({ op: "eq", col, value }),
+  inArray: (col: { name: string }, values: unknown[]) => ({
+    op: "inArray",
+    col,
+    values,
+  }),
+  sql: Object.assign(
+    (strings: TemplateStringsArray, ...values: unknown[]) => ({
+      op: "sql",
+      strings: Array.from(strings),
+      values,
+    }),
+    {
+      raw: (s: string) => s,
+    }
+  ),
+}));
+
+const updateSyncJobStageMock = jest.fn();
+jest.mock("@/services/syncLock", () => ({
+  updateSyncJobStage: (...args: unknown[]) => updateSyncJobStageMock(...args),
+}));
+
+// Stub every downstream sync helper — the executor wires them, but we
+// don't exercise them here.
+jest.mock("@/services/sync", () => ({
+  syncLeague: jest.fn(),
+}));
+jest.mock("@/services/playerSync", () => ({
+  syncPlayers: jest.fn(),
+}));
+jest.mock("@/services/fantasyCalcSync", () => ({
+  syncFantasyCalcValues: jest.fn(),
+}));
+jest.mock("@/services/rosterStatusSync", () => ({
+  syncRosterStatus: jest.fn(),
+}));
+jest.mock("@/services/injurySync", () => ({
+  syncInjuries: jest.fn(),
+}));
+jest.mock("@/services/scheduleSync", () => ({
+  syncSchedule: jest.fn(),
+}));
+jest.mock("@/services/managerGrades", () => ({
+  rollupManagerGrades: jest.fn(),
+}));
+
+import { getDb } from "@/db";
+import { runChunk, type ChunkedStage } from "../chunkedSync";
+
+const mockedGetDb = getDb as jest.MockedFunction<typeof getDb>;
+
+interface DbState {
+  cursor: number;
+  updates: Array<Record<string, unknown>>;
+}
+
+function makeMockDb(initialCursor: number): DbState {
+  const state: DbState = { cursor: initialCursor, updates: [] };
+  const dbStub = {
+    select: jest.fn(() => ({
+      from: () => ({
+        where: () => ({
+          limit: () => Promise.resolve([{ stagesCompleted: state.cursor }]),
+        }),
+      }),
+    })),
+    update: jest.fn(() => ({
+      set: (values: Record<string, unknown>) => {
+        state.updates.push(values);
+        return {
+          where: () => Promise.resolve(undefined),
+        };
+      },
+    })),
+  };
+  mockedGetDb.mockReturnValue(
+    dbStub as unknown as ReturnType<typeof getDb>
+  );
+  return state;
+}
+
+function makeStage(key: string, runImpl?: () => Promise<void>): ChunkedStage {
+  return {
+    key,
+    label: `stage:${key}`,
+    run: runImpl ?? jest.fn(async () => {}),
+  };
+}
+
+describe("runChunk", () => {
+  beforeEach(() => {
+    updateSyncJobStageMock.mockReset();
+    mockedGetDb.mockReset();
+  });
+
+  test("runs every stage to completion when budget is generous", async () => {
+    const state = makeMockDb(0);
+    const stages = [makeStage("a"), makeStage("b"), makeStage("c")];
+
+    const result = await runChunk("job-1", stages, {
+      deadlineAt: Date.now() + 60_000,
+    });
+
+    expect(result.status).toBe("completed");
+    expect(result.stagesCompleted).toBe(3);
+    expect(result.stagesTotal).toBe(3);
+    expect(result.currentStageLabel).toBeNull();
+    // Each stage gets a "started" + "finished" update.
+    expect(updateSyncJobStageMock).toHaveBeenCalledTimes(stages.length * 2);
+    // First update writes the total + initial label.
+    expect(state.updates[0]).toMatchObject({
+      stagesTotal: 3,
+      currentStage: "stage:a",
+    });
+  });
+
+  test("yields cleanly when the deadline is reached between stages", async () => {
+    makeMockDb(0);
+    const stages = [
+      makeStage("a"),
+      makeStage("b", async () => {
+        // Push the clock past the deadline mid-execution so the loop
+        // exits before the next stage starts.
+        const real = Date.now;
+        Date.now = () => real() + 30_000;
+      }),
+      makeStage("c"),
+    ];
+
+    const result = await runChunk("job-1", stages, {
+      deadlineAt: Date.now() + 1_000,
+    });
+
+    expect(result.status).toBe("in_progress");
+    expect(result.stagesCompleted).toBe(2);
+    expect(result.currentStageKey).toBe("c");
+    expect(result.currentStageLabel).toBe("stage:c");
+
+    // restore Date.now
+    Date.now = Date.now.bind(Date);
+  });
+
+  test("resumes from the persisted cursor on a follow-up tick", async () => {
+    const state = makeMockDb(2); // first 2 stages already done
+    const stages = [makeStage("a"), makeStage("b"), makeStage("c"), makeStage("d")];
+
+    // Track which stages actually ran so we can assert idempotency.
+    const ran: string[] = [];
+    stages.forEach((s) => {
+      const original = s.run;
+      s.run = async () => {
+        ran.push(s.key);
+        await original();
+      };
+    });
+
+    const result = await runChunk("job-1", stages, {
+      deadlineAt: Date.now() + 60_000,
+    });
+
+    expect(ran).toEqual(["c", "d"]);
+    expect(result.status).toBe("completed");
+    expect(result.stagesCompleted).toBe(4);
+    // Initial label set should be the *resumed* stage, not stage 'a'.
+    expect(state.updates[0]).toMatchObject({ currentStage: "stage:c" });
+  });
+
+  test("rethrows on stage failure and leaves cursor untouched", async () => {
+    makeMockDb(0);
+    const stages = [
+      makeStage("a"),
+      makeStage("b", async () => {
+        throw new Error("boom");
+      }),
+      makeStage("c"),
+    ];
+
+    await expect(
+      runChunk("job-1", stages, { deadlineAt: Date.now() + 60_000 })
+    ).rejects.toThrow(/boom/);
+
+    // Stage A's `updateSyncJobStage` calls fired (started + finished),
+    // and stage B's "started" call fired, but the post-stage-B
+    // increment never happened because the run threw.
+    const stageBumps = updateSyncJobStageMock.mock.calls.filter(
+      (c) => c[1] === "stage:c"
+    );
+    expect(stageBumps).toHaveLength(0);
+  });
+
+  test("returns completed immediately when stages list is empty", async () => {
+    makeMockDb(0);
+    const result = await runChunk("job-1", [], {
+      deadlineAt: Date.now() + 60_000,
+    });
+    expect(result.status).toBe("completed");
+    expect(result.stagesTotal).toBe(0);
+    expect(result.stagesCompleted).toBe(0);
+  });
+
+  test("uses startFromCursor override when supplied (test ergonomics)", async () => {
+    makeMockDb(0);
+    const stages = [makeStage("a"), makeStage("b"), makeStage("c")];
+    const result = await runChunk("job-1", stages, {
+      deadlineAt: Date.now() + 60_000,
+      startFromCursor: 2,
+    });
+    expect(result.status).toBe("completed");
+    expect(result.stagesCompleted).toBe(3);
+  });
+});

--- a/src/services/__tests__/chunkedSync.test.ts
+++ b/src/services/__tests__/chunkedSync.test.ts
@@ -149,28 +149,35 @@ describe("runChunk", () => {
 
   test("yields cleanly when the deadline is reached between stages", async () => {
     makeMockDb(0);
-    const stages = [
-      makeStage("a"),
-      makeStage("b", async () => {
-        // Push the clock past the deadline mid-execution so the loop
-        // exits before the next stage starts.
-        const real = Date.now;
-        Date.now = () => real() + 30_000;
-      }),
-      makeStage("c"),
-    ];
+    // Capture the original `Date.now` at the test scope so the `finally`
+    // can guarantee restoration even if assertions throw. The previous
+    // implementation reassigned `Date.now = Date.now.bind(Date)` which
+    // bound the already-patched lambda back to itself instead of restoring
+    // the native function — leaking a +30s skew into every subsequent test
+    // in this Jest worker.
+    const realNow = Date.now;
+    try {
+      const stages = [
+        makeStage("a"),
+        makeStage("b", async () => {
+          // Push the clock past the deadline mid-execution so the loop
+          // exits before the next stage starts.
+          Date.now = () => realNow() + 30_000;
+        }),
+        makeStage("c"),
+      ];
 
-    const result = await runChunk("job-1", stages, {
-      deadlineAt: Date.now() + 1_000,
-    });
+      const result = await runChunk("job-1", stages, {
+        deadlineAt: realNow() + 1_000,
+      });
 
-    expect(result.status).toBe("in_progress");
-    expect(result.stagesCompleted).toBe(2);
-    expect(result.currentStageKey).toBe("c");
-    expect(result.currentStageLabel).toBe("stage:c");
-
-    // restore Date.now
-    Date.now = Date.now.bind(Date);
+      expect(result.status).toBe("in_progress");
+      expect(result.stagesCompleted).toBe(2);
+      expect(result.currentStageKey).toBe("c");
+      expect(result.currentStageLabel).toBe("stage:c");
+    } finally {
+      Date.now = realNow;
+    }
   });
 
   test("resumes from the persisted cursor on a follow-up tick", async () => {

--- a/src/services/__tests__/syncLock.test.ts
+++ b/src/services/__tests__/syncLock.test.ts
@@ -375,6 +375,69 @@ describe("updateSyncJobStage", () => {
     });
   });
 
+  it("uses a CAS-style WHERE when stagesCompleted is provided (concurrent-tick safety)", async () => {
+    // bug_005 from ultrareview: concurrent ticks against the same jobId
+    // both pass `if (status === "running")` and run runChunk in parallel.
+    // A slow tick that finished stage 4 must NOT overwrite the cursor when
+    // a fast tick already advanced it to 5. The CAS predicate
+    // (`stages_completed IS NULL OR stages_completed < new`) makes Postgres
+    // reject the late write atomically.
+    const whereArgs: unknown[] = [];
+    const failingDb = {
+      update: jest.fn(() => ({
+        set: jest.fn(() => ({
+          where: jest.fn((arg: unknown) => {
+            whereArgs.push(arg);
+            return Promise.resolve();
+          }),
+        })),
+      })),
+    };
+    mockedGetDb.mockReturnValue(
+      failingDb as unknown as ReturnType<typeof getDb>
+    );
+
+    await updateSyncJobStage("job_a", "season 4 of 5", 4);
+
+    // The where predicate must NOT be a plain eq(id) — it carries the
+    // additional CAS clause as a tagged sql template.
+    expect(whereArgs).toHaveLength(1);
+    // The drizzle-orm mock at the top of this file produces `{ op: "sql",
+    // strings, values }` for sql-tagged templates and `{ op: "eq", col,
+    // value }` for eq(). The CAS path uses sql; the eq() path doesn't.
+    const predicate = whereArgs[0] as { op: string; strings?: string[] };
+    expect(predicate.op).toBe("sql");
+    const text = (predicate.strings ?? []).join("?");
+    expect(text).toContain(" < ");
+    expect(text).toContain("IS NULL");
+  });
+
+  it("currentStage-only update (no stagesCompleted) uses simple eq() WHERE — no CAS overhead", async () => {
+    // The label-only path is for slightly-stale stage labels. CAS would be
+    // overkill there. Confirm it stays on the simple eq() predicate.
+    const whereArgs: unknown[] = [];
+    const db = {
+      update: jest.fn(() => ({
+        set: jest.fn(() => ({
+          where: jest.fn((arg: unknown) => {
+            whereArgs.push(arg);
+            return Promise.resolve();
+          }),
+        })),
+      })),
+    };
+    mockedGetDb.mockReturnValue(
+      db as unknown as ReturnType<typeof getDb>
+    );
+
+    await updateSyncJobStage("job_a", "season 4 of 5");
+
+    expect(whereArgs).toHaveLength(1);
+    // Label-only updates take the cheap eq(id) path, not sql.
+    const predicate = whereArgs[0] as { op: string };
+    expect(predicate.op).toBe("eq");
+  });
+
   it("noops on an empty jobId", async () => {
     const calls: DbCalls = {
       selectResults: [],

--- a/src/services/chunkedSync.ts
+++ b/src/services/chunkedSync.ts
@@ -1,0 +1,292 @@
+/**
+ * Chunked sync executor (#151).
+ *
+ * Wraps the existing `syncLeague` / global-sync helpers so a single
+ * `syncJobs` row can be advanced one stage at a time across multiple
+ * HTTP ticks. Why chunked:
+ *
+ *   - Vercel functions cap at 30s. A pathological 10-season cold sync can
+ *     exceed that even after the within-season parallelism win.
+ *   - The cold-start loading screen (#151) needs a "what's happening right
+ *     now" signal, not just a binary done/not-done.
+ *
+ * Why not just run `syncLeagueFamily` per tick: it's atomic — once you
+ * call it, you're committed to the whole thing. We need finer granularity
+ * so the user sees per-season progress and so we can yield back to the
+ * client (and the Vercel runtime) cheaply between stages.
+ *
+ * Key invariants:
+ *
+ *   - Idempotent: each stage is gated on the underlying watermark / row
+ *     state, so re-running it is a no-op once data is in. Closing the
+ *     tab and coming back picks up cleanly.
+ *   - Budget-aware: `runChunk` accepts a deadline and stops cleanly between
+ *     stages when the budget is exhausted (never mid-stage).
+ *   - Progress-only side effects: every successful stage bumps
+ *     `stagesCompleted` / `currentStage` on the `syncJobs` row via
+ *     `updateSyncJobStage`. Counters are the single source of truth for
+ *     the loading screen.
+ */
+
+import { getDb, schema } from "@/db";
+import { eq, inArray } from "drizzle-orm";
+import { syncLeague } from "@/services/sync";
+import { syncPlayers } from "@/services/playerSync";
+import { syncFantasyCalcValues } from "@/services/fantasyCalcSync";
+import { syncRosterStatus } from "@/services/rosterStatusSync";
+import { syncInjuries } from "@/services/injurySync";
+import { syncSchedule } from "@/services/scheduleSync";
+import { rollupManagerGrades } from "@/services/managerGrades";
+import { updateSyncJobStage } from "@/services/syncLock";
+import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
+
+// --- Types --------------------------------------------------------------
+
+/** A single chunk of work the executor knows how to advance one tick at a time. */
+export interface ChunkedStage {
+  /** Stable key persisted to `sync_jobs.current_stage`. */
+  key: string;
+  /** Friendly label surfaced to the loading screen. */
+  label: string;
+  /** Function that runs the work. Idempotent. */
+  run: () => Promise<void>;
+}
+
+export interface ChunkedRunResult {
+  status: "in_progress" | "completed";
+  stagesCompleted: number;
+  stagesTotal: number;
+  currentStageKey: string | null;
+  currentStageLabel: string | null;
+}
+
+export interface BuildStagesOpts {
+  trigger?: SyncTrigger;
+}
+
+// --- Stage planning -----------------------------------------------------
+
+/**
+ * Build the ordered stage list for a family. Same shape every tick — the
+ * executor uses the persisted `stagesCompleted` count as a cursor into
+ * this array.
+ *
+ * Stages, in order:
+ *   1. `players` — global player metadata refresh
+ *   2. `nflverse` — roster status + injuries + schedule for every season
+ *   3. `fantasycalc` — dynasty trade values
+ *   4. For each season (oldest -> newest): one `season:{year}` stage that
+ *      runs the full per-season `syncLeague` (within-season parallelism is
+ *      already exploited inside that call). The label is friendly:
+ *      `"season N of M"`.
+ *   5. `manager-grades` — career rollup
+ *
+ * 5-season family: 1 + 1 + 1 + 5 + 1 = 9 stages. Issue body's "23 stages"
+ * count assumed per-data-type granularity per season; in practice the
+ * within-season parallelism makes per-season the right granularity.
+ */
+export async function buildFamilyStages(
+  familyId: string,
+  leagueIds: string[],
+  opts: BuildStagesOpts = {}
+): Promise<ChunkedStage[]> {
+  const trigger = opts.trigger ?? "lazy";
+  const db = getDb();
+
+  // Order leagues oldest-first — matches the existing sync route + makes
+  // "season 1 of 5" line up with the chronologically earliest season.
+  const members = await db
+    .select({
+      leagueId: schema.leagueFamilyMembers.leagueId,
+      season: schema.leagueFamilyMembers.season,
+    })
+    .from(schema.leagueFamilyMembers)
+    .where(inArray(schema.leagueFamilyMembers.leagueId, leagueIds));
+
+  const ordered = [...members].sort(
+    (a, b) => Number(a.season) - Number(b.season)
+  );
+
+  // Compute the union of seasons across the family so the global nflverse
+  // sync covers every season in one go.
+  const seasonNumbers: number[] = [];
+  for (const m of ordered) {
+    const n = parseInt(m.season, 10);
+    if (!isNaN(n)) seasonNumbers.push(n);
+  }
+  const uniqueSeasons = [...new Set(seasonNumbers)];
+
+  const totalSeasons = ordered.length;
+
+  const stages: ChunkedStage[] = [];
+
+  stages.push({
+    key: "players",
+    label: "Refreshing player metadata",
+    run: async () => {
+      await syncPlayers(false, {
+        trigger,
+        scope: `family=${familyId}`,
+      });
+    },
+  });
+
+  stages.push({
+    key: "nflverse",
+    label: "Loading NFL data",
+    run: async () => {
+      if (uniqueSeasons.length === 0) return;
+      await syncRosterStatus({ seasons: uniqueSeasons, trigger });
+      await syncInjuries({ seasons: uniqueSeasons, trigger });
+      await syncSchedule({ seasons: uniqueSeasons, trigger });
+    },
+  });
+
+  stages.push({
+    key: "fantasycalc",
+    label: "Pulling dynasty values",
+    run: async () => {
+      const mostRecent = ordered[ordered.length - 1]?.leagueId;
+      if (!mostRecent) return;
+      await syncFantasyCalcValues(mostRecent, { trigger });
+    },
+  });
+
+  ordered.forEach((member, i) => {
+    const seasonIndex = i + 1;
+    stages.push({
+      key: `season:${member.season}`,
+      label: `season ${seasonIndex} of ${totalSeasons}`,
+      run: async () => {
+        await syncLeague(member.leagueId, undefined, familyId, {
+          skipGlobalSyncs: true,
+          trigger,
+        });
+      },
+    });
+  });
+
+  stages.push({
+    key: "manager-grades",
+    label: "Computing career grades",
+    run: async () => {
+      try {
+        await rollupManagerGrades(familyId);
+      } catch (err) {
+        // Non-critical — match `syncLeagueFamily`'s behaviour. Surfacing
+        // this would block the loading screen indefinitely on a soft
+        // failure; the audit row already captures the underlying error.
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[chunked-sync] manager grade rollup failed for ${familyId}:`,
+          err
+        );
+      }
+    },
+  });
+
+  return stages;
+}
+
+// --- Executor -----------------------------------------------------------
+
+export interface RunChunkOpts {
+  /** Wallclock deadline (`Date.now()`). The executor stops cleanly when reached. */
+  deadlineAt: number;
+  /** Optional cursor override (for tests). Defaults to the persisted value. */
+  startFromCursor?: number;
+}
+
+/**
+ * Advance the chunked executor one HTTP-tick's worth of work. Stops when
+ * either (a) every stage has run, or (b) the deadline is reached. Always
+ * leaves the `syncJobs` row in a consistent state — `stagesCompleted` is
+ * the cursor of "stages done so far," and resuming on the next tick is a
+ * matter of starting from that index.
+ *
+ * Returns the final state for the tick (`in_progress` if more work
+ * remains; `completed` if every stage ran).
+ */
+export async function runChunk(
+  jobId: string,
+  stages: ChunkedStage[],
+  opts: RunChunkOpts
+): Promise<ChunkedRunResult> {
+  const db = getDb();
+  const total = stages.length;
+
+  // Read the persisted cursor (stagesCompleted) so concurrent ticks pick
+  // up where the last one left off.
+  let cursor = opts.startFromCursor;
+  if (cursor == null) {
+    const [row] = await db
+      .select({
+        stagesCompleted: schema.syncJobs.stagesCompleted,
+      })
+      .from(schema.syncJobs)
+      .where(eq(schema.syncJobs.id, jobId))
+      .limit(1);
+    cursor = row?.stagesCompleted ?? 0;
+  }
+
+  // Persist the total + the (optimistic) current stage label up front so
+  // the very first tick already shows real progress on the client.
+  if (total > 0 && cursor < total) {
+    await db
+      .update(schema.syncJobs)
+      .set({
+        stagesTotal: total,
+        currentStage: stages[cursor]?.label ?? null,
+      })
+      .where(eq(schema.syncJobs.id, jobId));
+  }
+
+  while (cursor < total) {
+    if (Date.now() >= opts.deadlineAt) break;
+
+    const stage = stages[cursor];
+    // Surface the stage we're about to run *before* running it so the
+    // client sees the label flip the moment the work starts.
+    await updateSyncJobStage(jobId, stage.label, cursor);
+
+    try {
+      await stage.run();
+    } catch (err) {
+      // Soft-fail: log and rethrow. The tick route catches and records
+      // failure on the audit row. We deliberately don't bump the cursor
+      // so the next manual reload retries the failed stage.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[chunked-sync] stage ${stage.key} failed for job ${jobId}:`,
+        err
+      );
+      throw err;
+    }
+
+    cursor += 1;
+    await updateSyncJobStage(
+      jobId,
+      cursor < total ? stages[cursor].label : null,
+      cursor
+    );
+  }
+
+  if (cursor >= total) {
+    return {
+      status: "completed",
+      stagesCompleted: cursor,
+      stagesTotal: total,
+      currentStageKey: null,
+      currentStageLabel: null,
+    };
+  }
+
+  const next = stages[cursor];
+  return {
+    status: "in_progress",
+    stagesCompleted: cursor,
+    stagesTotal: total,
+    currentStageKey: next?.key ?? null,
+    currentStageLabel: next?.label ?? null,
+  };
+}

--- a/src/services/syncLock.ts
+++ b/src/services/syncLock.ts
@@ -128,6 +128,18 @@ export async function incrementSyncJobApiCalls(
 /**
  * Update the current_stage / stages_completed audit fields. Used by the
  * chunked-stage executor (#151) to record progress as each stage finishes.
+ *
+ * **Concurrent-tick safety.** Two ticks against the same `jobId` can race
+ * (the design intentionally allows multiple visitors to share one chunked
+ * run). To prevent the cursor from regressing — slow tick A reads cursor=3,
+ * fast tick B advances it to 5, then A's late write tries to set 4 —
+ * `stagesCompleted` is updated under a CAS (`coalesce(current, 0) >= new`
+ * inverted to `< new`). Result: cursor only ever advances. Cosmetic but
+ * load-bearing for the loading-screen progress bar; also prevents wasted
+ * Sleeper API spend re-running stages a peer already finished.
+ *
+ * `currentStage` is NOT under CAS — it's a label, not a monotonic counter,
+ * and a slightly-stale label is acceptable.
  */
 export async function updateSyncJobStage(
   jobId: string,
@@ -137,11 +149,22 @@ export async function updateSyncJobStage(
   if (!jobId) return;
   try {
     const db = getDb();
-    const set: Record<string, unknown> = { currentStage };
-    if (stagesCompleted != null) set.stagesCompleted = stagesCompleted;
+    if (stagesCompleted != null) {
+      // CAS: only advance, never regress.
+      await db
+        .update(schema.syncJobs)
+        .set({
+          currentStage,
+          stagesCompleted,
+        })
+        .where(
+          sql`${schema.syncJobs.id} = ${jobId} AND (${schema.syncJobs.stagesCompleted} IS NULL OR ${schema.syncJobs.stagesCompleted} < ${stagesCompleted})`
+        );
+      return;
+    }
     await db
       .update(schema.syncJobs)
-      .set(set)
+      .set({ currentStage })
       .where(eq(schema.syncJobs.id, jobId));
   } catch {
     // Swallow — observability must never break the caller.


### PR DESCRIPTION
## Summary

Closes #151. Cold-start chunked executor + the DNA-themed first-impression loading screen for new families.

- Pure SVG + CSS DNA helix mark with `12s rotateY` rotor, 3D `perspective`, sage + slate strands, and a reduced-motion fallback that keeps a soft pulse on the base pairs.
- Locked copy: `font-serif text-2xl` "Sequencing your league's DNA..." with a `font-mono text-sm` "season N of M" suffix that updates from the executor's `current_stage` label.
- Idempotent `POST /api/sync/start` that allocates (or reuses) a `syncJobs` row keyed on the family root.
- 25s-budgeted `POST /api/sync/jobs/[jobId]/tick` driving a new chunked executor (`src/services/chunkedSync.ts`) — players, nflverse, FantasyCalc, per-season `syncLeague` (oldest -> newest), then the manager-grades rollup. Each stage is gated on its own watermark / upsert so resuming after a tab close is a no-op until the cursor catches up.
- The `(app)/league/[familyId]/layout.tsx` cold-path branch now renders the helix loading screen instead of the placeholder.
- Sentry: every tick wrapped in `withSyncTransaction("chunked-tick", "sync.family", ...)` with structured breadcrumbs at start / completion / failure.

## What's deferred

- 60fps measurement on iPhone 13 / mid-range Android — implementation is pure-CSS GPU transforms, but no real-device profiling has been run yet.
- The "Decoding {N} seasons of dynasty data..." copy variant from the issue body is intentionally not used; the locked design call in the issue's comment fixed copy to "Sequencing your league's DNA...".
- No new schema migration (the `syncJobs` `stages_total` / `stages_completed` / `current_stage` columns from migration 0017 are sufficient).

## Test plan

- [x] DnaHelix component tests — 6 specs: token-class assertions, dual strands, rotor wrapper present, default 180x240 sizing, aria `role="img"` + label, divergent paths.
- [x] `chunkedSync.runChunk` — 6 specs: full-completion path, deadline yield, resume-from-cursor, rethrow + cursor-frozen on stage failure, empty stage list, `startFromCursor` override.
- [x] `POST /api/sync/start` — 6 specs: invalid body 400, unknown family 404, cold acquire, reuse-in-flight, member fallback, no-members 404.
- [x] `POST /api/sync/jobs/[jobId]/tick` — 8 specs: 404 missing job, terminal-status passthrough, in-progress surfaces runChunk result, completed releases lock + touches `lastSyncedAt`, stage failure caught, missing-ref + missing-family soft-fail.
- [x] Full suite green: 37 suites, 329 passed (3 pre-existing skips).
- [x] `npx tsc --noEmit` clean.
- [x] `npm run lint` no new warnings.
- [x] `npm run build` passes; both `/api/sync/start` and `/api/sync/jobs/[jobId]/tick` appear in the route table.
- [ ] Verify by visiting `/league/<unsynced-family-id>` in a preview deploy.
- [ ] Verify on mobile that the helix renders at 60fps with no layout shift between stage labels.
- [ ] Verify reduced-motion fallback in macOS System Settings -> Accessibility -> Display.

🤖 Generated with [Claude Code](https://claude.com/claude-code)