### PR TITLE
Sync offseason (week-1) transactions so recently traded players keep their lineage

### DIFF
--- a/src/app/(app)/league/[familyId]/graph/page.tsx
+++ b/src/app/(app)/league/[familyId]/graph/page.tsx
@@ -129,6 +129,12 @@ export default function GraphPage() {
   const [response, setResponse] = useState<GraphResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // Set when a seed param (seedPlayerId/seedPickKey/seedTransactionId)
+  // resolves to nothing in the loaded graph — e.g. a player whose only
+  // tenure isn't in the synced data yet. The param is still cleared from
+  // the URL, but this keeps the empty state from looking like a silent
+  // failure.
+  const [seedMiss, setSeedMiss] = useState<"player" | "pick" | "transaction" | null>(null);
   const analyticsFiredRef = useRef(false);
 
   useEffect(() => {
@@ -193,6 +199,7 @@ export default function GraphPage() {
     const playerEdges = response.edges
       .filter((e) => e.assetKind === "player" && e.playerId === seedPlayerId);
     if (playerEdges.length === 0) {
+      setSeedMiss("player");
       updateUrl({ seedPlayerId: null });
       return;
     }
@@ -225,6 +232,7 @@ export default function GraphPage() {
     const nodeId = `tx:${seedTransactionId}`;
     const exists = response.nodes.some((n) => n.id === nodeId);
     if (!exists) {
+      setSeedMiss("transaction");
       updateUrl({ seedTransactionId: null });
       return;
     }
@@ -241,6 +249,7 @@ export default function GraphPage() {
       (e) => e.assetKind === "pick" && edgeAssetKey(e) === targetAssetKey,
     );
     if (pickEdges.length === 0) {
+      setSeedMiss("pick");
       updateUrl({ seedPickKey: null });
       return;
     }
@@ -308,6 +317,7 @@ export default function GraphPage() {
 
   const handlePickerSelect = useCallback(
     (focus: GraphFocus) => {
+      setSeedMiss(null);
       if (focus.kind === "player") {
         updateUrl({
           seedPlayerId: focus.playerId,
@@ -335,6 +345,7 @@ export default function GraphPage() {
   );
 
   const handleReset = useCallback(() => {
+    setSeedMiss(null);
     updateUrl({
       seed: null,
       seedPlayerId: null,
@@ -432,6 +443,11 @@ export default function GraphPage() {
         <Subheader title={subheaderTitle} rightSlot={subheaderRightSlot} />
         <RotateForCanvasHint />
         <SmallScreenHint />
+        {!hasSeed && seedMiss && (
+          <div className="mx-4 mt-3">
+            <SeedMissNotice kind={seedMiss} />
+          </div>
+        )}
         <MobileTimeline
           familyId={familyId}
           response={response}
@@ -487,7 +503,10 @@ export default function GraphPage() {
             )}
             {!hasSeed && response && !error && (
               <div className="flex items-center justify-center h-full">
-                <AssetPicker familyId={familyId} onPick={handlePickerSelect} />
+                <div className="flex flex-col items-center gap-4">
+                  {seedMiss && <SeedMissNotice kind={seedMiss} />}
+                  <AssetPicker familyId={familyId} onPick={handlePickerSelect} />
+                </div>
               </div>
             )}
             {hasSeed && visibleGraph && !error && (
@@ -523,6 +542,18 @@ export default function GraphPage() {
         </div>
       </div>
     </>
+  );
+}
+
+function SeedMissNotice({ kind }: { kind: "player" | "pick" | "transaction" }) {
+  return (
+    <div
+      role="status"
+      className="max-w-md rounded-md border border-grade-c/25 bg-grade-c/8 px-3 py-2 text-xs text-grade-c"
+    >
+      No lineage data found for that {kind} yet — a recent move may not have
+      synced. Check back shortly, or pick another asset below.
+    </div>
   );
 }
 

--- a/src/services/__tests__/sync.coverage.test.ts
+++ b/src/services/__tests__/sync.coverage.test.ts
@@ -34,6 +34,7 @@ interface DbCall {
   table: string;
   rowCount: number;
   op: "insert-update" | "insert-nothing" | "update";
+  vals?: unknown;
 }
 
 const insertCalls: DbCall[] = [];
@@ -53,12 +54,13 @@ const dbState = {
 
 const fakeDb = {
   insert: (table: { __tableName?: string }) => ({
-    values: () => ({
+    values: (vals: unknown) => ({
       onConflictDoUpdate: () => {
         insertCalls.push({
           table: table.__tableName ?? "?",
           rowCount: 0,
           op: "insert-update",
+          vals,
         });
         return Promise.resolve();
       },
@@ -67,6 +69,7 @@ const fakeDb = {
           table: table.__tableName ?? "?",
           rowCount: 0,
           op: "insert-nothing",
+          vals,
         });
         return Promise.resolve();
       },
@@ -449,6 +452,63 @@ describe("syncLeague — drafts, traded picks, watermarks, winners bracket", () 
       (c) => c.table === "syncWatermarks"
     );
     expect(watermarkWrites.length).toBeGreaterThanOrEqual(2);
+  });
+
+  // Offseason leagues (pre_draft/drafting) must still fetch week 1 —
+  // Sleeper files offseason trades under leg 1 of the new-season league.
+  // getMaxWeek previously returned 0 for these statuses, so offseason
+  // trades never landed in the DB and recently traded players vanished
+  // from the lineage tracer (their only open tenure was silently
+  // truncated because rosters ARE synced in the offseason).
+  it.each(["pre_draft", "drafting"])(
+    "fetches week-1 transactions for offseason (%s) leagues",
+    async (status) => {
+      sleeperMock.getLeague.mockResolvedValue({
+        league_id: "L1",
+        name: "Test League",
+        season: "2026",
+        previous_league_id: "L0",
+        status,
+        settings: { playoff_week_start: 15 },
+        scoring_settings: { rec: 1 },
+        roster_positions: ["QB", "RB", "WR", "TE", "FLEX"],
+        total_rosters: 12,
+        draft_id: "D1",
+      });
+
+      await syncLeague("L1", undefined, undefined, { skipGlobalSyncs: true });
+
+      expect(sleeperMock.getTransactions).toHaveBeenCalledTimes(1);
+      expect(sleeperMock.getTransactions).toHaveBeenCalledWith("L1", 1);
+      // The completed trade from week 1 lands in the transactions table.
+      const txWrites = insertCalls.filter((c) => c.table === "transactions");
+      expect(txWrites.some((c) => c.rowCount > 0)).toBe(true);
+    }
+  );
+
+  it("keeps the offseason transactions watermark at 0 so week 1 is re-fetched every sync", async () => {
+    sleeperMock.getLeague.mockResolvedValue({
+      league_id: "L1",
+      name: "Test League",
+      season: "2026",
+      previous_league_id: "L0",
+      status: "pre_draft",
+      settings: {},
+      scoring_settings: {},
+      roster_positions: [],
+      total_rosters: 12,
+      draft_id: "D1",
+    });
+
+    await syncLeague("L1", undefined, undefined, { skipGlobalSyncs: true });
+
+    const txWatermark = insertCalls.find(
+      (c) =>
+        c.table === "syncWatermarks" &&
+        (c.vals as { dataType?: string })?.dataType === "transactions"
+    );
+    expect(txWatermark).toBeDefined();
+    expect((txWatermark!.vals as { lastWeek: number }).lastWeek).toBe(0);
   });
 
   it("writes the winners bracket when playoffs have started + bracket has results", async () => {

--- a/src/services/sync.ts
+++ b/src/services/sync.ts
@@ -576,7 +576,13 @@ async function runSyncLeague(
 function getMaxWeek(status: string): number {
   if (status === "complete") return 18;
   if (status === "in_season") return 18;
-  return 0;
+  // Offseason (pre_draft/drafting): Sleeper files offseason trades under
+  // leg 1 of the new-season league, so week 1 must still be fetched —
+  // returning 0 here silently dropped every offseason trade, which erased
+  // recently traded players from the lineage tracer. The non-complete
+  // watermark rule above (maxWeek - 1 = 0) keeps week 1 re-fetched on
+  // every offseason sync.
+  return 1;
 }
 
 const COMPLETED_STALENESS_MS = 7 * 24 * 60 * 60 * 1000; // 7 days


### PR DESCRIPTION
## Problem

The lineage tracer went blank for players traded during the offseason (observed with Drake Maye in the test family): seeding by player silently dropped back to the asset picker with no explanation.

## Root cause

`getMaxWeek()` returned `0` for offseason league statuses (`pre_draft`/`drafting`), so the new-season league's transactions were never fetched — even though Sleeper files offseason trades under leg 1 of that league. Rosters, however, ARE synced unconditionally, so the graph builder saw the player on the new owner's roster while the event walk still had the old owner holding an open tenure. That open tenure is silently truncated by design, which left a single-tenure player (drafted once, never moved until the trade) with **zero** tenure edges — and the graph page then silently cleared the unresolvable `seedPlayerId`.

## Changes

- **`src/services/sync.ts`** — `getMaxWeek` now returns `1` for offseason statuses. The existing non-complete watermark rule (`maxWeek - 1 = 0`) keeps week 1 re-fetched on every offseason sync, so trades keep flowing in all offseason.
- **`src/services/__tests__/sync.coverage.test.ts`** — regression tests: week-1 transactions are fetched for `pre_draft` and `drafting` leagues (and the trade row lands), and the transactions watermark stays at 0 so week 1 is re-fetched next sync.
- **`src/app/(app)/league/[familyId]/graph/page.tsx`** — when a seed param (`seedPlayerId` / `seedPickKey` / `seedTransactionId`) resolves to nothing in the graph, show a "No lineage data found yet" notice above the asset picker instead of silently stripping the param.

## Verification

- Full jest suite green (413 passed), lint clean, `tsc --noEmit` clean.
- The CI sync benchmark's synthetic family only uses `complete`/`in_season` statuses, so the exact `api_calls` baseline is unaffected.
- Verified end-to-end on the preview deployment against the test family: before the fix, Drake Maye (`11564`) had a single `draft_selected` asset event and zero tenure edges; after one lazy sync with this branch's code, the 2026 week-1 trade (Stove17 → tendererbrick) was ingested and the tracer renders his full thread (draft → trade → open tenure at the new manager's current roster).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B6T9tf9yWNzsKD37mPfswR

---
_Generated by [Claude Code](https://claude.ai/code/session_01B6T9tf9yWNzsKD37mPfswR)_