### PR TITLE
Fix #177 (2/2): add loading.tsx with DNA helix for /league navigation

### DIFF
--- a/src/app/(app)/league/[familyId]/loading.tsx
+++ b/src/app/(app)/league/[familyId]/loading.tsx
@@ -1,0 +1,33 @@
+import { DnaHelix } from "@/components/loading/DnaHelix";
+
+/**
+ * Route-level Suspense fallback for `/league/[familyId]/...` (#177, fix 2).
+ *
+ * The layout above (`layout.tsx`) awaits `ensureLeagueFresh()` server-side,
+ * which in the stale path can run a multi-second sync before responding.
+ * Without this file, Next.js renders no fallback during navigation — a
+ * click on "Open" looks dead until the layout resolves. App Router uses
+ * route-level `loading.tsx` as the automatic Suspense boundary, so the
+ * helix flashes immediately while the server-side freshness gate runs.
+ *
+ * Scope: presentation only. No polling, no jobId, no fetching — that's
+ * the cold-sync screen's job (rendered by the layout when `ready=false`).
+ * Stale path renders the layout, which Suspense-falls-back to this file.
+ *
+ * Reduced motion is handled inside `DnaHelix` itself.
+ */
+export default function LeagueFamilyLoading() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center bg-background">
+      <div className="flex flex-col items-center text-center gap-6 px-6">
+        <DnaHelix />
+        <p
+          role="status"
+          className="font-mono text-sm text-muted-foreground"
+        >
+          Loading league&hellip;
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `src/app/(app)/league/[familyId]/loading.tsx` — a route-level Suspense fallback that renders the existing `<DnaHelix />` mark while the layout's server-side `ensureLeagueFresh()` runs.
- Fixes the dead-button feel of clicking **Open** on `/start`: the layout above awaits a freshness gate that, on the stale path, can run a multi-second sync before responding. Today there's no `loading.tsx` anywhere in `src/app/`, so App Router shows nothing during that wait.
- Presentation only: no polling, no jobId, no client fetches. The cold-sync screen (rendered by the layout when `ready=false`) still owns the chunked-tick loop for cold path; this file only covers the stale-path Suspense boundary.

## Why this approach

Next.js App Router automatically wraps route segments with their `loading.tsx` as a Suspense boundary, so the fallback shows the instant a navigation begins — no client wiring needed. The fix is correctness (instant feedback), not duration tuning; for the very fresh case the helix may flash for <100ms, which is fine.

Refs #177 — companion to fix 1 (lazy-sync watermark bump) shipping in a parallel PR. Issue stays open.

## Test plan

- [ ] `npm run lint` — clean (only pre-existing warnings)
- [ ] `npm run build` — clean
- [ ] `npm run dev`, navigate to `/start`, enter a username, click **Open** on a league. Confirm the helix flashes immediately on click rather than the previous dead-button delay.
- [ ] Reduced-motion: confirm the helix's existing reduced-motion behavior (pulse-only, no rotor) still kicks in via the OS setting — no new code required.
- [ ] Accessibility: the helix has `role="img"` from `<DnaHelix />`; the status text is wrapped in `role="status"`.