### PR TITLE
Fix #177 (1/2): bump lastSyncedAt for skipped seasons + wire apiCallsMade for lazy syncs

### DIFF
--- a/src/app/api/sync/league/__tests__/route.test.ts
+++ b/src/app/api/sync/league/__tests__/route.test.ts
@@ -64,6 +64,8 @@ beforeEach(() => {
   acquireSyncLockMock.mockReset();
   releaseSyncLockMock.mockReset();
   dbSelectChain.mockReset();
+  // Default sync result so route handlers can read .apiCallsMade.
+  syncLeagueFamilyMock.mockResolvedValue({ apiCallsMade: 0 });
   process.env.CRON_SECRET = "test-cron-secret";
 });
 
@@ -104,7 +106,7 @@ describe("POST /api/sync/league", () => {
     dbSelectChain.mockResolvedValueOnce([
       { leagueId: "l-2025", season: "2025", familyId: "fam-origin" },
     ]);
-    syncLeagueFamilyMock.mockResolvedValueOnce(undefined);
+    syncLeagueFamilyMock.mockResolvedValueOnce({ apiCallsMade: 7 });
 
     const res = await POST(
       makeRequest(
@@ -150,7 +152,7 @@ describe("POST /api/sync/league — fail-closed when CRON_SECRET never set", () 
     dbSelectChain.mockResolvedValueOnce([
       { leagueId: "l-2025", season: "2025", familyId: "fam-no-secret" },
     ]);
-    syncLeagueFamilyMock.mockResolvedValueOnce(undefined);
+    syncLeagueFamilyMock.mockResolvedValueOnce({ apiCallsMade: 0 });
 
     const res = await POST(
       makeRequest(
@@ -192,7 +194,7 @@ describe("POST /api/sync/league — happy paths", () => {
       { leagueId: "l-2024", season: "2024", familyId: "fam-1" },
       { leagueId: "l-2025", season: "2025", familyId: "fam-1" },
     ]);
-    syncLeagueFamilyMock.mockResolvedValueOnce(undefined);
+    syncLeagueFamilyMock.mockResolvedValueOnce({ apiCallsMade: 23 });
 
     const res = await POST(
       makeRequest(
@@ -210,6 +212,12 @@ describe("POST /api/sync/league — happy paths", () => {
       "fam-1",
       { trigger: "manual" }
     );
-    expect(releaseSyncLockMock).toHaveBeenCalledWith("job-1", "success");
+    // Audit fields wired through so sync_jobs reflects API spend (#177).
+    expect(releaseSyncLockMock).toHaveBeenCalledWith(
+      "job-1",
+      "success",
+      undefined,
+      { apiCallsMade: 23 }
+    );
   });
 });

--- a/src/app/api/sync/league/route.ts
+++ b/src/app/api/sync/league/route.ts
@@ -58,19 +58,15 @@ export async function POST(req: NextRequest) {
         .sort((a, b) => Number(a.season) - Number(b.season))
         .map((m) => m.leagueId);
 
-      if (allLeagueIds.length === 0) {
-        // Fallback: sync just the requested league
-        await syncLeagueFamily([leagueId], undefined, familyId, {
-          trigger: "manual",
-        });
-      } else {
-        // Sync all seasons in the family
-        await syncLeagueFamily(allLeagueIds, undefined, familyId, {
-          trigger: "manual",
-        });
-      }
+      // Fallback to the single league if family discovery returned nothing.
+      const idsToSync = allLeagueIds.length === 0 ? [leagueId] : allLeagueIds;
+      const result = await syncLeagueFamily(idsToSync, undefined, familyId, {
+        trigger: "manual",
+      });
 
-      await releaseSyncLock(jobId, "success");
+      await releaseSyncLock(jobId, "success", undefined, {
+        apiCallsMade: result.apiCallsMade,
+      });
 
       return NextResponse.json({
         success: true,

--- a/src/lib/__tests__/freshness.test.ts
+++ b/src/lib/__tests__/freshness.test.ts
@@ -31,8 +31,12 @@ const releaseSyncLockMock = jest.fn();
 jest.mock("@/services/syncLock", () => ({
   acquireSyncLock: (ref: string, opts?: unknown) =>
     acquireSyncLockMock(ref, opts),
-  releaseSyncLock: (jobId: string, status: string, error?: string) =>
-    releaseSyncLockMock(jobId, status, error),
+  releaseSyncLock: (
+    jobId: string,
+    status: string,
+    error?: string,
+    audit?: unknown
+  ) => releaseSyncLockMock(jobId, status, error, audit),
 }));
 
 const recordBreadcrumbMock = jest.fn();
@@ -172,6 +176,8 @@ beforeEach(() => {
 
   // Default happy-path resolution.
   resolveFamilyMock.mockResolvedValue(FAMILY_ID);
+  // Default sync result — tests can override per case.
+  syncLeagueFamilyMock.mockResolvedValue({ apiCallsMade: 0 });
   // Default: family row + members exist.
   dbState.family = [{ rootLeagueId: ROOT_LEAGUE }];
   dbState.members = MEMBERS;
@@ -264,7 +270,8 @@ describe("ensureLeagueFresh — fresh path", () => {
     expect(releaseSyncLockMock).toHaveBeenCalledWith(
       "job-stale-1",
       "success",
-      undefined
+      undefined,
+      { apiCallsMade: 0 }
     );
   });
 
@@ -304,7 +311,8 @@ describe("ensureLeagueFresh — stale path", () => {
     expect(releaseSyncLockMock).toHaveBeenCalledWith(
       "job-1",
       "success",
-      undefined
+      undefined,
+      { apiCallsMade: 0 }
     );
     expect(recordBreadcrumbMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -313,6 +321,26 @@ describe("ensureLeagueFresh — stale path", () => {
         scope: FAMILY_ID,
         outcome: "success",
       })
+    );
+  });
+
+  it("threads apiCallsMade from syncLeagueFamily into releaseSyncLock + breadcrumb", async () => {
+    const now = new Date("2025-04-15T12:00:00Z");
+    const stale = new Date(now.getTime() - 2 * 60 * 60 * 1000);
+    dbState.leagues = [{ lastSyncedAt: stale }];
+    acquireSyncLockMock.mockResolvedValue("job-counted-1");
+    syncLeagueFamilyMock.mockResolvedValue({ apiCallsMade: 42 });
+
+    await ensureLeagueFresh(FAMILY_ID, { now });
+
+    expect(releaseSyncLockMock).toHaveBeenCalledWith(
+      "job-counted-1",
+      "success",
+      undefined,
+      { apiCallsMade: 42 }
+    );
+    expect(recordBreadcrumbMock).toHaveBeenCalledWith(
+      expect.objectContaining({ apiCalls: 42, outcome: "success" })
     );
   });
 
@@ -329,7 +357,8 @@ describe("ensureLeagueFresh — stale path", () => {
     expect(releaseSyncLockMock).toHaveBeenCalledWith(
       "job-fail-1",
       "failed",
-      "boom"
+      "boom",
+      { apiCallsMade: 0 }
     );
     expect(recordBreadcrumbMock).toHaveBeenCalledWith(
       expect.objectContaining({ outcome: "failed", error: "boom" })

--- a/src/lib/freshness.ts
+++ b/src/lib/freshness.ts
@@ -276,20 +276,22 @@ export async function ensureLeagueFresh(
   const start = Date.now();
   let outcome: "success" | "failed" = "success";
   let errMsg: string | undefined;
+  let apiCallsMade = 0;
 
   try {
     const leagueIds = await getFamilyLeagueIds(familyId);
-    await withSyncTransaction(
+    const result = await withSyncTransaction(
       `freshness.ensureLeagueFresh(${familyId})`,
       "sync.lazy",
       () =>
         syncLeagueFamily(leagueIds, undefined, familyId, { trigger: "lazy" })
     );
-    await releaseSyncLock(jobId, "success");
+    apiCallsMade = result.apiCallsMade;
+    await releaseSyncLock(jobId, "success", undefined, { apiCallsMade });
   } catch (err) {
     outcome = "failed";
     errMsg = err instanceof Error ? err.message : String(err);
-    await releaseSyncLock(jobId, "failed", errMsg);
+    await releaseSyncLock(jobId, "failed", errMsg, { apiCallsMade });
   } finally {
     recordSyncBreadcrumb({
       source: "league-family",
@@ -297,6 +299,7 @@ export async function ensureLeagueFresh(
       scope: familyId,
       durationMs: Date.now() - start,
       outcome,
+      apiCalls: apiCallsMade,
       error: errMsg,
     });
   }

--- a/src/lib/sleeper/__tests__/rateLimit.test.ts
+++ b/src/lib/sleeper/__tests__/rateLimit.test.ts
@@ -24,6 +24,7 @@ import {
   flushSleeperRateGauge,
   getCurrentCallsPerMinute,
   getCurrentUtilizationPct,
+  getTotalSleeperCalls,
   __resetSleeperRateState,
   __getLastFlushAt,
   SLEEPER_LIMIT_PER_MINUTE,
@@ -171,5 +172,18 @@ describe("Sleeper rate-limit gauge", () => {
     expect(() => {
       recordSleeperCall(1_700_000_000_000);
     }).not.toThrow();
+  });
+
+  it("getTotalSleeperCalls is monotonic across the rolling-window prune", () => {
+    const t0 = 1_700_000_000_000;
+    expect(getTotalSleeperCalls()).toBe(0);
+    recordSleeperCall(t0);
+    recordSleeperCall(t0 + 1000);
+    expect(getTotalSleeperCalls()).toBe(2);
+    // Advance well past the rolling window — pruning the window must not
+    // touch the lifetime counter (the counter is what attribution snapshots).
+    recordSleeperCall(t0 + 120_000);
+    expect(getCurrentCallsPerMinute(t0 + 120_000)).toBe(1);
+    expect(getTotalSleeperCalls()).toBe(3);
   });
 });

--- a/src/lib/sleeper/rateLimit.ts
+++ b/src/lib/sleeper/rateLimit.ts
@@ -23,6 +23,13 @@ const FLUSH_INTERVAL_MS = 60 * 1000;
 
 const callTimestamps: number[] = [];
 let lastFlushAt = 0;
+/**
+ * Monotonic count of every Sleeper call made since process start. Snapshot
+ * with `getTotalSleeperCalls()` before/after a sync to attribute API-call
+ * counts to a `sync_jobs` row. Separate from the rolling window (which
+ * prunes); never decrements.
+ */
+let totalCalls = 0;
 
 function isDsnConfigured(): boolean {
   return Boolean(
@@ -117,6 +124,7 @@ export function flushSleeperRateGauge(now: number = Date.now()): void {
  */
 export function recordSleeperCall(now: number = Date.now()): void {
   callTimestamps.push(now);
+  totalCalls++;
   pruneOldCalls(now);
 
   if (now - lastFlushAt >= FLUSH_INTERVAL_MS) {
@@ -124,10 +132,19 @@ export function recordSleeperCall(now: number = Date.now()): void {
   }
 }
 
+/**
+ * Snapshot the lifetime call count. Used by sync entry points to attribute
+ * Sleeper API spend to a `sync_jobs` row by diffing before/after.
+ */
+export function getTotalSleeperCalls(): number {
+  return totalCalls;
+}
+
 /** Test-only: drop every retained call timestamp. */
 export function __resetSleeperRateState(): void {
   callTimestamps.length = 0;
   lastFlushAt = 0;
+  totalCalls = 0;
 }
 
 /** Test-only: read the lastFlushAt cursor. */

--- a/src/services/__tests__/sync.coverage.test.ts
+++ b/src/services/__tests__/sync.coverage.test.ts
@@ -591,6 +591,61 @@ describe("syncLeagueFamily", () => {
     expect(sleeperMock.getLeague).not.toHaveBeenCalledWith("L_recent");
   });
 
+  it("bumps lastSyncedAt for skipped recently-synced seasons (#177)", async () => {
+    // Three completed seasons all within the 7-day skip window. None should
+    // hit Sleeper, but all three must get their `lastSyncedAt` bumped so the
+    // family-MIN watermark advances on every lazy run.
+    const recentTs = new Date(Date.now() - 60 * 1000);
+    dbState.leagueStatuses = [
+      { id: "L1", status: "complete", lastSyncedAt: recentTs },
+      { id: "L2", status: "complete", lastSyncedAt: recentTs },
+      { id: "L3", status: "complete", lastSyncedAt: recentTs },
+    ];
+
+    await syncLeagueFamily(["L1", "L2", "L3"], undefined, undefined);
+
+    // No Sleeper traffic for any skipped league.
+    expect(sleeperMock.getLeague).not.toHaveBeenCalled();
+
+    // Exactly one batched UPDATE against leagues that bumps lastSyncedAt.
+    const watermarkBumps = updateCalls.filter(
+      (c) => c.table === "leagues" && "lastSyncedAt" in c.set
+    );
+    expect(watermarkBumps).toHaveLength(1);
+    expect(watermarkBumps[0].set.lastSyncedAt).toBeInstanceOf(Date);
+  });
+
+  it("does NOT issue the skip-bump UPDATE when no leagues are skipped", async () => {
+    // All-stale: no skipIds populated -> no bump UPDATE issued.
+    const staleTs = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000);
+    dbState.leagueStatuses = [
+      { id: "L1", status: "complete", lastSyncedAt: staleTs },
+    ];
+
+    sleeperMock.getLeague.mockImplementation(async (id: string) => ({
+      league_id: id,
+      name: id,
+      season: "2024",
+      previous_league_id: null,
+      status: "complete",
+      settings: {},
+      scoring_settings: {},
+      roster_positions: [],
+      total_rosters: 12,
+      draft_id: "D",
+    }));
+
+    await syncLeagueFamily(["L1"], undefined, undefined);
+
+    const watermarkBumps = updateCalls.filter(
+      (c) =>
+        c.table === "leagues" &&
+        "lastSyncedAt" in c.set &&
+        Object.keys(c.set).length === 1
+    );
+    expect(watermarkBumps).toHaveLength(0);
+  });
+
   it("treats unknown leagues as active (sequential path)", async () => {
     dbState.leagueStatuses = []; // no status row -> goes to active branch
 
@@ -648,7 +703,7 @@ describe("syncLeagueFamily", () => {
 
     await expect(
       syncLeagueFamily(["L1"], undefined, "fam_1")
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual(expect.objectContaining({ apiCallsMade: expect.any(Number) }));
   });
 
   it("throws when EVERY attempted season fails", async () => {
@@ -690,7 +745,7 @@ describe("syncLeagueFamily", () => {
 
     await expect(
       syncLeagueFamily(["L1", "L2"], undefined, "fam_1")
-    ).resolves.toBeUndefined();
+    ).resolves.toEqual(expect.objectContaining({ apiCallsMade: expect.any(Number) }));
     expect(calls).toBeGreaterThanOrEqual(2);
   });
 

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -17,6 +17,7 @@ import { pMapSettled } from "@/lib/concurrency";
 import { recordSyncBreadcrumb } from "@/lib/observability/syncBreadcrumb";
 import type { SyncTrigger } from "@/lib/observability/syncBreadcrumb";
 import { withSyncTransaction } from "@/lib/observability/withSyncTransaction";
+import { getTotalSleeperCalls } from "@/lib/sleeper/rateLimit";
 
 /**
  * Per-week fetch concurrency for transactions/matchups within a single season.
@@ -589,6 +590,12 @@ const COMPLETED_STALENESS_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
 // the meaningful win, so we serialize across seasons.
 const PARALLEL_CONCURRENCY = 1;
 
+export interface SyncLeagueFamilyResult {
+  /** Sleeper API calls made during this run. Snapshotted at entry/exit so it
+   *  attributes correctly even when the global rate-limit window churns. */
+  apiCallsMade: number;
+}
+
 /**
  * Sync the entire league family (all seasons).
  * Hoists shared syncs (players, nflverse, fantasyCalc) to run once.
@@ -600,12 +607,13 @@ export async function syncLeagueFamily(
   onProgress?: ProgressCallback,
   familyId?: string,
   opts?: { trigger?: SyncTrigger }
-): Promise<void> {
+): Promise<SyncLeagueFamilyResult> {
   const trigger = opts?.trigger ?? "manual";
   const scope = familyId
     ? `family=${familyId}`
     : `leagues=${leagueIds.join(",") || "(none)"}`;
   const startedAt = Date.now();
+  const apiCallsBefore = getTotalSleeperCalls();
 
   try {
     await withSyncTransaction(
@@ -613,20 +621,25 @@ export async function syncLeagueFamily(
       "sync.family",
       () => runSyncLeagueFamily(leagueIds, onProgress, familyId, trigger),
     );
+    const apiCallsMade = getTotalSleeperCalls() - apiCallsBefore;
     recordSyncBreadcrumb({
       source: "league-family",
       trigger,
       scope,
       outcome: "success",
       durationMs: Date.now() - startedAt,
+      apiCalls: apiCallsMade,
     });
+    return { apiCallsMade };
   } catch (err) {
+    const apiCallsMade = getTotalSleeperCalls() - apiCallsBefore;
     recordSyncBreadcrumb({
       source: "league-family",
       trigger,
       scope,
       outcome: "failed",
       durationMs: Date.now() - startedAt,
+      apiCalls: apiCallsMade,
       error: err instanceof Error ? err.message : String(err),
     });
     throw err;
@@ -722,6 +735,17 @@ async function runSyncLeagueFamily(
       step: "family",
       detail: `Skipping ${skipIds.length} recently-synced season(s)`,
     });
+
+    // Bump lastSyncedAt for skipped leagues. The freshness gate
+    // (`ensureLeagueFresh`) reads MIN(lastSyncedAt) across the family — without
+    // this bump, the watermark stays pinned to whichever skipped season is
+    // oldest and the gate fires on every visit instead of once per window.
+    // Verifying "this league does not need a fetch" IS a sync event from the
+    // gate's perspective. See #177.
+    await db
+      .update(schema.leagues)
+      .set({ lastSyncedAt: new Date() })
+      .where(inArray(schema.leagues.id, skipIds));
   }
 
   // Process completed seasons in parallel (concurrency limited).


### PR DESCRIPTION
## Summary

Two surgical fixes for the lazy-sync watermark trap diagnosed in #177. Refs #177 -- this is partial (Fix 2, the `loading.tsx` UX, lands in a separate parallel PR; do **not** close #177 on merge).

### The bug (Fix 1)

`ensureLeagueFresh` reads `MIN(lastSyncedAt)` across every league in a family. `syncLeagueFamily` skips completed seasons within the 7-day staleness window (`skipIds`), but **never touches their `lastSyncedAt`** -- so the family-wide MIN stays pinned to whichever skipped season was oldest, and the freshness gate fires on every visit instead of once per window. The issue comment "Measurements (prod, last 24h)" verified this against a live family: 5 historical seasons at `15:08 EDT`, only the active 2026 league bumped to ~now, gate firing every 8 minutes.

**Fix:** after populating `skipIds`, issue a single batched `UPDATE leagues SET last_synced_at = NOW() WHERE id IN (skipIds)`. Semantic: "we deliberately verified this league does not need a fetch" *is* a sync event from the freshness gate's perspective. Two lines, no migration, no semantic change to user-visible data.

### Instrumentation hygiene (Fix 4)

`sync_jobs.api_calls_made` was always 0 for lazy syncs because `releaseSyncLock` in `freshness.ts` was called with no audit. Wired it through:

- Added monotonic `getTotalSleeperCalls()` to `src/lib/sleeper/rateLimit.ts` -- separate from the existing 60s rolling window so it never decrements.
- `syncLeagueFamily` now snapshots before/after and returns `{ apiCallsMade }`. Both lazy (`freshness.ts`) and manual (`/api/sync/league`) call sites pass it to `releaseSyncLock` via `audit.apiCallsMade`. Also added to the success/failure breadcrumbs.

## Test plan

- [x] `npm run lint` passes (no new warnings)
- [x] `npm run build` passes
- [x] `npm test` passes (410 passed, 3 pre-existing skipped integration tests)
- [x] New test in `sync.coverage.test.ts`: asserts `lastSyncedAt` UPDATE issued exactly once when skipIds is populated, and **not** issued when no leagues are skipped
- [x] New test in `freshness.test.ts`: asserts `apiCallsMade` from `syncLeagueFamily`'s result is threaded into both `releaseSyncLock` and the breadcrumb
- [x] New test in `rateLimit.test.ts`: asserts the lifetime counter is monotonic across rolling-window prunes
- [x] Existing `route.test.ts` updated for the new `releaseSyncLock` audit signature
- [ ] Post-merge: tail `sync_jobs` for one lazy run on the affected family and confirm `api_calls_made > 0` and that subsequent visits within the 1h window do NOT trigger another stale sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)