### PR TITLE
Fix #173: fetch slot_to_roster_id from /draft/{id} (not list endpoint)

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "db:dev:reset": "dotenv -e .env.development -- tsx scripts/reset-db.ts",
     "notify-waitlist": "tsx scripts/notify-waitlist.ts",
     "backfill:fantasycalc": "dotenv -e .env.local -- tsx scripts/backfill-fantasycalc-keys.ts",
+    "backfill:slot-to-roster-id": "dotenv -e .env.local -- tsx scripts/backfill-slot-to-roster-id.ts",
     "sync:family": "dotenv -e .env.local -- tsx scripts/sync-family.ts",
     "sync:season": "dotenv -e .env.local -- tsx scripts/sync-season.ts",
     "sync:players": "dotenv -e .env.local -- tsx scripts/sync-players.ts",

--- a/scripts/__tests__/backfill-slot-to-roster-id.test.ts
+++ b/scripts/__tests__/backfill-slot-to-roster-id.test.ts
@@ -1,0 +1,156 @@
+/**
+ * @jest-environment node
+ */
+
+import { run } from "../backfill-slot-to-roster-id";
+
+interface FakeDraftRow {
+  id: string;
+  season: string;
+  status: string | null;
+  slotToRosterId: Record<string, number> | null;
+}
+
+function makeFakeDb(initial: FakeDraftRow[]) {
+  // The script issues two SELECTs (full + null-only) and one UPDATE per
+  // backfilled row. Drizzle's `.from()` and `.from().where()` are both
+  // thenables; mirror that with PromiseLike so `await select(...).from(...)`
+  // and `await select(...).from(...).where(...)` both resolve.
+  const rows = initial.map((r) => ({ ...r }));
+  const updates: Array<{ id: string; slotToRosterId: Record<string, number> }> = [];
+
+  const thenable = <T,>(value: T): PromiseLike<T> => ({
+    then: (onfulfilled, onrejected) => Promise.resolve(value).then(onfulfilled, onrejected),
+  });
+
+  return {
+    db: {
+      select: () => ({
+        from: () => {
+          const fullRows = rows.map((r) => ({ ...r }));
+          return {
+            ...thenable(fullRows),
+            where: () => thenable(rows.filter((r) => r.slotToRosterId === null)),
+          };
+        },
+      }),
+      update: () => ({
+        set: (s: { slotToRosterId: Record<string, number> }) => ({
+          where: () => {
+            const target = rows.find((r) => r.slotToRosterId === null);
+            if (target) {
+              target.slotToRosterId = s.slotToRosterId;
+              updates.push({ id: target.id, slotToRosterId: s.slotToRosterId });
+            }
+            return Promise.resolve();
+          },
+        }),
+      }),
+    },
+    rows,
+    updates,
+  };
+}
+
+describe("backfill-slot-to-roster-id", () => {
+  it("dry-run does not call update; reports counts", async () => {
+    const fake = makeFakeDb([
+      { id: "D1", season: "2022", status: "complete", slotToRosterId: null },
+      { id: "D2", season: "2023", status: "complete", slotToRosterId: { "1": 1 } },
+    ]);
+    const fetchDraft = jest.fn().mockResolvedValue({ slot_to_roster_id: { "1": 7 } });
+    const logs: string[] = [];
+
+    const stats = await run([], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: fake.db as any,
+      fetchDraft,
+      log: (m) => logs.push(m),
+    });
+
+    expect(stats.total).toBe(2);
+    expect(stats.alreadyPopulated).toBe(1);
+    expect(stats.fetched).toBe(1);
+    expect(stats.updated).toBe(1);
+    expect(stats.failed).toBe(0);
+    expect(fetchDraft).toHaveBeenCalledWith("D1");
+    expect(fake.updates).toHaveLength(0); // dry-run: no DB write
+  });
+
+  it("--apply persists slot_to_roster_id only for null rows", async () => {
+    const fake = makeFakeDb([
+      { id: "D1", season: "2022", status: "complete", slotToRosterId: null },
+      { id: "D2", season: "2023", status: "complete", slotToRosterId: { "1": 1 } },
+    ]);
+    const fetchDraft = jest.fn().mockResolvedValue({ slot_to_roster_id: { "1": 7, "2": 8 } });
+
+    const stats = await run(["--apply"], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: fake.db as any,
+      fetchDraft,
+      log: () => undefined,
+    });
+
+    expect(stats.updated).toBe(1);
+    expect(fake.updates).toEqual([{ id: "D1", slotToRosterId: { "1": 7, "2": 8 } }]);
+    expect(fetchDraft).toHaveBeenCalledTimes(1);
+    expect(fetchDraft).toHaveBeenCalledWith("D1");
+  });
+
+  it("counts but does not write when API returns no slot_to_roster_id (pre-draft)", async () => {
+    const fake = makeFakeDb([
+      { id: "D1", season: "2027", status: "pre_draft", slotToRosterId: null },
+    ]);
+    const fetchDraft = jest.fn().mockResolvedValue({}); // no slot map yet
+
+    const stats = await run(["--apply"], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: fake.db as any,
+      fetchDraft,
+      log: () => undefined,
+    });
+
+    expect(stats.fetched).toBe(1);
+    expect(stats.updated).toBe(0);
+    expect(stats.skippedNoMap).toBe(1);
+    expect(fake.updates).toHaveLength(0);
+  });
+
+  it("isolates fetch failures and continues", async () => {
+    const fake = makeFakeDb([
+      { id: "D1", season: "2022", status: "complete", slotToRosterId: null },
+      { id: "D2", season: "2023", status: "complete", slotToRosterId: null },
+    ]);
+    const fetchDraft = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("Sleeper 503"))
+      .mockResolvedValueOnce({ slot_to_roster_id: { "1": 5 } });
+
+    const stats = await run(["--apply"], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: fake.db as any,
+      fetchDraft,
+      log: () => undefined,
+    });
+
+    expect(stats.failed).toBe(1);
+    expect(stats.updated).toBe(1);
+    expect(fake.updates).toHaveLength(1);
+  });
+
+  it("--help prints usage and returns zero counts", async () => {
+    const fetchDraft = jest.fn();
+    const logs: string[] = [];
+
+    const stats = await run(["--help"], {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      db: undefined as any,
+      fetchDraft,
+      log: (m) => logs.push(m),
+    });
+
+    expect(stats.total).toBe(0);
+    expect(fetchDraft).not.toHaveBeenCalled();
+    expect(logs.some((m) => m.includes("Usage"))).toBe(true);
+  });
+});

--- a/scripts/backfill-slot-to-roster-id.ts
+++ b/scripts/backfill-slot-to-roster-id.ts
@@ -1,0 +1,152 @@
+/**
+ * Backfill `drafts.slot_to_roster_id` for every row where it's null.
+ *
+ * Why: `Sleeper.getDrafts()` calls `/league/{id}/drafts`, which returns
+ * summary entries that omit `slot_to_roster_id`. The list-endpoint bug has
+ * been writing NULL into the column for the lifetime of the schema. The
+ * graph-route remap that converts `draft_selected` events from "drafter"
+ * to "true original owner" silently no-ops without it, breaking lineage
+ * tracer pick→player resolution for traded picks (#173).
+ *
+ * The sibling fix in `src/services/sync.ts` swaps to the per-draft endpoint
+ * so future syncs populate the column naturally; this script repairs
+ * existing rows so we don't have to wait for natural re-sync.
+ *
+ * Idempotent: only updates rows where `slot_to_roster_id IS NULL`. Re-runs
+ * are no-ops.
+ *
+ * Usage:
+ *   # Dry-run (default; prints what would change without writing)
+ *   npm run backfill:slot-to-roster-id
+ *
+ *   # Apply against the database `.env.local`/`getDb()` resolves to.
+ *   # Off-Vercel that's `DATABASE_URL_DEV` if set, else `DATABASE_URL`.
+ *   npm run backfill:slot-to-roster-id -- --apply
+ *
+ * Targeting prod: temporarily unset `DATABASE_URL_DEV` in `.env.local` (or
+ * pass an explicit `DATABASE_URL` env var) before running with `--apply`.
+ */
+
+import { getDb, schema } from "@/db";
+import { Sleeper } from "@/lib/sleeper";
+import { eq } from "drizzle-orm";
+
+interface RunStats {
+  total: number;
+  alreadyPopulated: number;
+  fetched: number;
+  updated: number;
+  failed: number;
+  skippedNoMap: number;
+}
+
+export async function run(
+  argv: string[],
+  deps: {
+    db?: ReturnType<typeof getDb>;
+    fetchDraft?: (id: string) => Promise<{ slot_to_roster_id?: Record<string, number> }>;
+    log?: (msg: string) => void;
+  } = {}
+): Promise<RunStats> {
+  const apply = argv.includes("--apply");
+  const help = argv.includes("--help") || argv.includes("-h");
+  const log = deps.log ?? ((msg: string) => console.log(msg));
+
+  if (help) {
+    log(
+      "Usage: backfill-slot-to-roster-id [--apply]\n" +
+        "  --apply  Persist updates. Without it, prints planned changes only."
+    );
+    return {
+      total: 0,
+      alreadyPopulated: 0,
+      fetched: 0,
+      updated: 0,
+      failed: 0,
+      skippedNoMap: 0,
+    };
+  }
+
+  const db = deps.db ?? getDb();
+  const fetchDraft = deps.fetchDraft ?? Sleeper.getDraft;
+
+  const allDrafts = await db
+    .select({
+      id: schema.drafts.id,
+      season: schema.drafts.season,
+      status: schema.drafts.status,
+      slotToRosterId: schema.drafts.slotToRosterId,
+    })
+    .from(schema.drafts);
+
+  const targets = allDrafts.filter((d) => d.slotToRosterId == null);
+
+  const stats: RunStats = {
+    total: allDrafts.length,
+    alreadyPopulated: allDrafts.length - targets.length,
+    fetched: 0,
+    updated: 0,
+    failed: 0,
+    skippedNoMap: 0,
+  };
+
+  log(`Found ${allDrafts.length} drafts in DB.`);
+  log(
+    `  ${stats.alreadyPopulated} already populated.\n` +
+      `  ${targets.length} to backfill.${apply ? "" : " (dry-run; pass --apply to persist)"}`
+  );
+
+  for (const draft of targets) {
+    try {
+      const sleeperDraft = await fetchDraft(draft.id);
+      stats.fetched++;
+      const slotMap = sleeperDraft.slot_to_roster_id ?? null;
+      if (!slotMap) {
+        // Pre-draft drafts haven't had slots assigned yet. Expected for
+        // upcoming-season rows; nothing to do.
+        stats.skippedNoMap++;
+        log(
+          `  - draft ${draft.id} (${draft.season}, ${draft.status}): no slot_to_roster_id from API; skipping`
+        );
+        continue;
+      }
+      if (apply) {
+        await db
+          .update(schema.drafts)
+          .set({ slotToRosterId: slotMap })
+          .where(eq(schema.drafts.id, draft.id));
+      }
+      stats.updated++;
+      log(
+        `  ${apply ? "+" : "."} draft ${draft.id} (${draft.season}): ${
+          Object.keys(slotMap).length
+        } slots`
+      );
+    } catch (err) {
+      stats.failed++;
+      log(
+        `  ! draft ${draft.id} (${draft.season}): fetch failed: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
+    }
+  }
+
+  log(
+    `\nDone. fetched=${stats.fetched} updated=${stats.updated} skipped=${stats.skippedNoMap} failed=${stats.failed}` +
+      (apply ? "" : " (dry-run)")
+  );
+
+  return stats;
+}
+
+// CLI entry — only executes when invoked directly via tsx / node.
+if (require.main === module) {
+  run(process.argv.slice(2)).then(
+    (stats) => process.exit(stats.failed > 0 ? 1 : 0),
+    (err) => {
+      console.error(err);
+      process.exit(1);
+    }
+  );
+}

--- a/scripts/calibrate-trade-grades.ts
+++ b/scripts/calibrate-trade-grades.ts
@@ -19,6 +19,7 @@ import { neon } from "@neondatabase/serverless";
 import { drizzle } from "drizzle-orm/neon-http";
 import { eq, and, inArray, sql } from "drizzle-orm";
 import * as schema from "../src/db/schema";
+import { Sleeper } from "../src/lib/sleeper";
 import * as fs from "fs";
 import * as path from "path";
 
@@ -69,18 +70,6 @@ async function fetchFantasyCalcValues(opts: {
 // Sleeper API helpers
 // ============================================================
 
-async function fetchSleeperDraft(
-  draftId: string
-): Promise<{
-  draft_id: string;
-  slot_to_roster_id?: Record<string, number>;
-  type: string;
-  status: string;
-}> {
-  const res = await fetch(`https://api.sleeper.app/v1/draft/${draftId}`);
-  if (!res.ok) throw new Error(`Sleeper API error: ${res.status}`);
-  return res.json();
-}
 
 // ============================================================
 // Pick resolution (mirrors src/services/tradeGrading.ts)
@@ -576,7 +565,7 @@ async function run() {
     // If we don't have slot_to_roster_id, fetch from Sleeper API
     if (!slotToRosterId && draft.status === "complete") {
       try {
-        const sleeperDraft = await fetchSleeperDraft(draft.id);
+        const sleeperDraft = await Sleeper.getDraft(draft.id);
         slotToRosterId = sleeperDraft.slot_to_roster_id || null;
         if (slotToRosterId) {
           // Store it in DB for future use

--- a/src/lib/__tests__/sleeper.test.ts
+++ b/src/lib/__tests__/sleeper.test.ts
@@ -120,6 +120,16 @@ describe("Sleeper API method routing", () => {
     );
   });
 
+  it("getDraft hits /v1/draft/:id (returns slot_to_roster_id)", async () => {
+    const fetchMock = jest.fn(() => Promise.resolve(jsonResponse({})));
+    global.fetch = fetchMock as unknown as typeof fetch;
+    const { Sleeper } = await import("../sleeper");
+    await Sleeper.getDraft("D1");
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.sleeper.app/v1/draft/D1"
+    );
+  });
+
   it("getDraftPicks hits /v1/draft/:id/picks", async () => {
     const fetchMock = jest.fn(() => Promise.resolve(jsonResponse([])));
     global.fetch = fetchMock as unknown as typeof fetch;

--- a/src/lib/sleeper.ts
+++ b/src/lib/sleeper.ts
@@ -242,6 +242,11 @@ export const Sleeper = {
   getDrafts: (leagueId: string) =>
     get<SleeperDraft[]>(`/league/${leagueId}/drafts`),
 
+  // The list endpoint above returns summary entries that omit
+  // `slot_to_roster_id`. Fetch the per-draft endpoint to get it.
+  getDraft: (draftId: string) =>
+    get<SleeperDraft>(`/draft/${draftId}`),
+
   getDraftPicks: (draftId: string) =>
     get<SleeperDraftPick[]>(`/draft/${draftId}/picks`),
 

--- a/src/services/__tests__/sync.coverage.test.ts
+++ b/src/services/__tests__/sync.coverage.test.ts
@@ -18,6 +18,7 @@ const sleeperMock = {
   getLeagueUsers: jest.fn(),
   getRosters: jest.fn(),
   getDrafts: jest.fn(),
+  getDraft: jest.fn(),
   getDraftPicks: jest.fn(),
   getTradedPicks: jest.fn(),
   getTransactions: jest.fn(),
@@ -271,9 +272,18 @@ function resetSleeper(status: "complete" | "in_season" = "complete") {
       status: "complete",
       start_time: 1_700_000_000_000,
       settings: {},
-      slot_to_roster_id: { "1": 1 },
     },
   ]);
+  sleeperMock.getDraft.mockResolvedValue({
+    draft_id: "D1",
+    league_id: "L1",
+    season: "2024",
+    type: "snake",
+    status: "complete",
+    start_time: 1_700_000_000_000,
+    settings: {},
+    slot_to_roster_id: { "1": 1 },
+  });
   sleeperMock.getDraftPicks.mockResolvedValue([
     {
       round: 1,
@@ -369,6 +379,26 @@ describe("syncLeague — drafts, traded picks, watermarks, winners bracket", () 
     expect(pickWrites.length).toBeGreaterThan(0);
   });
 
+  it("fetches /draft/{id} per draft to enrich slot_to_roster_id (#173)", async () => {
+    await syncLeague("L1", undefined, undefined, { skipGlobalSyncs: true });
+    // The list endpoint returns the draft id; the per-draft endpoint
+    // returns slot_to_roster_id. Both must fire on every sync, otherwise
+    // the lineage tracer pick→player remap silently no-ops.
+    expect(sleeperMock.getDrafts).toHaveBeenCalledWith("L1");
+    expect(sleeperMock.getDraft).toHaveBeenCalledWith("D1");
+  });
+
+  it("falls back to the list-endpoint draft when /draft/{id} throws", async () => {
+    sleeperMock.getDraft.mockRejectedValueOnce(new Error("boom"));
+    // Should not throw — partial data lands and the COALESCE upsert
+    // preserves any prior slot_to_roster_id in the DB.
+    await expect(
+      syncLeague("L1", undefined, undefined, { skipGlobalSyncs: true })
+    ).resolves.toBeUndefined();
+    const draftWrites = insertCalls.filter((c) => c.table === "drafts");
+    expect(draftWrites.length).toBeGreaterThan(0);
+  });
+
   it("skips fetching draft picks for non-complete drafts", async () => {
     sleeperMock.getDrafts.mockResolvedValue([
       {
@@ -381,6 +411,15 @@ describe("syncLeague — drafts, traded picks, watermarks, winners bracket", () 
         settings: {},
       },
     ]);
+    sleeperMock.getDraft.mockResolvedValue({
+      draft_id: "D2",
+      league_id: "L1",
+      season: "2024",
+      type: "snake",
+      status: "drafting",
+      start_time: 1,
+      settings: {},
+    });
     await syncLeague("L1", undefined, undefined, { skipGlobalSyncs: true });
     expect(sleeperMock.getDraftPicks).not.toHaveBeenCalled();
   });

--- a/src/services/__tests__/sync.test.ts
+++ b/src/services/__tests__/sync.test.ts
@@ -21,6 +21,7 @@ const sleeperMock = {
   getLeagueUsers: jest.fn(),
   getRosters: jest.fn(),
   getDrafts: jest.fn(),
+  getDraft: jest.fn(),
   getDraftPicks: jest.fn(),
   getTradedPicks: jest.fn(),
   getTransactions: jest.fn(),
@@ -154,6 +155,15 @@ function resetSleeperMocks() {
   sleeperMock.getLeagueUsers.mockResolvedValue([]);
   sleeperMock.getRosters.mockResolvedValue([]);
   sleeperMock.getDrafts.mockResolvedValue([]);
+  sleeperMock.getDraft.mockResolvedValue({
+    draft_id: "D1",
+    league_id: "L1",
+    season: "2024",
+    type: "snake",
+    status: "complete",
+    start_time: 0,
+    settings: {},
+  });
   sleeperMock.getDraftPicks.mockResolvedValue([]);
   sleeperMock.getTradedPicks.mockResolvedValue([]);
   sleeperMock.getWinnersBracket.mockResolvedValue([]);

--- a/src/services/__tests__/syncLeagueFamily.integration.test.ts
+++ b/src/services/__tests__/syncLeagueFamily.integration.test.ts
@@ -69,6 +69,7 @@ const sleeperMock = {
   getLeagueUsers: jest.fn(),
   getRosters: jest.fn(),
   getDrafts: jest.fn(),
+  getDraft: jest.fn(),
   getDraftPicks: jest.fn(),
   getTradedPicks: jest.fn(),
   getTransactions: jest.fn(),
@@ -186,9 +187,18 @@ function buildSleeperFixtures() {
       status: "complete",
       start_time: 1_700_000_000_000,
       settings: {},
-      slot_to_roster_id: { "1": 1, "2": 2 },
     },
   ]);
+  sleeperMock.getDraft.mockResolvedValue({
+    draft_id: TEST_DRAFT_ID,
+    league_id: TEST_LEAGUE_ID,
+    season: "2024",
+    type: "snake",
+    status: "complete",
+    start_time: 1_700_000_000_000,
+    settings: {},
+    slot_to_roster_id: { "1": 1, "2": 2 },
+  });
 
   sleeperMock.getDraftPicks.mockResolvedValue([
     {

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -221,9 +221,27 @@ async function runSyncLeague(
       })
   );
 
-  // Sync drafts (bulk upsert)
+  // Sync drafts (bulk upsert).
+  //
+  // The /league/{id}/drafts list endpoint returns summary entries that omit
+  // `slot_to_roster_id`. Fetch the per-draft endpoint for each so the slot
+  // map lands in the DB; without it, the lineage tracer's pick→player
+  // remap (graph route) silently no-ops and traded picks fail to resolve
+  // to the player drafted with them (#173).
   onProgress?.({ step: "drafts", detail: "Fetching draft data" });
-  const drafts = await Sleeper.getDrafts(leagueId);
+  const draftSummaries = await Sleeper.getDrafts(leagueId);
+  // Cap fan-out at the same limit transactions/matchups use. Falls back to
+  // the summary on a per-draft fetch failure so a flaky /draft/{id} can't
+  // sink the whole league sync — the COALESCE in the upsert below
+  // preserves any prior populated slot_to_roster_id when that happens.
+  const draftFetches = await pMapSettled(
+    draftSummaries,
+    (s) => Sleeper.getDraft(s.draft_id),
+    PER_WEEK_FETCH_CONCURRENCY
+  );
+  const drafts = draftFetches.map((r, i) =>
+    r.status === "fulfilled" ? r.value : draftSummaries[i]
+  );
 
   await batchInsert(
     schema.drafts,
@@ -243,7 +261,9 @@ async function runSyncLeague(
         set: {
           status: sql`excluded.status`,
           settings: sql`excluded.settings`,
-          slotToRosterId: sql`excluded.slot_to_roster_id`,
+          // COALESCE so a transient null from a flaky /draft/{id} fetch
+          // never overwrites a populated slot map (defense in depth).
+          slotToRosterId: sql`COALESCE(excluded.slot_to_roster_id, ${schema.drafts.slotToRosterId})`,
         },
       })
   );


### PR DESCRIPTION
Closes #173.

## Summary

`Sleeper.getDrafts()` calls `/league/{id}/drafts`, which returns **summary entries** that omit `slot_to_roster_id`. The list-endpoint bug has been writing NULL into `drafts.slot_to_roster_id` for the lifetime of that column. Without it, the lineage tracer's pick→player remap (`src/app/api/leagues/[familyId]/graph/route.ts:236`) silently no-ops and traded picks fail to resolve to the player drafted with them.

Verified directly against the Sleeper API:
- `/league/{id}/drafts` → list, no `slot_to_roster_id` key
- `/draft/{draft_id}` → single draft, includes the full slot map

Verified against prod for family `afc3acf8…`: every draft 2021–2026 has `slot_to_roster_id = NULL`.

The visible regression (R1→London missing, R2→Dotson swap, 2024 R1 unresolved) traces to this. The lineage tracer landing commit (`9da5c8f`) had a one-time backfill comment, and `scripts/calibrate-trade-grades.ts` has the same fallback in line, but every subsequent league sync **wipes the column back to NULL** via the upsert `slotToRosterId: sql\`excluded.slot_to_roster_id\``. Recent backend work (#150 lazy-on-visit, #151 chunked executor) increased re-sync cadence, which plausibly triggered the visible regression.

## What changed

- **`Sleeper.getDraft(draftId)`** in `src/lib/sleeper.ts` — hits `/draft/{id}` (returns the slot map).
- **`syncLeague`** enriches each draft via `pMapSettled` with the same `PER_WEEK_FETCH_CONCURRENCY=5` cap as transactions/matchups. Falls back to the list-endpoint summary on a per-draft fetch failure so a flaky `/draft/{id}` can't sink the whole league sync.
- **`drafts` upsert** COALESCEs `excluded.slot_to_roster_id` with the existing column so a transient null never wipes a populated slot map (defense in depth — the same pattern that ate the original backfill).
- **`scripts/backfill-slot-to-roster-id.ts`** — idempotent backfill (dry-run by default, `--apply` to persist). Available as `npm run backfill:slot-to-roster-id`.
- **Cleanup**: removed the dead `fetchSleeperDraft` helper in `scripts/calibrate-trade-grades.ts` in favor of `Sleeper.getDraft`.

## Tests

- 5 new tests for the backfill script (dry-run, `--apply`, pre-draft empty-map skip, isolated fetch failures, `--help`).
- 2 new tests for `syncLeague` covering the per-draft fan-out and the fallback-on-throw branch.
- New unit test for `Sleeper.getDraft` URL routing.
- Existing fixtures updated to mock `getDraft` separately from `getDrafts`, mirroring how the real API splits the data.

## Verification

- [x] `npx tsc --noEmit` clean
- [x] `npm test` — 409/409 passing
- [x] `npm run lint` — only pre-existing warnings unchanged by this PR
- [x] `npm run build` — green
- [x] Dry-run against prod confirms 6 drafts fetched with 12 slots each; apply step deferred until after merge per #173 plan.
- [ ] Post-merge: run `npm run backfill:slot-to-roster-id -- --apply` against prod to repair existing rows so users see the fix without waiting for natural re-sync.

## Test plan post-merge

1. Run the backfill against prod with `--apply`; confirm `slot_to_roster_id` populated for all 6 drafts in family `afc3acf8…`.
2. Visit https://dynasty-dna.vercel.app/league/afc3acf8-2d18-47c9-80c1-998252c9a06a/graph?from=overview&seedPlayerId=4866 and confirm:
   - The 2022 R1 chain (jrygrande's, traded in the Saquon transaction) resolves to Drake London.
   - The 2022 R2 chain resolves to Trey McBride (not Dotson).
   - The 2024 R1 chain originating from rkerstiens resolves to whoever Stove17 drafted with it.
3. Trigger a fresh `npm run sync:family <id>` against dev; confirm `slot_to_roster_id` populated naturally without the backfill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)