### PR TITLE
Reframe /experiments as offline evals; remove simulated A/B layer

### DIFF
--- a/.github/ISSUE_TEMPLATE/experiment.yml
+++ b/.github/ISSUE_TEMPLATE/experiment.yml
@@ -1,70 +1,65 @@
-name: Experiment Proposal
-description: Propose an A/B test or feature experiment with a structured hypothesis
-title: "[Experiment] "
+name: Eval Proposal
+description: Propose an offline eval — a grading-algorithm change tested against historical league data
+title: "[Eval] "
 labels: ["type:experiment", "roadmap"]
 body:
   - type: markdown
     attributes:
       value: |
-        Experiments help us make data-informed decisions. Define what you're testing,
-        what you expect to happen, and how you'll measure it.
+        Evals are how algorithm changes earn their way into production. Define the
+        hypothesis and acceptance criteria BEFORE running anything — the decision
+        rule is pre-registered, not fitted to the results.
 
   - type: textarea
     id: hypothesis
     attributes:
       label: Hypothesis
-      description: "What do you believe will happen? Use the format: If we [change], then [outcome] because [rationale]."
-      placeholder: "If we show counterfactual trade analysis, then managers will engage more with trade history because understanding 'what could have been' creates stronger emotional connection to the data."
+      description: "What do you believe will happen? Use the format: If we [change the algorithm], then [metric improves] because [rationale]."
+      placeholder: "If we score production as points-above-replacement instead of rank decay, then correlation with actual PPG improves because rank gaps in the positional mid-tier are arbitrary."
     validations:
       required: true
 
   - type: textarea
-    id: control
+    id: baseline
     attributes:
-      label: Control (Current Behavior)
-      description: What does the user experience today?
+      label: Baseline (Current Algorithm)
+      description: What does the production algorithm do today?
     validations:
       required: true
 
   - type: textarea
-    id: treatment
+    id: variants
     attributes:
-      label: Treatment (New Behavior)
-      description: What will the user experience in the experiment variant?
+      label: Variant(s)
+      description: What alternative(s) will the eval compare against the baseline?
     validations:
       required: true
 
   - type: textarea
-    id: metrics
+    id: method
     attributes:
-      label: Primary & Secondary Metrics
-      description: What will you measure to determine success?
+      label: Method & Data
+      description: What historical data is replayed, and what is measured?
       placeholder: |
-        Primary: Click-through rate on trade detail pages
-        Secondary: Time spent on trade analysis, return visit rate
-    validations:
-      required: true
-
-  - type: input
-    id: rollout
-    attributes:
-      label: Rollout Percentage
-      description: What % of users should see the treatment?
-      placeholder: "50"
-    validations:
-      required: true
-
-  - type: input
-    id: duration
-    attributes:
-      label: Experiment Duration
-      description: How long should the experiment run before evaluation?
-      placeholder: "2 weeks"
+        Replay all completed league-family seasons. Measure Spearman correlation
+        of each variant's manager scores against Manager Outcome Score (MOS),
+        plus grade-distribution entropy as a secondary check.
     validations:
       required: true
 
   - type: textarea
-    id: guardrails
+    id: acceptance
     attributes:
-      label: Guardrails
-      description: What negative outcomes would cause you to stop the experiment early?
+      label: Acceptance Criteria
+      description: The decision rule, written before the run. What result would confirm the hypothesis? What would reject it?
+      placeholder: "Variant beats baseline MOS correlation in ≥2 of 3 pillars; otherwise keep baseline."
+    validations:
+      required: true
+
+  - type: textarea
+    id: decision
+    attributes:
+      label: Decision This Informs
+      description: What ships if confirmed? What happens if rejected? (Every verdict should have a consequence.)
+    validations:
+      required: true

--- a/src/app/(public)/experiments/evalNotes.ts
+++ b/src/app/(public)/experiments/evalNotes.ts
@@ -12,7 +12,7 @@
  * production code changes, update the entry.
  */
 
-export type EvalOutcome = "shipped" | "kept-baseline" | "rejected";
+export type EvalOutcome = "shipped" | "kept-baseline" | "rejected" | "follow-up";
 
 export interface EvalNote {
   /** Display order on the page (ascending) */
@@ -26,6 +26,8 @@ export interface EvalNote {
   outcome: EvalOutcome;
   /** Where the decision lives in production code */
   shippedRef?: string;
+  /** GitHub issue tracking a follow-up eval, when outcome is "follow-up" */
+  issueUrl?: string;
 }
 
 export const EVAL_NOTES: Record<string, EvalNote> = {
@@ -35,9 +37,10 @@ export const EVAL_NOTES: Record<string, EvalNote> = {
     question:
       "How should we score a player's production — points above a positional replacement level (PAR), or an exponential decay on positional rank? Rank decay treats WR13 and WR30 as meaningfully different even when their per-game output is nearly identical.",
     decision:
-      "Shipped. PAR replaced rank decay as the production scorer across draft, trade, and waiver grading; rank-based scoring survives only as a legacy fallback.",
-    outcome: "shipped",
+      "Follow-up open. PAR is in production, but this run's criterion failed — a redesigned eval (roster-outcome correlation, small-sample fix) either passes or PAR reverts to rank decay.",
+    outcome: "follow-up",
     shippedRef: "src/services/gradingCore.ts · playerSeasonalPAR()",
+    issueUrl: "https://github.com/jrygrande/dynasty-dna/issues/188",
   },
   "blend-sensitivity": {
     order: 2,
@@ -45,9 +48,10 @@ export const EVAL_NOTES: Record<string, EvalNote> = {
     question:
       "Grades blend market value with realized production over time. Should one universal ramp curve govern all transaction types, or do trades, drafts, and waivers each deserve their own? A rookie pick shouldn't be judged on production after 8 weeks; a waiver add should.",
     decision:
-      "Shipped. Each pillar got its own blend profile — waivers ramp to production fastest, drafts slowest.",
-    outcome: "shipped",
+      "Follow-up open. Per-pillar curves are in production, but the trade curve failed its calibration check — a slower ramp won one horizon bucket outright, so the follow-up tunes the curve until it beats the universal ramp or reverts the trade pillar.",
+    outcome: "follow-up",
     shippedRef: "src/services/algorithmConfig.ts · DEFAULT_CONFIG.blendProfiles",
+    issueUrl: "https://github.com/jrygrande/dynasty-dna/issues/189",
   },
   "production-layer-ablation": {
     order: 3,
@@ -76,9 +80,10 @@ export const EVAL_NOTES: Record<string, EvalNote> = {
     question:
       "Manager Outcome Score is the ground truth every other eval correlates against, so its weights have to be defensible. Do the baseline weights (40% starter points, 30% win rate, 20% playoff, 10% championship) discriminate between managers and stay stable season over season?",
     decision:
-      "Kept the baseline. No alternative weight vector beat 40/30/20/10 on both distribution entropy and cross-season stability.",
-    outcome: "kept-baseline",
+      "Follow-up open. Baseline kept for now — two different vectors each edged it on a single metric by small margins, so the original criterion can't name one winner. The follow-up reruns with a composite criterion and confidence intervals.",
+    outcome: "follow-up",
     shippedRef: "src/services/outcomeScore.ts · DEFAULT_WEIGHTS",
+    issueUrl: "https://github.com/jrygrande/dynasty-dna/issues/190",
   },
   "quality-x-quantity-blend": {
     order: 6,

--- a/src/app/(public)/experiments/evalNotes.ts
+++ b/src/app/(public)/experiments/evalNotes.ts
@@ -1,0 +1,113 @@
+/**
+ * Editorial layer for the /experiments (Evals) page.
+ *
+ * Each entry closes the loop between an eval run (persisted to
+ * `experiment_runs` by scripts/experiments/*) and the production decision
+ * it drove. The DB rows carry the hypothesis, verdict, and scorecard; this
+ * file carries the narrative: the product question, the decision made, and
+ * where that decision lives in shipped code.
+ *
+ * Keyed by the eval's `name` as passed to runExperiment(). Every claim in
+ * a `decision` must be verifiable in the referenced source file — if the
+ * production code changes, update the entry.
+ */
+
+export type EvalOutcome = "shipped" | "kept-baseline" | "rejected";
+
+export interface EvalNote {
+  /** Display order on the page (ascending) */
+  order: number;
+  /** Display title (overrides slug-derived name) */
+  title: string;
+  /** The product question this eval was designed to answer */
+  question: string;
+  /** What we decided and did as a result */
+  decision: string;
+  outcome: EvalOutcome;
+  /** Where the decision lives in production code */
+  shippedRef?: string;
+}
+
+export const EVAL_NOTES: Record<string, EvalNote> = {
+  "par-vs-rank": {
+    order: 1,
+    title: "PAR vs Rank-Based Production",
+    question:
+      "How should we score a player's production — points above a positional replacement level (PAR), or an exponential decay on positional rank? Rank decay treats WR13 and WR30 as meaningfully different even when their per-game output is nearly identical.",
+    decision:
+      "Shipped. PAR replaced rank decay as the production scorer across draft, trade, and waiver grading; rank-based scoring survives only as a legacy fallback.",
+    outcome: "shipped",
+    shippedRef: "src/services/gradingCore.ts · playerSeasonalPAR()",
+  },
+  "blend-sensitivity": {
+    order: 2,
+    title: "Blend Curve Sensitivity",
+    question:
+      "Grades blend market value with realized production over time. Should one universal ramp curve govern all transaction types, or do trades, drafts, and waivers each deserve their own? A rookie pick shouldn't be judged on production after 8 weeks; a waiver add should.",
+    decision:
+      "Shipped. Each pillar got its own blend profile — waivers ramp to production fastest, drafts slowest.",
+    outcome: "shipped",
+    shippedRef: "src/services/algorithmConfig.ts · DEFAULT_CONFIG.blendProfiles",
+  },
+  "production-layer-ablation": {
+    order: 3,
+    title: "Production Layer Ablation",
+    question:
+      "Does weighting production by context — did the player actually start, did the matchup swing on him, was it the playoffs — track season outcomes better than raw PAR? An ablation across four configurations isolates what each layer contributes.",
+    decision:
+      "Shipped. The full layered stack (starter × matchup × playoff multipliers) is how production is computed inside every ownership window.",
+    outcome: "shipped",
+    shippedRef:
+      "src/services/gradingCore.ts · starterMultiplier / matchupOutcomeMultiplier / playoffWeightMultiplier",
+  },
+  "roster-scoped-vs-unbounded": {
+    order: 4,
+    title: "Roster-Scoped vs Unbounded Production",
+    question:
+      "When you trade a player away and he breaks out two seasons later, should that production count in your grade? Unbounded scoring said yes — and produced grades that felt wrong in exactly the cases managers care most about.",
+    decision:
+      "Shipped. Production is scoped to roster ownership windows — a grade reflects what a player did while you actually held him.",
+    outcome: "shipped",
+    shippedRef: "src/services/gradingCore.ts · ownership-window production",
+  },
+  "mos-weight-sensitivity": {
+    order: 5,
+    title: "MOS Weight Sensitivity",
+    question:
+      "Manager Outcome Score is the ground truth every other eval correlates against, so its weights have to be defensible. Do the baseline weights (40% starter points, 30% win rate, 20% playoff, 10% championship) discriminate between managers and stay stable season over season?",
+    decision:
+      "Kept the baseline. No alternative weight vector beat 40/30/20/10 on both distribution entropy and cross-season stability.",
+    outcome: "kept-baseline",
+    shippedRef: "src/services/outcomeScore.ts · DEFAULT_WEIGHTS",
+  },
+  "quality-x-quantity-blend": {
+    order: 6,
+    title: "Quality × Quantity Blend",
+    question:
+      "Should a manager's pillar score reward average decision quality alone (α = 1.0), or blend in the volume of good decisions? One great trade shouldn't automatically outrank ten good ones.",
+    decision:
+      "Shipped. Per-pillar α values (trade 0.50, draft 0.60, waiver 0.40) are the production quality weights.",
+    outcome: "shipped",
+    shippedRef: "src/services/algorithmConfig.ts · DEFAULT_CONFIG.qualityWeights",
+  },
+  "waiver-grading-validation": {
+    order: 7,
+    title: "Waiver Grading Validation",
+    question:
+      "Is waiver activity real signal about manager skill, or noise? Before keeping waiver_score as a pillar of the composite, verify it correlates with outcomes on its own and that a 4-pillar composite out-predicts a 2-pillar one.",
+    decision:
+      "Kept. Waiver grading carries independent signal and the 4-pillar composite predicts outcomes best — waiver_score remains a full pillar of MPS.",
+    outcome: "kept-baseline",
+    shippedRef: "src/services/algorithmConfig.ts · DEFAULT_CONFIG.pillarWeights",
+  },
+  "faab-efficiency-signal": {
+    order: 8,
+    title: "FAAB Efficiency Signal",
+    question:
+      "In FAAB leagues, does rewarding bid efficiency — getting value cheaply — add predictive signal on top of raw value scoring, or just noise?",
+    decision:
+      "Rejected. Stripping the FAAB bonus predicted outcomes as well or better, so the bonus was removed from production scoring entirely. A hypothesis we liked, killed by its own scorecard.",
+    outcome: "rejected",
+    shippedRef: "src/services/algorithmConfig.ts · faabBonusMax = 0",
+  },
+};

--- a/src/app/(public)/experiments/page.tsx
+++ b/src/app/(public)/experiments/page.tsx
@@ -503,12 +503,11 @@ export default function EvalsPage() {
             playoff results.
           </p>
           <p className="text-muted-foreground mt-3 text-sm leading-relaxed max-w-2xl">
-            Why evals instead of A/B tests? Dynasty DNA doesn&apos;t have the
-            traffic to detect behavioral effects, and pretending otherwise
-            would produce noise dressed up as rigor. What it does have is
-            complete historical data with known outcomes — so every algorithm
-            variant can be replayed against the past and scored on how well
-            it predicts what really happened.
+            Fantasy history is a rare luxury: complete data with known
+            outcomes. Instead of guessing how an algorithm change will
+            perform, every variant is replayed against years of real seasons
+            and scored on how well it predicts what actually happened —
+            before it touches a single grade in production.
           </p>
         </div>
 

--- a/src/app/(public)/experiments/page.tsx
+++ b/src/app/(public)/experiments/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState, useMemo } from "react";
 import { formatDate } from "@/lib/utils";
+import { EVAL_NOTES, type EvalNote, type EvalOutcome } from "./evalNotes";
 
 // ============================================================
 // Types
@@ -110,6 +111,43 @@ function VerdictBlock({ verdict, reason }: { verdict: string | null; reason: str
       {reason && (
         <p className={`mt-1.5 text-sm ${style.text} opacity-80`}>{reason}</p>
       )}
+    </div>
+  );
+}
+
+// ============================================================
+// Decision block — what happened in production as a result
+// ============================================================
+
+const OUTCOME_LABELS: Record<EvalOutcome, string> = {
+  shipped: "Shipped",
+  "kept-baseline": "Kept baseline",
+  rejected: "Rejected — not shipped",
+};
+
+const OUTCOME_STYLES: Record<EvalOutcome, string> = {
+  shipped: "bg-grade-a/8 text-grade-a border-grade-a/25",
+  "kept-baseline": "bg-grade-b/8 text-grade-b border-grade-b/25",
+  rejected: "bg-muted text-muted-foreground border-border",
+};
+
+function DecisionBlock({ note }: { note: EvalNote }) {
+  return (
+    <div>
+      <h4 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-2">
+        Decision
+      </h4>
+      <div className="rounded-lg border border-border p-4 space-y-2">
+        <span
+          className={`inline-block px-2 py-0.5 rounded-full border text-[11px] font-mono uppercase tracking-wide ${OUTCOME_STYLES[note.outcome]}`}
+        >
+          {OUTCOME_LABELS[note.outcome]}
+        </span>
+        <p className="text-sm leading-relaxed">{note.decision}</p>
+        {note.shippedRef && (
+          <p className="text-xs font-mono text-muted-foreground">{note.shippedRef}</p>
+        )}
+      </div>
     </div>
   );
 }
@@ -256,16 +294,25 @@ function ScorecardSection({ scorecard }: { scorecard: Scorecard }) {
 }
 
 // ============================================================
-// Experiment card
+// Eval card
 // ============================================================
 
-function ExperimentCard({ run }: { run: ExperimentRun }) {
+function EvalCard({ run, note }: { run: ExperimentRun; note?: EvalNote }) {
   const [showDetails, setShowDetails] = useState(false);
   const [showRawJson, setShowRawJson] = useState(false);
 
   return (
     <div className="border rounded-lg bg-card">
       <div className="p-5 space-y-4">
+        {note && (
+          <div>
+            <h4 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-1">
+              The Question
+            </h4>
+            <p className="text-sm leading-relaxed">{note.question}</p>
+          </div>
+        )}
+
         {run.hypothesis && (
           <div>
             <h4 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-1">
@@ -278,7 +325,10 @@ function ExperimentCard({ run }: { run: ExperimentRun }) {
         {run.acceptanceCriteria && (
           <div>
             <h4 className="text-[11px] font-semibold uppercase tracking-widest text-muted-foreground mb-1">
-              Acceptance Criteria
+              Acceptance Criteria{" "}
+              <span className="normal-case tracking-normal font-normal">
+                (set before the run)
+              </span>
             </h4>
             <p className="text-sm leading-relaxed text-muted-foreground">
               {run.acceptanceCriteria}
@@ -287,6 +337,8 @@ function ExperimentCard({ run }: { run: ExperimentRun }) {
         )}
 
         <VerdictBlock verdict={run.verdict} reason={run.verdictReason} />
+
+        {note && <DecisionBlock note={note} />}
 
         {run.scorecard && run.scorecard.primaryMetrics.length > 0 && (
           <ScorecardSection scorecard={run.scorecard} />
@@ -356,10 +408,51 @@ function ExperimentCard({ run }: { run: ExperimentRun }) {
 }
 
 // ============================================================
+// How it works
+// ============================================================
+
+const PIPELINE_STEPS: { label: string; detail: string }[] = [
+  {
+    label: "Pre-register",
+    detail: "Hypothesis and acceptance criteria are committed before the eval runs — no moving the goalposts after seeing the numbers.",
+  },
+  {
+    label: "Replay history",
+    detail: "The candidate algorithm is scored against complete league history. Every run is persisted with its config and git hash.",
+  },
+  {
+    label: "Score the verdict",
+    detail: "The result is judged against the pre-registered criteria: confirmed, rejected, or inconclusive.",
+  },
+  {
+    label: "Decide & ship",
+    detail: "Winners are promoted into the production algorithm config; losers are rejected and documented. Every verdict has a consequence.",
+  },
+];
+
+function HowItWorks() {
+  return (
+    <div className="mb-10 grid gap-3 sm:grid-cols-2">
+      {PIPELINE_STEPS.map((step, i) => (
+        <div key={step.label} className="border rounded-lg p-4 bg-card">
+          <div className="flex items-center gap-2 mb-1.5">
+            <span className="font-mono text-xs text-primary">{i + 1}</span>
+            <h3 className="text-sm font-semibold">{step.label}</h3>
+          </div>
+          <p className="text-xs text-muted-foreground leading-relaxed">
+            {step.detail}
+          </p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ============================================================
 // Page
 // ============================================================
 
-export default function ExperimentsPage() {
+export default function EvalsPage() {
   const [runs, setRuns] = useState<ExperimentRun[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -371,12 +464,13 @@ export default function ExperimentsPage() {
         setRuns(data.runs || []);
         if (data.error) setError(data.error);
       })
-      .catch(() => setError("Failed to load experiments."))
+      .catch(() => setError("Failed to load evals."))
       .finally(() => setLoading(false));
   }, []);
 
-  // Group by experiment name, show only the most recent run per experiment
-  const { experiments, runCounts } = useMemo(() => {
+  // Group by eval name, show only the most recent run per eval,
+  // ordered by the editorial sequence in EVAL_NOTES (unknown names last).
+  const { evals, runCounts } = useMemo(() => {
     const latestByName = new Map<string, ExperimentRun>();
     const counts = new Map<string, number>();
     for (const run of runs) {
@@ -386,27 +480,43 @@ export default function ExperimentsPage() {
         latestByName.set(run.name, run);
       }
     }
-    return {
-      experiments: Array.from(latestByName.values()).sort((a, b) => a.name.localeCompare(b.name)),
-      runCounts: counts,
-    };
+    const ordered = Array.from(latestByName.values()).sort((a, b) => {
+      const orderA = EVAL_NOTES[a.name]?.order ?? Number.MAX_SAFE_INTEGER;
+      const orderB = EVAL_NOTES[b.name]?.order ?? Number.MAX_SAFE_INTEGER;
+      return orderA !== orderB ? orderA - orderB : a.name.localeCompare(b.name);
+    });
+    return { evals: ordered, runCounts: counts };
   }, [runs]);
 
   return (
     <div className="min-h-screen bg-background">
       <main className="container mx-auto px-6 py-8 max-w-3xl">
-        <div className="mb-10">
-          <h1 className="font-serif text-4xl font-medium tracking-tight">Experiments</h1>
-          <p className="text-muted-foreground mt-2 text-sm leading-relaxed max-w-2xl">
-            Experiments tune Manager Process Score (MPS) — our composite
-            grading algorithm — to be predictive of actual fantasy league
-            success, as measured by Manager Outcome Score (MOS).
+        <div className="mb-8">
+          <h1 className="font-serif text-4xl font-medium tracking-tight">Evals</h1>
+          <p className="text-muted-foreground mt-3 text-sm leading-relaxed max-w-2xl">
+            Every change to the grading engine earns its way into production
+            through an offline eval: a pre-registered hypothesis, a replay
+            against years of real league history, and a decision. The goal is
+            a Manager Process Score (MPS) that actually predicts league
+            success — measured as correlation with Manager Outcome Score
+            (MOS), the ground-truth composite of wins, starter points, and
+            playoff results.
+          </p>
+          <p className="text-muted-foreground mt-3 text-sm leading-relaxed max-w-2xl">
+            Why evals instead of A/B tests? Dynasty DNA doesn&apos;t have the
+            traffic to detect behavioral effects, and pretending otherwise
+            would produce noise dressed up as rigor. What it does have is
+            complete historical data with known outcomes — so every algorithm
+            variant can be replayed against the past and scored on how well
+            it predicts what really happened.
           </p>
         </div>
 
+        <HowItWorks />
+
         {loading && (
           <div className="text-center py-12 text-muted-foreground">
-            Loading experiments...
+            Loading evals...
           </div>
         )}
 
@@ -416,30 +526,56 @@ export default function ExperimentsPage() {
           </div>
         )}
 
-        {!loading && experiments.length === 0 && !error && (
+        {!loading && evals.length === 0 && !error && (
           <div className="text-center py-12">
-            <p className="text-muted-foreground">No experiments have been run yet.</p>
+            <p className="text-muted-foreground">No evals have been run yet.</p>
           </div>
         )}
 
         <div className="space-y-8">
-          {experiments.map((run) => {
+          {evals.map((run) => {
+            const note = EVAL_NOTES[run.name];
             const totalRuns = runCounts.get(run.name) ?? 1;
             return (
               <div key={run.name}>
                 <div className="flex items-baseline gap-2 mb-3">
-                  <h2 className="text-lg font-semibold">{formatName(run.name)}</h2>
+                  <h2 className="text-lg font-semibold">
+                    {note?.title ?? formatName(run.name)}
+                  </h2>
                   {totalRuns > 1 && (
                     <span className="text-xs text-muted-foreground">
                       (latest of {totalRuns} runs)
                     </span>
                   )}
                 </div>
-                <ExperimentCard run={run} />
+                <EvalCard run={run} note={note} />
               </div>
             );
           })}
         </div>
+
+        {!loading && evals.length > 0 && (
+          <footer className="mt-12 pt-6 border-t space-y-2">
+            <p className="text-xs text-muted-foreground leading-relaxed">
+              <span className="font-medium text-foreground/70">Method notes:</span>{" "}
+              predictiveness is measured with Spearman rank correlation against
+              MOS. Samples are league-seasons, not users — small by design, so
+              lifts are treated as directional evidence and weighed alongside
+              manual review of extreme cases, not read as significance tests.
+            </p>
+            <p className="text-xs text-muted-foreground">
+              The eval harness, per-eval scripts, and full methodology are open source:{" "}
+              <a
+                href="https://github.com/jrygrande/dynasty-dna/tree/main/scripts/experiments"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-primary hover:underline"
+              >
+                scripts/experiments on GitHub
+              </a>
+            </p>
+          </footer>
+        )}
       </main>
     </div>
   );

--- a/src/app/(public)/experiments/page.tsx
+++ b/src/app/(public)/experiments/page.tsx
@@ -123,12 +123,14 @@ const OUTCOME_LABELS: Record<EvalOutcome, string> = {
   shipped: "Shipped",
   "kept-baseline": "Kept baseline",
   rejected: "Rejected — not shipped",
+  "follow-up": "Follow-up open",
 };
 
 const OUTCOME_STYLES: Record<EvalOutcome, string> = {
   shipped: "bg-grade-a/8 text-grade-a border-grade-a/25",
   "kept-baseline": "bg-grade-b/8 text-grade-b border-grade-b/25",
   rejected: "bg-muted text-muted-foreground border-border",
+  "follow-up": "bg-grade-c/8 text-grade-c border-grade-c/25",
 };
 
 function DecisionBlock({ note }: { note: EvalNote }) {
@@ -144,9 +146,21 @@ function DecisionBlock({ note }: { note: EvalNote }) {
           {OUTCOME_LABELS[note.outcome]}
         </span>
         <p className="text-sm leading-relaxed">{note.decision}</p>
-        {note.shippedRef && (
-          <p className="text-xs font-mono text-muted-foreground">{note.shippedRef}</p>
-        )}
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+          {note.shippedRef && (
+            <p className="text-xs font-mono text-muted-foreground">{note.shippedRef}</p>
+          )}
+          {note.issueUrl && (
+            <a
+              href={note.issueUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-xs text-primary hover:underline"
+            >
+              Tracked in #{note.issueUrl.split("/").pop()}
+            </a>
+          )}
+        </div>
       </div>
     </div>
   );
@@ -494,20 +508,13 @@ export default function EvalsPage() {
         <div className="mb-8">
           <h1 className="font-serif text-4xl font-medium tracking-tight">Evals</h1>
           <p className="text-muted-foreground mt-3 text-sm leading-relaxed max-w-2xl">
-            Every change to the grading engine earns its way into production
-            through an offline eval: a pre-registered hypothesis, a replay
-            against years of real league history, and a decision. The goal is
-            a Manager Process Score (MPS) that actually predicts league
-            success — measured as correlation with Manager Outcome Score
-            (MOS), the ground-truth composite of wins, starter points, and
-            playoff results.
-          </p>
-          <p className="text-muted-foreground mt-3 text-sm leading-relaxed max-w-2xl">
-            Fantasy history is a rare luxury: complete data with known
-            outcomes. Instead of guessing how an algorithm change will
-            perform, every variant is replayed against years of real seasons
-            and scored on how well it predicts what actually happened —
-            before it touches a single grade in production.
+            Every change to the grading engine ships through an offline eval:
+            a pre-registered hypothesis and acceptance criteria, a replay
+            against the full transaction history of every ingested league,
+            and a recorded decision. The target is a Manager Process Score
+            (MPS) that predicts real league success, measured as correlation
+            with Manager Outcome Score (MOS) — the composite of wins, starter
+            points, and playoff results.
           </p>
         </div>
 

--- a/src/app/(public)/page.tsx
+++ b/src/app/(public)/page.tsx
@@ -81,8 +81,8 @@ export default function LandingPage() {
             <BuildCard
               href="/experiments"
               icon={<FlaskConical className="h-5 w-5 text-primary" />}
-              title="Experiments"
-              description="Algorithm variants tested against real data to find what actually works."
+              title="Evals"
+              description="Every grading-algorithm change is replayed against years of real league history before it ships — hypothesis, verdict, and decision."
             />
           </div>
         </div>

--- a/src/app/(public)/roadmap/page.tsx
+++ b/src/app/(public)/roadmap/page.tsx
@@ -4,9 +4,6 @@ import { useEffect, useMemo, useState } from "react";
 import { ArrowRight } from "lucide-react";
 import { RoadmapCard } from "@/components/RoadmapCard";
 import type { RoadmapIssue } from "@/app/api/roadmap/route";
-import { type FeatureFlag, getActiveExperiments } from "@/lib/featureFlags";
-
-const experiments = getActiveExperiments();
 
 type FilterTab = "now" | "next" | "later" | "shipped" | "all";
 
@@ -60,38 +57,6 @@ function groupByPhase(
       name: PHASE_NAMES[phase] || "Other",
       items,
     }));
-}
-
-function ExperimentCard({ flag }: { flag: FeatureFlag }) {
-  return (
-    <div className="border border-dashed border-chart-4/40 rounded-lg p-4 bg-chart-4/5">
-      <div className="flex items-start justify-between gap-3 mb-2">
-        <h3 className="text-sm font-semibold">{flag.title}</h3>
-        <span className="px-2 py-0.5 text-xs font-medium rounded-full bg-chart-4/15 text-chart-4 whitespace-nowrap">
-          {flag.rolloutPercent}% rollout
-        </span>
-      </div>
-      <p className="text-xs text-muted-foreground mb-2">{flag.description}</p>
-      {flag.hypothesis && (
-        <p className="text-xs text-muted-foreground mb-2">
-          <span className="font-medium text-foreground/70">Hypothesis:</span>{" "}
-          {flag.hypothesis}
-        </p>
-      )}
-      {flag.metrics && flag.metrics.length > 0 && (
-        <div className="flex flex-wrap gap-x-3 gap-y-1">
-          <span className="text-[11px] font-medium text-muted-foreground">
-            Measuring:
-          </span>
-          {flag.metrics.map((m, i) => (
-            <span key={i} className="text-[11px] text-muted-foreground">
-              {m}
-            </span>
-          ))}
-        </div>
-      )}
-    </div>
-  );
 }
 
 export default function RoadmapPage() {
@@ -226,23 +191,6 @@ export default function RoadmapPage() {
               .
             </p>
           </div>
-        )}
-
-        {/* Active Experiments section */}
-        {experiments.length > 0 && (
-          <section className="mt-12">
-            <div className="flex items-center gap-3 mb-4">
-              <h2 className="text-lg font-semibold">Active Experiments</h2>
-              <span className="text-xs text-muted-foreground">
-                Testing hypotheses with real users
-              </span>
-            </div>
-            <div className="space-y-3">
-              {experiments.map((flag) => (
-                <ExperimentCard key={flag.id} flag={flag} />
-              ))}
-            </div>
-          </section>
         )}
 
         {/* Footer */}

--- a/src/app/api/roadmap/route.ts
+++ b/src/app/api/roadmap/route.ts
@@ -58,7 +58,7 @@ function parseIssue(issue: {
   return {
     id: issue.id,
     number: issue.number,
-    title: issue.title.replace(/^\[(Feature|Experiment|Bug)\]\s*/i, ""),
+    title: issue.title.replace(/^\[(Feature|Experiment|Eval|Bug)\]\s*/i, ""),
     body: issue.body,
     html_url: issue.html_url,
     status,

--- a/src/app/design/page.tsx
+++ b/src/app/design/page.tsx
@@ -205,7 +205,7 @@ export default function DesignSystemPage() {
                 <CardTitle>Status pills</CardTitle>
                 <CardDescription>
                   Shipped / in progress / planned / exploring. Used on
-                  roadmap + experiments.
+                  roadmap + evals.
                 </CardDescription>
               </CardHeader>
               <CardContent className="flex flex-wrap gap-2">

--- a/src/components/PublicNav.tsx
+++ b/src/components/PublicNav.tsx
@@ -19,7 +19,7 @@ const navLinks: Array<{ href: string; label: string; soon?: boolean }> = [
   { href: "/trade-finder", label: "Trade Finder", soon: true },
   { href: "/roadmap", label: "Roadmap" },
   { href: "/changelog", label: "Changelog" },
-  { href: "/experiments", label: "Experiments" },
+  { href: "/experiments", label: "Evals" },
 ];
 
 type LeagueMenuItem = {

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,122 +1,47 @@
 /**
- * Lightweight feature flags with experiment support.
+ * Minimal feature flags: static on/off gates for features in development.
  *
- * Each flag has a hypothesis and metrics — making experimentation
- * thinking visible in the codebase itself. Active experiments are
- * surfaced on the public /roadmap page.
+ * This is deliberately NOT an experimentation system. Dynasty DNA doesn't
+ * have the traffic for meaningful A/B tests — algorithm decisions are made
+ * with offline evals (see /experiments and scripts/experiments/), and
+ * feature launches are gated by explicit promotion criteria (see
+ * docs/experiments/asset-graph-browser.md for the pattern).
  */
 
-export type FlagStatus = "enabled" | "disabled" | "experiment";
+export type FlagStatus = "enabled" | "disabled";
 
 export interface FeatureFlag {
   id: string;
   title: string;
   description: string;
   status: FlagStatus;
-  /** For experiments: percentage of users who see the treatment (0-100) */
-  rolloutPercent?: number;
-  /** What we believe will happen */
-  hypothesis?: string;
-  /** How we'll measure success */
-  metrics?: string[];
-  /** Link to the GitHub Issue for this experiment */
-  issueUrl?: string;
 }
 
 /**
- * CONVENTION: Callers pass the OBJECT KEY of the FLAGS map (e.g., "ASSET_GRAPH_BROWSER"),
- * NOT the `flag.id` field (e.g., "asset-graph-browser"). `isEnabled()` looks up by
- * object key. Callers using flag.id will silently get `false` back.
- *
- * Use the `FlagKey` type to keep calls type-safe.
+ * CONVENTION: Callers pass the OBJECT KEY of the FLAGS map (e.g.,
+ * "ASSET_GRAPH_BROWSER"), not the `flag.id` field. The `FlagKey` type
+ * keeps calls type-safe.
  */
 export const FLAGS = {
-  TRADE_COUNTERFACTUAL: {
-    id: "trade-counterfactual",
-    title: "Trade Counterfactual Analysis",
-    description: "Show 'what if you hadn't made this trade' scenarios on trade detail pages",
-    status: "experiment",
-    rolloutPercent: 50,
-    hypothesis:
-      "Counterfactual analysis makes trade grades more actionable — managers who see what would have happened will engage more deeply with trade history",
-    metrics: [
-      "Click-through rate on trade detail pages",
-      "Time spent on trade analysis views",
-    ],
-  },
   MANAGER_DNA_PROFILE: {
     id: "manager-dna-profile",
     title: "Manager DNA Profile",
     description: "Manager Process Score (MPS) combining draft, trade, waiver, and lineup grades",
     status: "disabled",
-    hypothesis:
-      "A single composite score increases engagement with individual analytics features by giving managers a 'headline number' to improve",
-    metrics: [
-      "Weekly return rate to manager profile",
-      "Cross-feature navigation (lineup -> trades -> drafts)",
-    ],
   },
-  /**
-   * Operational metric definitions (for the experiment):
-   * - "Multi-hop trade chain": a transaction with ≥3 asset legs (adds.length + draftPicks.length ≥ 3).
-   * - "Share rate": graph_link_copied / graph_view_opened, computed per session.
-   *
-   * Promotion criteria (disabled → experiment → enabled) live at docs/experiments/asset-graph-browser.md.
-   */
   ASSET_GRAPH_BROWSER: {
     id: "asset-graph-browser",
     title: "Lineage Tracer",
     description: "Interactive visualization of how players and picks flow between managers",
     status: "enabled",
-    hypothesis:
-      "Visualizing the network of trades as a graph will surface non-obvious patterns that managers find more insightful than a transaction log",
-    metrics: [
-      "Discovery of multi-hop trade chains",
-      "Share rate of graph visualizations",
-    ],
   },
 } satisfies Record<string, FeatureFlag>;
 
 export type FlagKey = keyof typeof FLAGS;
 
-/**
- * Deterministic hash for consistent user bucketing.
- * Same user always gets the same variant for a given flag.
- */
-function simpleHash(str: string): number {
-  let hash = 0;
-  for (let i = 0; i < str.length; i++) {
-    const char = str.charCodeAt(i);
-    hash = (hash << 5) - hash + char;
-    hash |= 0; // Convert to 32-bit integer
-  }
-  return Math.abs(hash);
-}
-
-/**
- * Check if a feature flag is enabled for a given user.
- *
- * - "enabled" flags are always on
- * - "disabled" flags are always off
- * - "experiment" flags use deterministic bucketing based on userId
- */
-export function isEnabled(flagId: string, userId?: string): boolean {
-  const flag = (FLAGS as Record<string, FeatureFlag>)[flagId];
-  if (!flag) return false;
-  if (flag.status === "enabled") return true;
-  if (flag.status === "disabled") return false;
-
-  if (flag.status === "experiment" && flag.rolloutPercent && userId) {
-    const hash = simpleHash(userId + flag.id);
-    return hash % 100 < flag.rolloutPercent;
-  }
-
-  return false;
-}
-
-/** Get all flags with experiment status (for the public /roadmap page) */
-export function getActiveExperiments(): FeatureFlag[] {
-  return Object.values(FLAGS).filter((f) => f.status === "experiment");
+/** Check whether a feature flag is enabled. */
+export function isEnabled(flagKey: FlagKey): boolean {
+  return FLAGS[flagKey].status === "enabled";
 }
 
 /** Get all flags (for debugging / admin views) */

--- a/src/lib/featureFlags.ts
+++ b/src/lib/featureFlags.ts
@@ -1,10 +1,9 @@
 /**
  * Minimal feature flags: static on/off gates for features in development.
  *
- * This is deliberately NOT an experimentation system. Dynasty DNA doesn't
- * have the traffic for meaningful A/B tests — algorithm decisions are made
- * with offline evals (see /experiments and scripts/experiments/), and
- * feature launches are gated by explicit promotion criteria (see
+ * This is deliberately NOT an experimentation system. Algorithm decisions
+ * are made with offline evals (see /experiments and scripts/experiments/),
+ * and feature launches are gated by explicit promotion criteria (see
  * docs/experiments/asset-graph-browser.md for the pattern).
  */
 

--- a/src/lib/useFlag.ts
+++ b/src/lib/useFlag.ts
@@ -2,8 +2,6 @@
 
 import { isEnabled, type FlagKey } from "./featureFlags";
 
-// TODO #84: PostHog flag SDK — replace this stub with anonymous-distinct-id
-// bucketing once the PostHog client is wired up.
 export function useFlag(flagKey: FlagKey): boolean {
   return isEnabled(flagKey);
 }


### PR DESCRIPTION
## Summary

- Retitle `/experiments` to **Evals** and reframe the section around what the project genuinely does — algorithm changes are replayed against the full transaction history of every ingested league and scored on how well they predict Manager Outcome Score (MOS), rather than presented with borrowed A/B-testing vocabulary the app can't back up (rollout percentages, guardrails, an analytics sink that was a production no-op).
- Add `evalNotes.ts`, an editorial layer that closes the loop from each eval run (`experiment_runs` DB rows) to the production decision it drove — every eval card now shows **the question**, the verdict, and a **Decision** block (Shipped / Kept baseline / Rejected / Follow-up open), each backed by a real code reference.
- Three evals had a `rejected` verdict sitting next to a "shipped" production change (par-vs-rank, blend-sensitivity, mos-weight-sensitivity). Rather than paper over the mismatch, those now show **Follow-up open** linking to tracking issues [#188](https://github.com/jrygrande/dynasty-dna/issues/188), [#189](https://github.com/jrygrande/dynasty-dna/issues/189), [#190](https://github.com/jrygrande/dynasty-dna/issues/190) — each a pre-registered eval proposal with a path to either a passing result or a revert.
- Strip the simulated A/B layer from `featureFlags.ts`: removed the `TRADE_COUNTERFACTUAL` 50%-rollout flag (the feature never existed in code), hash-based bucketing, and per-flag hypothesis/metrics fields. Flags are now plain on/off gates.
- Remove the "Active Experiments" section from `/roadmap` (no real users were ever bucketed into it).
- Rewrite the experiment issue template as an **Eval Proposal**: baseline, variants, method & data, pre-registered acceptance criteria, decision informed — replacing the control/treatment/rollout-%/duration A-B fields.
- Update landing card, nav label, and design-page copy to match ("Evals").

## Test plan

- [x] `npm run lint` — clean (2 pre-existing unrelated warnings)
- [x] `npm run build` — passes
- [x] `npm test` — 413 passed, 3 skipped (unrelated), 0 failed
- [x] Verified live eval data via the production `/api/experiments` endpoint to ground the new decision copy and the three follow-up issues in actual verdicts/metrics
- [ ] Manual check of `/experiments` and `/roadmap` in the preview deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013fSN23qCminNZomFdrYaMt)_