### PR TITLE
Fix #183: 3D DNA helix using three.js + R3F

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-slot": "^1.2.4",
         "@radix-ui/react-tabs": "^1.1.13",
         "@radix-ui/react-tooltip": "^1.2.8",
+        "@react-three/fiber": "^8.18.0",
         "@sentry/nextjs": "^10.52.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -34,6 +35,7 @@
         "resend": "^6.12.2",
         "tailwind-merge": "^3.3.1",
         "tailwindcss-animate": "^1.0.7",
+        "three": "^0.160.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -42,6 +44,7 @@
         "@types/node": "^20.14.10",
         "@types/react": "^18.3.3",
         "@types/react-dom": "^18.3.0",
+        "@types/three": "^0.160.0",
         "autoprefixer": "^10.4.19",
         "dotenv": "^17.2.2",
         "dotenv-cli": "^11.0.0",
@@ -504,6 +507,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -4198,6 +4210,81 @@
       "integrity": "sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==",
       "license": "MIT"
     },
+    "node_modules/@react-three/fiber": {
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/@react-three/fiber/-/fiber-8.18.0.tgz",
+      "integrity": "sha512-FYZZqD0UUHUswKz3LQl2Z7H24AhD14XGTsIRw3SJaXUxyfVMi+1yiZGmqTcPt/CkPpdU7rrxqcyQ1zJE5DjvIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.17.8",
+        "@types/react-reconciler": "^0.26.7",
+        "@types/webxr": "*",
+        "base64-js": "^1.5.1",
+        "buffer": "^6.0.3",
+        "its-fine": "^1.0.6",
+        "react-reconciler": "^0.27.0",
+        "react-use-measure": "^2.1.7",
+        "scheduler": "^0.21.0",
+        "suspend-react": "^0.1.3",
+        "zustand": "^3.7.1"
+      },
+      "peerDependencies": {
+        "expo": ">=43.0",
+        "expo-asset": ">=8.4",
+        "expo-file-system": ">=11.0",
+        "expo-gl": ">=11.0",
+        "react": ">=18 <19",
+        "react-dom": ">=18 <19",
+        "react-native": ">=0.64",
+        "three": ">=0.133"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "expo-asset": {
+          "optional": true
+        },
+        "expo-file-system": {
+          "optional": true
+        },
+        "expo-gl": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/@react-three/fiber/node_modules/zustand": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@reactflow/background": {
       "version": "11.3.14",
       "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
@@ -5848,14 +5935,12 @@
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
       "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "18.3.24",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.24.tgz",
       "integrity": "sha512-0dLEBsA1kI3OezMBF8nSsb7Nk19ZnsyE1LLhB8r27KbgU5H4pvuqZLdtE+aUkJVoXgTVuA+iLIwmZ0TuK4tx6A==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -5872,10 +5957,26 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/react-reconciler": {
+      "version": "0.26.7",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.26.7.tgz",
+      "integrity": "sha512-mBDYl8x+oyPX/VBb3E638N0B7xG+SPk/EAMcVPeexqus/5aTpTphQi0curhhshOqRrc9t6OPoJfEUkbymse/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/stack-utils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
       "integrity": "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
       "dev": true,
       "license": "MIT"
     },
@@ -5888,10 +5989,29 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/three": {
+      "version": "0.160.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.160.0.tgz",
+      "integrity": "sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/stats.js": "*",
+        "@types/webxr": "*",
+        "fflate": "~0.6.10",
+        "meshoptimizer": "~0.18.1"
+      }
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
       "license": "MIT"
     },
     "node_modules/@types/yargs": {
@@ -7247,6 +7367,26 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.27",
       "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz",
@@ -7348,6 +7488,30 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
       }
     },
     "node_modules/buffer-from": {
@@ -7743,7 +7907,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/csv-parse": {
@@ -9317,6 +9480,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.6.10",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.6.10.tgz",
+      "integrity": "sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9876,6 +10046,26 @@
       "engines": {
         "node": ">=10.17.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -10596,6 +10786,27 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/its-fine": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/its-fine/-/its-fine-1.2.5.tgz",
+      "integrity": "sha512-fXtDA0X0t0eBYAGLVM5YsgJGsJ5jEmqZEPrGbzdf5awjv0xE7nqv3TVnvtUF060Tkes15DbDAKW/I48vsb6SyA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/react-reconciler": "^0.28.0"
+      },
+      "peerDependencies": {
+        "react": ">=18.0"
+      }
+    },
+    "node_modules/its-fine/node_modules/@types/react-reconciler": {
+      "version": "0.28.9",
+      "resolved": "https://registry.npmjs.org/@types/react-reconciler/-/react-reconciler-0.28.9.tgz",
+      "integrity": "sha512-HHM3nxyUZ3zAylX8ZEyrDNd2XZOnQ0D5XfunJF5FLQnZbHHYq4UWvW1QfelQNXv1ICNkwYhfxjwfnqivYB6bFg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*"
       }
     },
     "node_modules/jackspeak": {
@@ -11951,6 +12162,13 @@
         "node": ">= 8"
       }
     },
+    "node_modules/meshoptimizer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.18.1.tgz",
+      "integrity": "sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -13024,6 +13242,31 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/react-reconciler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.27.0.tgz",
+      "integrity": "sha512-HmMDKciQjYmBRGuuhIaKA1ba/7a+UsM5FzOZsMO2JYHt9Jh8reCb7j1eDC95NOyUlKM9KRyvdx0flBuDvYSBoA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.21.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
+      }
+    },
+    "node_modules/react-reconciler/node_modules/scheduler": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.21.0.tgz",
+      "integrity": "sha512-1r87x5fz9MXqswA2ERLo0EbOAU74DpIUO090gIasYTqlVoJeMcl+Z1Rg7WHz+qtPujhS/hGIt9kxZOYBV3faRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
     "node_modules/react-redux": {
       "version": "9.2.0",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
@@ -13112,6 +13355,21 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-use-measure": {
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/react-use-measure/-/react-use-measure-2.1.7.tgz",
+      "integrity": "sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.13",
+        "react-dom": ">=16.13"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
           "optional": true
         }
       }
@@ -14256,6 +14514,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/suspend-react": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/suspend-react/-/suspend-react-0.1.3.tgz",
+      "integrity": "sha512-aqldKgX9aZqpoDp3e8/BZ8Dm7x1pJl+qI3ZKxDN0i/IQTWUwBx/ManmlVJ3wowqbno6c2bmiIfs+Um6LbsjJyQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=17.0"
+      }
+    },
     "node_modules/svix": {
       "version": "1.90.0",
       "resolved": "https://registry.npmjs.org/svix/-/svix-1.90.0.tgz",
@@ -14520,6 +14787,12 @@
       "engines": {
         "node": ">=0.8"
       }
+    },
+    "node_modules/three": {
+      "version": "0.160.1",
+      "resolved": "https://registry.npmjs.org/three/-/three-0.160.1.tgz",
+      "integrity": "sha512-Bgl2wPJypDOZ1stAxwfWAcJ0WQf7QzlptsxkjYiURPz+n5k4RBDLsq+6f9Y75TYxn6aHLcWz+JNmwTOXWrQTBQ==",
+      "license": "MIT"
     },
     "node_modules/tiny-invariant": {
       "version": "1.3.3",

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-tooltip": "^1.2.8",
+    "@react-three/fiber": "^8.18.0",
     "@sentry/nextjs": "^10.52.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -54,6 +55,7 @@
     "resend": "^6.12.2",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",
+    "three": "^0.160.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {
@@ -62,6 +64,7 @@
     "@types/node": "^20.14.10",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",
+    "@types/three": "^0.160.0",
     "autoprefixer": "^10.4.19",
     "dotenv": "^17.2.2",
     "dotenv-cli": "^11.0.0",

--- a/src/app/(app)/league/[familyId]/loading.tsx
+++ b/src/app/(app)/league/[familyId]/loading.tsx
@@ -1,4 +1,4 @@
-import { DnaHelix } from "@/components/loading/DnaHelix";
+import { DnaHelix3D } from "@/components/loading/DnaHelix3DDynamic";
 
 /**
  * Route-level Suspense fallback for `/league/[familyId]/...` (#177, fix 2).
@@ -20,7 +20,7 @@ export default function LeagueFamilyLoading() {
   return (
     <div className="min-h-[60vh] flex items-center justify-center bg-background">
       <div className="flex flex-col items-center text-center gap-6 px-6">
-        <DnaHelix />
+        <DnaHelix3D />
         <p
           role="status"
           className="font-mono text-sm text-muted-foreground"

--- a/src/components/loading/DnaHelix3D.tsx
+++ b/src/components/loading/DnaHelix3D.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { Canvas, useFrame } from "@react-three/fiber";
+import { useEffect, useMemo, useRef, useState } from "react";
+import * as THREE from "three";
+
+interface DnaHelix3DProps {
+  width?: number;
+  height?: number;
+  className?: string;
+  ariaLabel?: string;
+}
+
+const HELIX_RADIUS = 0.9;
+const HELIX_HEIGHT = 4.4;
+const HELIX_TURNS = 2;
+const TUBE_RADIUS = 0.085;
+const TUBE_SEGMENTS = 220;
+const TUBE_RADIAL_SEGMENTS = 14;
+const BASE_PAIR_COUNT = 9;
+const BASE_PAIR_RADIUS = 0.045;
+const ROTATION_SPEED = (2 * Math.PI) / 12;
+
+class HelixCurve extends THREE.Curve<THREE.Vector3> {
+  constructor(
+    private radius: number,
+    private height: number,
+    private turns: number,
+    private phase: number
+  ) {
+    super();
+  }
+
+  getPoint(t: number, target = new THREE.Vector3()): THREE.Vector3 {
+    const angle = 2 * Math.PI * this.turns * t + this.phase;
+    const x = this.radius * Math.cos(angle);
+    const y = (t - 0.5) * this.height;
+    const z = this.radius * Math.sin(angle);
+    return target.set(x, y, z);
+  }
+}
+
+function pointOnHelix(t: number, phase: number): THREE.Vector3 {
+  const angle = 2 * Math.PI * HELIX_TURNS * t + phase;
+  return new THREE.Vector3(
+    HELIX_RADIUS * Math.cos(angle),
+    (t - 0.5) * HELIX_HEIGHT,
+    HELIX_RADIUS * Math.sin(angle)
+  );
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [prefers, setPrefers] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefers(mq.matches);
+    const onChange = (e: MediaQueryListEvent) => setPrefers(e.matches);
+    mq.addEventListener("change", onChange);
+    return () => mq.removeEventListener("change", onChange);
+  }, []);
+  return prefers;
+}
+
+/**
+ * Convert an HSL-triplet CSS var ("95 18% 46%") to hex. shadcn-style tokens
+ * (--primary, --background, --muted-foreground, etc.) are stored this way so
+ * Tailwind's `<alpha-value>` substitution works. three.js needs hex/rgb.
+ */
+function hslTripletToHex(triplet: string): string {
+  const match = triplet
+    .trim()
+    .match(/^(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)%$/);
+  if (!match) return "#000000";
+  const h = Number(match[1]) / 360;
+  const s = Number(match[2]) / 100;
+  const l = Number(match[3]) / 100;
+  const a = s * Math.min(l, 1 - l);
+  const f = (n: number) => {
+    const k = (n + h * 12) % 12;
+    const c = l - a * Math.max(-1, Math.min(k - 3, 9 - k, 1));
+    return Math.round(c * 255)
+      .toString(16)
+      .padStart(2, "0");
+  };
+  return `#${f(0)}${f(8)}${f(4)}`;
+}
+
+interface HelixColors {
+  /** Brand primary — sage. Used for both strands + base pairs. */
+  primary: string;
+  /** Canvas — cream. Used to tint the key light so the scene reads warm. */
+  canvas: string;
+}
+
+/**
+ * Read shadcn semantic tokens straight from `:root`. Component is mounted
+ * client-only via `next/dynamic({ ssr: false })`, so CSS is always loaded
+ * by the time this runs — no fallback flicker, no SSR mismatch.
+ */
+function readHelixColors(): HelixColors {
+  const cs = getComputedStyle(document.documentElement);
+  return {
+    primary: hslTripletToHex(cs.getPropertyValue("--primary")),
+    canvas: hslTripletToHex(cs.getPropertyValue("--background")),
+  };
+}
+
+interface BasePair {
+  midpoint: THREE.Vector3;
+  quaternion: THREE.Quaternion;
+  length: number;
+}
+
+function buildBasePairs(): BasePair[] {
+  const pairs: BasePair[] = [];
+  const yAxis = new THREE.Vector3(0, 1, 0);
+  for (let i = 1; i <= BASE_PAIR_COUNT; i++) {
+    const t = i / (BASE_PAIR_COUNT + 1);
+    const a = pointOnHelix(t, 0);
+    const b = pointOnHelix(t, Math.PI);
+    const mid = a.clone().add(b).multiplyScalar(0.5);
+    const dir = b.clone().sub(a);
+    const length = dir.length();
+    dir.normalize();
+    const q = new THREE.Quaternion().setFromUnitVectors(yAxis, dir);
+    pairs.push({ midpoint: mid, quaternion: q, length });
+  }
+  return pairs;
+}
+
+function HelixScene({
+  reducedMotion,
+  primary,
+  canvas,
+}: {
+  reducedMotion: boolean;
+  primary: string;
+  canvas: string;
+}) {
+  const groupRef = useRef<THREE.Group>(null);
+
+  const strandACurve = useMemo(
+    () => new HelixCurve(HELIX_RADIUS, HELIX_HEIGHT, HELIX_TURNS, 0),
+    []
+  );
+  const strandBCurve = useMemo(
+    () => new HelixCurve(HELIX_RADIUS, HELIX_HEIGHT, HELIX_TURNS, Math.PI),
+    []
+  );
+  const basePairs = useMemo(() => buildBasePairs(), []);
+
+  useFrame((_, delta) => {
+    if (reducedMotion) return;
+    if (groupRef.current) {
+      groupRef.current.rotation.y += ROTATION_SPEED * delta;
+    }
+  });
+
+  // Tilt slightly forward so reduced-motion viewers still see depth.
+  const initialRotation: [number, number, number] = reducedMotion
+    ? [0.18, 0.6, 0]
+    : [0.18, 0, 0];
+
+  return (
+    <>
+      <ambientLight intensity={0.85} />
+      {/* Key light tinted with the cream canvas so highlights read warm,
+          not clinical white. */}
+      <directionalLight position={[3, 4, 5]} intensity={1.05} color={canvas} />
+      {/* Sage rim from the back-left lifts the shadow side off black. */}
+      <directionalLight position={[-4, -2, -3]} intensity={0.45} color={primary} />
+
+      <group ref={groupRef} rotation={initialRotation}>
+        <mesh>
+          <tubeGeometry
+            args={[strandACurve, TUBE_SEGMENTS, TUBE_RADIUS, TUBE_RADIAL_SEGMENTS, false]}
+          />
+          <meshStandardMaterial
+            color={primary}
+            emissive={primary}
+            emissiveIntensity={0.2}
+            roughness={0.45}
+            metalness={0.05}
+          />
+        </mesh>
+
+        <mesh>
+          <tubeGeometry
+            args={[strandBCurve, TUBE_SEGMENTS, TUBE_RADIUS, TUBE_RADIAL_SEGMENTS, false]}
+          />
+          <meshStandardMaterial
+            color={primary}
+            emissive={primary}
+            emissiveIntensity={0.2}
+            roughness={0.45}
+            metalness={0.05}
+          />
+        </mesh>
+
+        {basePairs.map((bp, i) => (
+          <mesh
+            key={i}
+            position={bp.midpoint}
+            quaternion={bp.quaternion}
+          >
+            <cylinderGeometry
+              args={[BASE_PAIR_RADIUS, BASE_PAIR_RADIUS, bp.length, 12]}
+            />
+            <meshStandardMaterial
+              color={primary}
+              emissive={primary}
+              emissiveIntensity={0.18}
+              roughness={0.5}
+              metalness={0.05}
+            />
+          </mesh>
+        ))}
+      </group>
+    </>
+  );
+}
+
+export function DnaHelix3D({
+  width = 180,
+  height = 240,
+  className,
+  ariaLabel = "Loading helix",
+}: DnaHelix3DProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  // Lazy init: ssr:false guarantees CSS is loaded by mount, so we read tokens
+  // once and never again — no fallback flicker, no useEffect.
+  const [{ primary, canvas }] = useState<HelixColors>(readHelixColors);
+
+  // Soft vertical fade on the canvas itself: the helix strands end abruptly
+  // at top + bottom, so we mask the outermost ~14% to transparent. Reads as
+  // "the helix continues into space" rather than "cut off."
+  const fadeMask =
+    "linear-gradient(to bottom, transparent 0%, black 14%, black 86%, transparent 100%)";
+
+  return (
+    <div
+      className={`inline-block ${className ?? ""}`.trim()}
+      style={{ width, height }}
+      role="img"
+      aria-label={ariaLabel}
+      data-testid="dna-helix-3d"
+    >
+      <Canvas
+        camera={{ position: [0, 0, 5.6], fov: 38 }}
+        dpr={[1, 2]}
+        gl={{ antialias: true, alpha: true }}
+        style={{
+          background: "transparent",
+          maskImage: fadeMask,
+          WebkitMaskImage: fadeMask,
+        }}
+      >
+        <HelixScene
+          reducedMotion={reducedMotion}
+          primary={primary}
+          canvas={canvas}
+        />
+      </Canvas>
+    </div>
+  );
+}
+
+export default DnaHelix3D;

--- a/src/components/loading/DnaHelix3D.tsx
+++ b/src/components/loading/DnaHelix3D.tsx
@@ -62,15 +62,35 @@ function usePrefersReducedMotion(): boolean {
 }
 
 /**
+ * Brand sage-500 (matches `--sage-500` in `globals.css`). Used as the
+ * graceful-degradation fallback when an HSL-triplet token can't be parsed —
+ * if the design system ever migrates to `oklch()` or another format, the
+ * helix renders sage instead of going pure black.
+ */
+const FALLBACK_SAGE_HEX = "#6F8A60";
+
+/**
  * Convert an HSL-triplet CSS var ("95 18% 46%") to hex. shadcn-style tokens
  * (--primary, --background, --muted-foreground, etc.) are stored this way so
  * Tailwind's `<alpha-value>` substitution works. three.js needs hex/rgb.
+ *
+ * On parse failure (e.g., a future `oklch()` migration): warns in dev so the
+ * regression is visible, then returns the brand sage so the helix still
+ * renders something on-brand instead of pure black on the cream canvas.
  */
 function hslTripletToHex(triplet: string): string {
   const match = triplet
     .trim()
     .match(/^(\d+(?:\.\d+)?)\s+(\d+(?:\.\d+)?)%\s+(\d+(?:\.\d+)?)%$/);
-  if (!match) return "#000000";
+  if (!match) {
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        `[DnaHelix3D] could not parse HSL triplet "${triplet}" — falling back to sage. ` +
+          `If the design tokens migrated off HSL, update hslTripletToHex.`
+      );
+    }
+    return FALLBACK_SAGE_HEX;
+  }
   const h = Number(match[1]) / 360;
   const s = Number(match[2]) / 100;
   const l = Number(match[3]) / 100;
@@ -243,7 +263,7 @@ export function DnaHelix3D({
       style={{ width, height }}
       role="img"
       aria-label={ariaLabel}
-      data-testid="dna-helix-3d"
+      data-testid="dna-helix"
     >
       <Canvas
         camera={{ position: [0, 0, 5.6], fov: 38 }}

--- a/src/components/loading/DnaHelix3DDynamic.tsx
+++ b/src/components/loading/DnaHelix3DDynamic.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import dynamic from "next/dynamic";
+
+export const DnaHelix3D = dynamic(
+  () => import("./DnaHelix3D").then((m) => m.DnaHelix3D),
+  { ssr: false }
+);


### PR DESCRIPTION
## Summary

- Replaces the 2D SVG `<DnaHelix />` with a true 3D mesh on the league loading fallback (`src/app/(app)/league/[familyId]/loading.tsx`). Two `tubeGeometry` strands along a parametric helix curve, base-pair cylinders rotated to span between them, lit with a cream key (from `--background`) + sage rim (from `--primary`). Reduced-motion drops the spin and tilts the rig so the 3D pose still reads.
- Colors come from semantic shadcn tokens (`--primary`, `--background`) — no raw scale tokens, no hardcoded hex outside the regex-failure sentinel inside `hslTripletToHex`. If the brand primary ever retints, the helix follows.
- Mounted via `next/dynamic({ ssr: false })` (`DnaHelix3DDynamic.tsx`) so three.js + R3F never run server-side and stay code-split out of every route that doesn't import the wrapper.

### Bundle impact

Adds `three` (~150KB gz) + `@react-three/fiber` (~30KB gz). Dynamic-loaded — present only on routes that import `DnaHelix3DDynamic`. Currently that's just the league loading fallback. The other three surfaces called out in the issue (`ColdSyncLoadingScreen`, `BrandMark`, `/design`) still consume the 2D `<DnaHelix />` and can be swapped in a follow-up if the bundle math holds.

### Out of scope (deliberate)

- Did not swap `ColdSyncLoadingScreen`, `BrandMark`, or `/design`. Keeping the 2D helix on those for now lets us A/B the bundle cost in production.
- The old `<DnaHelix />` (2D SVG) is unchanged and still exported — no consumers of that API break.

## Test plan

- [ ] `npm run build` succeeds; the league loading route code-splits the three.js chunk.
- [ ] Navigate to `/league/<familyId>` from `/start` — helix flashes during the freshness gate, animates smoothly.
- [ ] Cold-path (DB stale): helix renders during the synchronous stale-sync window.
- [ ] OS-level "Reduce motion" enabled: rotation stops; static 3D pose is tilted so depth still reads.
- [ ] `/design` reference page is unchanged (still shows 2D helix).
- [ ] No raw Tailwind color classes introduced; ESLint design-system rule passes.

Closes #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)