### PR TITLE
Fix #177: stream loading.tsx instantly (helix appears on click, not after gate)

### DIFF
--- a/src/app/(app)/league/[familyId]/layout.tsx
+++ b/src/app/(app)/league/[familyId]/layout.tsx
@@ -1,5 +1,7 @@
+import { Suspense } from "react";
 import { ensureLeagueFresh } from "@/lib/freshness";
 import { ColdSyncLoadingScreen } from "@/components/loading/ColdSyncLoadingScreen";
+import LeagueFamilyLoading from "./loading";
 
 /**
  * Server-component layout for every page under `/league/[familyId]/...`.
@@ -16,27 +18,43 @@ import { ColdSyncLoadingScreen } from "@/components/loading/ColdSyncLoadingScree
  *                              navigates to the dashboard when the chunked
  *                              executor reports `completed`.
  *
- * The gate is single-pass per request — `ensureLeagueFresh` short-circuits
- * cheaply when data is fresh, and concurrency is enforced by the existing
- * `syncJobs` lock. When the same family is being indexed by another
- * visitor, `ensureLeagueFresh` returns the in-flight `jobId`, so both
- * tabs share one chunked run.
+ * Streaming contract (#177 follow-up): the layout itself MUST stay
+ * synchronous and return immediately. The slow `await ensureLeagueFresh()`
+ * lives inside `<FreshnessGate>`, which is wrapped in a `<Suspense>`
+ * boundary so the helix fallback flushes in the first response chunk. If
+ * the layout `await`ed at the top level, the server couldn't send any
+ * bytes until the gate resolved — the browser would stay frozen on the
+ * previous page for the full sync duration before the helix appeared.
  */
-export default async function LeagueFamilyLayout({
+export default function LeagueFamilyLayout({
   children,
   params,
 }: {
   children: React.ReactNode;
   params: { familyId: string };
 }) {
-  const result = await ensureLeagueFresh(params.familyId);
+  return (
+    <Suspense fallback={<LeagueFamilyLoading />}>
+      <FreshnessGate familyId={params.familyId}>{children}</FreshnessGate>
+    </Suspense>
+  );
+}
+
+async function FreshnessGate({
+  familyId,
+  children,
+}: {
+  familyId: string;
+  children: React.ReactNode;
+}) {
+  const result = await ensureLeagueFresh(familyId);
 
   if (!result.ready) {
     // `result.familyId` is guaranteed when `ready === false` — the cold
     // path resolves the family before deciding to lazy-sync.
     return (
       <ColdSyncLoadingScreen
-        familyId={result.familyId ?? params.familyId}
+        familyId={result.familyId ?? familyId}
         initialJobId={result.jobId}
       />
     );


### PR DESCRIPTION
## Why

Reopens #177. After PR #178 added `loading.tsx`, users still reported:

> still getting occasional feeling that the open button for a given league doesn't work. will sit there motionless for a few seconds, before flashing to the helix, and ultimately loading the page.

The fallback file existed but wasn't firing on click — the helix only appeared once the server's `ensureLeagueFresh()` had already completed.

## Root cause

`src/app/(app)/league/[familyId]/layout.tsx` was an `async` server component that awaited `ensureLeagueFresh()` **before** returning any JSX. Until the await resolved:

- The layout function had no return value, so React had no Suspense boundary to fall back from.
- The server couldn't flush a single byte to the browser.
- The browser stayed on `/start` for the full sync duration, then received the rendered route in one shot.

`loading.tsx` is a route-segment Suspense fallback — but it can only catch a *child* that suspends. When the **layout itself** is the suspending unit, there's no parent boundary inside the segment to render the fallback. So the helix never showed during the await.

## Fix

Keep `LeagueFamilyLayout` synchronous and return immediately. Push the await into a `FreshnessGate` child server component wrapped in `<Suspense fallback={<LeagueFamilyLoading />}>`:

```tsx
export default function LeagueFamilyLayout({ children, params }) {
  return (
    <Suspense fallback={<LeagueFamilyLoading />}>
      <FreshnessGate familyId={params.familyId}>{children}</FreshnessGate>
    </Suspense>
  );
}

async function FreshnessGate({ familyId, children }) {
  const result = await ensureLeagueFresh(familyId);
  if (!result.ready) return <ColdSyncLoadingScreen .../>;
  return <>{children}</>;
}
```

Now the layout returns instantly, the Suspense fallback (the same helix UI as `loading.tsx`) flushes in the very first response chunk, and the browser shows the helix the moment navigation commits — even if the gate takes 18s.

## Test plan

- [x] `npm test` — 413/413 passing (freshness logic untouched)
- [x] `npm run lint` — clean (only pre-existing warnings)
- [x] `npm run build` — succeeds
- [ ] Vercel preview: click "Open" on `/start` for a stale league, helix appears within ~100ms instead of after the full sync
- [ ] Cold-path still works (new league → ColdSyncLoadingScreen with polling)
- [ ] Fresh-path still works (recent visit → no helix flash, page renders directly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)